### PR TITLE
test: use bitnami prod image version for smaller docker test env

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.9.0
+FROM bitnami/node:8.9.1-r0-prod
 
 RUN npm install full-icu
 RUN npm install -g gulp-cli


### PR DESCRIPTION
build and then test like normally

    docker build -t icambron/luxon docker
    ./docker/gulp test

old: 292 MB (compressed)
new: 150MB (uncompressed), I haven't pushed to registry to see the size after compressed. an educated guess would be around 50-60MB

I also tried with `node:8-alpine` (official image) but there were a couple of failed tests. like this one.
I'm not sure if it's related to `alpine` or `bitnami:node` (based on debian).
Using `node:8-alpine` would result in even smaller image size (100MB uncompressed) but i want to clarify with you first if those tests are related.

```
FAIL  test/datetime/diff.test.js
  ● DateTime#diff is precise for lower order units

    expect(received).toEqual(expected)

    Expected value to equal:
      {"hours": 2999}
    Received:
      {"hours": 3000}

    Difference:

    - Expected
    + Received

      Object {
    -   "hours": 2999,
    +   "hours": 3000,
      }

      at Object.<anonymous> (test/datetime/diff.test.js:143:5)
          at new Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)
```