### PR TITLE
docs: jsdoc interrogation spelling

### DIFF
--- a/src/interval.js
+++ b/src/interval.js
@@ -18,7 +18,7 @@ function validateStartEnd(start, end) {
  *
  * * **Creation** To create an Interval, use {@link fromDateTimes}, {@link after}, {@link before}, or {@link fromISO}.
  * * **Accessors** Use {@link start} and {@link end} to get the start and end.
- * * **Interogation** To analyze the Interval, use {@link count}, {@link length}, {@link hasSame}, {@link contains}, {@link isAfter}, or {@link isBefore}.
+ * * **Interrogation** To analyze the Interval, use {@link count}, {@link length}, {@link hasSame}, {@link contains}, {@link isAfter}, or {@link isBefore}.
  * * **Transformation** To create other Intervals out of this one, use {@link set}, {@link splitAt}, {@link splitBy}, {@link divideEqually}, {@link merge}, {@link xor}, {@link union}, {@link intersection}, or {@link difference}.
  * * **Comparison** To compare this Interval to another one, use {@link equals}, {@link overlaps}, {@link abutsStart}, {@link abutsEnd}, {@link engulfs}
  * * **Output*** To convert the Interval into other representations, see {@link toString}, {@link toISO}, {@link toFormat}, and {@link toDuration}.


### PR DESCRIPTION
Just a quick spelling update for `interrogation`, noticed on the [interval docs](https://moment.github.io/luxon/docs/class/src/interval.js~Interval.html).