### PR TITLE
[docs] correct repo link for proposal-intl-relative-time

### DIFF
--- a/docs/manual/faq/moment.html
+++ b/docs/manual/faq/moment.html
@@ -245,7 +245,7 @@ d1.valueOf() === d2.valueOf(); //=&gt; false</code>
 <li>Months in Luxon are 1-indexed instead of 0-indexed like in Moment and the native Date type.</li>
 <li>Localizations and time zones are implemented by the native Intl API (or a polyfill of it), instead of by the library itself.</li>
 <li>Luxon has both a Duration type and an Interval type. The Interval type is like Twix.</li>
-<li>Luxon lacks the relative time features of Moment and will until the required <a href="./manual/(https://github.com/tc39/proposal-intl-relative-time">facilities</a> are provided by the browser.</li>
+<li>Luxon lacks the relative time features of Moment and will until the required <a href="https://github.com/tc39/proposal-intl-relative-time">facilities</a> are provided by the browser.</li>
 </ol>
 <h2 id="other-api-style-differences">Other API style differences</h2>
 <ol>


### PR DESCRIPTION
This correct the "facilities" link in https://moment.github.io/luxon/docs/manual/faq/moment.html.