### PR TITLE
fix return type for toJSDate

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1491,7 +1491,7 @@ export class DateTime {
 
   /**
    * Returns a Javascript Date equivalent to this DateTime.
-   * @return {object}
+   * @return {Date}
    */
   toJSDate() {
     return new Date(this.isValid ? this.ts : NaN);


### PR DESCRIPTION
not sure why it was `object`.  Seems obvious that it should be `Date`.