### PR TITLE
Don’t publish unused files to npm.

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,5 +57,6 @@
   "engines": {
     "node": "*"
   },
+  "files": ["build/cjs/luxon.js"],
   "license": "MIT"
 }


### PR DESCRIPTION
Only include the generated cjs file in the npm package (exclude sites, site, src etc.). This removed tens of megabytes from the npm package. Note that package.json, changelog.md, license.txt and readme.md are not listed, since they are always included by npm publish.