### PR TITLE
Support 1-9 digits of fractional seconds parsing ISO times

### DIFF
--- a/src/impl/regexParser.js
+++ b/src/impl/regexParser.js
@@ -67,12 +67,11 @@ function extractISOTime(match, cursor) {
   const local = !match[cursor + 4] && !match[cursor + 5],
     fullOffset = Util.signedOffset(match[cursor + 5], match[cursor + 6]),
     nanosecond = Util.padEnd(match[cursor + 3] || '0'),
-    millisecond = Math.round(parseInt(nanosecond) / 1000000),
     item = {
       hour: parseInt(match[cursor]) || 0,
       minute: parseInt(match[cursor + 1]) || 0,
       second: parseInt(match[cursor + 2]) || 0,
-      millisecond
+      millisecond: Math.round(parseInt(nanosecond) / 1000000)
     },
     zone = local ? null : new FixedOffsetZone(fullOffset);
 

--- a/src/impl/regexParser.js
+++ b/src/impl/regexParser.js
@@ -46,7 +46,7 @@ function simpleParse(...keys) {
 }
 
 // ISO parsing
-const isoTimeRegex = /(?:T(\d\d)(?::?(\d\d)(?::?(\d\d)(?:[.,](\d\d\d))?)?)?(?:(Z)|([+-]\d\d)(?::?(\d\d))?)?)?$/,
+const isoTimeRegex = /(?:T(\d\d)(?::?(\d\d)(?::?(\d\d)(?:[.,](\d{1,9}))?)?)?(?:(Z)|([+-]\d\d)(?::?(\d\d))?)?)?$/,
   isoYmdRegex = /^([+-]\d{6}|\d{4})(?:-?(\d\d)(?:-?(\d\d))?)?/,
   isoWeekRegex = /^(\d{4})-?W(\d\d)-?(\d)/,
   isoOrdinalRegex = /^(\d{4})-?(\d{3})/,
@@ -66,11 +66,13 @@ function extractISOYmd(match, cursor) {
 function extractISOTime(match, cursor) {
   const local = !match[cursor + 4] && !match[cursor + 5],
     fullOffset = Util.signedOffset(match[cursor + 5], match[cursor + 6]),
+    nanosecond = Util.padEnd(match[cursor + 3] || '0'),
+    millisecond = Math.round(parseInt(nanosecond) / 1000000),
     item = {
       hour: parseInt(match[cursor]) || 0,
       minute: parseInt(match[cursor + 1]) || 0,
       second: parseInt(match[cursor + 2]) || 0,
-      millisecond: parseInt(match[cursor + 3]) || 0
+      millisecond
     },
     zone = local ? null : new FixedOffsetZone(fullOffset);
 

--- a/src/impl/util.js
+++ b/src/impl/util.js
@@ -64,6 +64,10 @@ export class Util {
     return ('0'.repeat(n) + input).slice(-n);
   }
 
+  static padEnd(input, n = 9) {
+    return (input + '0'.repeat(n)).slice(0, n);
+  }
+
   static towardZero(input) {
     return input < 0 ? Math.ceil(input) : Math.floor(input);
   }

--- a/test/datetime/regexParse.test.js
+++ b/test/datetime/regexParse.test.js
@@ -255,6 +255,36 @@ test('DateTime.fromISO() accepts year-moth-dayThour:minute:second.millisecond', 
     second: 15,
     millisecond: 123
   });
+
+  isSame('2016-05-25T09:24:15.123456789', {
+    year: 2016,
+    month: 5,
+    day: 25,
+    hour: 9,
+    minute: 24,
+    second: 15,
+    millisecond: 123
+  });
+
+  isSame('2016-05-25T09:24:15.3456', {
+    year: 2016,
+    month: 5,
+    day: 25,
+    hour: 9,
+    minute: 24,
+    second: 15,
+    millisecond: 346
+  });
+
+  isSame('2016-05-25T09:24:15.1', {
+    year: 2016,
+    month: 5,
+    day: 25,
+    hour: 9,
+    minute: 24,
+    second: 15,
+    millisecond: 100
+  });
 });
 
 test('DateTime.fromISO() accepts year-week-day', () => {


### PR DESCRIPTION
Fixes #65 

This PR will convert the fractional part of the time to nanoseconds by padding the number to 9 digits and then converting to milliseconds by dividing by 1,000,000 and rounding the result.