### PR TITLE
Feature: module

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,6 @@
   "engines": {
     "node": "*"
   },
-  "files": ["build/node/luxon.js", "build/cjs-browser/luxon.js"],
+  "files": ["build/node/luxon.js", "build/cjs-browser/luxon.js", "src"],
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "vinyl-source-stream": "latest"
   },
   "main": "build/node/luxon.js",
+  "module": "src/luxon.js",
   "browser": "build/cjs-browser/luxon.js",
   "engines": {
     "node": "*"


### PR DESCRIPTION
Add module entry to package.json.
This way webpack or rollup can use the ES6 module instead of the transpiled ES5 version from babel which includes a lot of shimed code.
If module import is supported the `src/luxon.js` file gets imported otherwise it falls back to `build/node/index.js` when using `require`.
This will save quite a few bytes in the final bundle.

See: https://github.com/rollup/rollup/wiki/pkg.module