### PR TITLE
Add support for ISO week duration

### DIFF
--- a/src/impl/regexParser.js
+++ b/src/impl/regexParser.js
@@ -79,14 +79,15 @@ function extractISOTime(match, cursor) {
 
 // ISO duration parsing
 
-const isoDuration = /^P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/;
+const isoDuration = /^P(?:(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?|(\d+)W)$/;
 
 function extractISODuration(match) {
-  const [, yearStr, monthStr, dayStr, hourStr, minuteStr, secondStr] = match;
+  const [, yearStr, monthStr, dayStr, hourStr, minuteStr, secondStr, weekStr] = match;
 
   return {
     year: parseInt(yearStr),
     month: parseInt(monthStr),
+    week: parseInt(weekStr),
     day: parseInt(dayStr),
     hour: parseInt(hourStr),
     minute: parseInt(minuteStr),

--- a/test/duration/parse.test.js
+++ b/test/duration/parse.test.js
@@ -15,6 +15,7 @@ test('Duration.fromISO can parse a variety of ISO formats', () => {
   check('PT54M32S', { minutes: 54, seconds: 32 });
   check('P3DT54M32S', { days: 3, minutes: 54, seconds: 32 });
   check('P1YT34000S', { years: 1, seconds: 34000 });
+  check('P2W', { weeks: 2 });
 });
 
 test('Duration.fromISO rejects junk', () => {
@@ -27,4 +28,5 @@ test('Duration.fromISO rejects junk', () => {
   rejects('5Y');
   rejects('P34S');
   rejects('P34K');
+  rejects('P5D2W');
 });


### PR DESCRIPTION
The `PnW` format for durations was not supported.