### PR TITLE
Update Interval.intersection API documentation

### DIFF
--- a/src/interval.js
+++ b/src/interval.js
@@ -336,6 +336,7 @@ export class Interval {
   /**
    * Return an Interval representing the intersection of this Interval and the specified Interval.
    * Specifically, the resulting Interval has the maximum start time and the minimum end time of the two Intervals.
+   * Returns null if the intersection is empty, i.e., the intervals don't intersect.
    * @param {Interval} other
    * @return {Interval}
    */


### PR DESCRIPTION
Add mention about the null value when intersection is empty.
The null may not be the best solution (causes null pointers by surprise) but at least it should be mentioned.