### PR TITLE
Quarter unit support

### DIFF
--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -224,3 +224,5 @@ The macro options available correspond one-to-one with the preset formats define
 | FF              |              | less short localized date and time with seconds                | Aug 6, 2014, 1:07:04 PM                                     |
 | FFF             |              | verbose localized date and time with seconds                   | August 6, 2014, 1:07:04 PM EDT                              |
 | FFFF            |              | extra verbose localized date and time with seconds             | Wednesday, August 6, 2014, 1:07:04 PM Eastern Daylight Time |
+| q               |              | quarter, no padding                                            | 9                                                           |
+| qq              |              | quarter, padded to 2                                           | 13                                                          |

--- a/docs/math.md
+++ b/docs/math.md
@@ -189,10 +189,11 @@ But how do those conversions actually work? First, uncontroversially:
  
 These are always true and you can roll them up and down with consistency (e.g. `1 hour = 60 * 60 * 1000 milliseconds`). However, this isn't really true for the higher order units, which vary in length, even putting DSTs aside. A year is sometimes 365 days long and sometimes 366. Months are 28, 29, 30, or 31 days. By default Luxon converts between these units using what you might call "casual" conversions:
 
-|       | Month | Week | Day |
-| ---   | ---   |  --- | --- |
-| Year  | 12    |   52 | 365 |
-| Month |       |    4 |  30 |
+|         | Month | Week | Day |
+| ---     | ---   |  --- | --- |
+| Year    | 12    |   52 | 365 |
+| Quarter | 3     |   13 |  91 |
+| Month   |       |    4 |  30 |
 
 These should match your intuition and for most purposes they work well. But they're not just wrong; they're not even self-consistent:
 
@@ -210,10 +211,11 @@ DateTime.local().plus(dur).year                         //=> 52017
 
 Those are 33 years apart! So Luxon offers an alternative conversion scheme, based on the 400-year calendar cycle:
 
-|       | Month |     Week |       Day |
-|----   | ---   |      --- |       --- |
-| Year  | 12    |  52.1775 |  365.2425 |
-| Month |       | 4.348125 | 30.436875 |
+|         | Month |     Week |       Day |
+|----     | ---   |      --- |       --- |
+| Year    | 12    |  52.1775 |  365.2425 |
+| Quarter |  3    | 13.04435 | 91.310625 |
+| Month   |       | 4.348125 | 30.436875 |
 
 You can see why these are irritating to work with, which is why they're not the default.
 

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -119,7 +119,7 @@ function adjustTime(inst, dur) {
   const oPre = inst.o,
     c = Object.assign({}, inst.c, {
       year: inst.c.year + dur.years,
-      month: inst.c.month + dur.months,
+      month: inst.c.month + dur.months + dur.quarters * 3,
       day: inst.c.day + dur.days + dur.weeks * 7
     }),
     millisToAdd = Duration.fromObject({
@@ -815,6 +815,14 @@ export class DateTime {
   }
 
   /**
+   * Get the quarter
+   * @example DateTime.local(2017, 5, 25).quarter //=> 2
+   * @return {number}
+   */
+  get quarter() {
+    return this.isValid ? Math.ceil(this.c.month / 3) : NaN;
+  }
+  /**
    * Get the month (1-12).
    * @example DateTime.local(2017, 5, 25).month //=> 5
    * @return {number}
@@ -1215,6 +1223,7 @@ export class DateTime {
       case 'years':
         o.month = 1;
       // falls through
+      case 'quarters':
       case 'months':
         o.day = 1;
       // falls through
@@ -1239,6 +1248,10 @@ export class DateTime {
 
     if (normalizedUnit === 'weeks') {
       o.weekday = 1;
+    }
+
+    if (normalizedUnit === 'quarters') {
+      o.month = Math.floor(this.month / 3) * 3 + 1;
     }
 
     return this.set(o);

--- a/src/duration.js
+++ b/src/duration.js
@@ -37,6 +37,14 @@ const lowOrderMatrix = {
         seconds: 365 * 24 * 60 * 60,
         milliseconds: 365 * 24 * 60 * 60 * 1000
       },
+      quarters: {
+        months: 3,
+        weeks: 13,
+        days: 91,
+        hours: 91 * 24,
+        minutes: 91 * 24 * 60,
+        milliseconds: 91 * 24 * 60 * 60 * 1000
+      },
       months: {
         weeks: 4,
         days: 30,
@@ -61,6 +69,15 @@ const lowOrderMatrix = {
         seconds: daysInYearAccurate * 24 * 60 * 60,
         milliseconds: daysInYearAccurate * 24 * 60 * 60 * 1000
       },
+      quarters: {
+        months: 3,
+        weeks: daysInYearAccurate / 28,
+        days: daysInYearAccurate / 4,
+        hours: daysInYearAccurate * 24 / 4,
+        minutes: daysInYearAccurate * 24 * 60 / 4,
+        seconds: daysInYearAccurate * 24 * 60 * 60 / 4,
+        milliseconds: daysInYearAccurate * 24 * 60 * 60 * 1000 / 4
+      },
       months: {
         weeks: daysInMonthAccurate / 7,
         days: daysInMonthAccurate,
@@ -76,6 +93,7 @@ const lowOrderMatrix = {
 // units ordered by size
 const orderedUnits = [
   'years',
+  'quarters',
   'months',
   'weeks',
   'days',
@@ -164,6 +182,7 @@ export class Duration {
    * Create an Duration from a Javascript object with keys like 'years' and 'hours'.
    * @param {Object} obj - the object to create the DateTime from
    * @param {number} obj.years
+   * @param {number} obj.quarters
    * @param {number} obj.months
    * @param {number} obj.weeks
    * @param {number} obj.days
@@ -225,6 +244,8 @@ export class Duration {
     const normalized = {
       year: 'years',
       years: 'years',
+      quarter: 'quarters',
+      quarters: 'quarters',
       month: 'months',
       months: 'months',
       week: 'weeks',
@@ -316,7 +337,7 @@ export class Duration {
     norm = isHighOrderNegative(norm.values) ? norm.negate() : norm;
 
     if (norm.years > 0) s += norm.years + 'Y';
-    if (norm.months > 0) s += norm.months + 'M';
+    if (norm.months > 0 || norm.quarters > 0) s += norm.months + norm.quarters * 3 + 'M';
     if (norm.days > 0 || norm.weeks > 0) s += norm.days + norm.weeks * 7 + 'D';
     if (norm.hours > 0 || norm.minutes > 0 || norm.seconds > 0 || norm.milliseconds > 0) s += 'T';
     if (norm.hours > 0) s += norm.hours + 'H';
@@ -545,6 +566,14 @@ export class Duration {
    */
   get years() {
     return this.isValid ? this.values.years || 0 : NaN;
+  }
+
+  /**
+   * Get the quarters.
+   * @return {number}
+   */
+  get quarters() {
+    return this.isValid ? this.values.quarters || 0 : NaN;
   }
 
   /**

--- a/src/impl/formatter.js
+++ b/src/impl/formatter.js
@@ -325,6 +325,12 @@ export class Formatter {
             return this.num(dt.ordinal);
           case 'ooo':
             return this.num(dt.ordinal, 3);
+          case 'q':
+            // like 1
+            return this.num(dt.quarter);
+          case 'qq':
+            // like 01
+            return this.num(dt.quarter, 2);
           default:
             return maybeMacro(token);
         }

--- a/test/datetime/math.test.js
+++ b/test/datetime/math.test.js
@@ -23,6 +23,12 @@ test('DateTime#plus({ year: 1}) adds a year', () => {
   expect(i.year).toBe(2011);
 });
 
+test('DateTime#plus({quarter: 1}) adds a quarter', () => {
+  const i = createDateTime().plus({ quarters: 1 });
+  expect(i.quarter).toBe(2);
+  expect(i.month).toBe(5);
+});
+
 test('DateTime#plus({ days: 1 }) keeps the same time across a DST', () => {
   const i = DateTime.fromISO('2016-03-12T10:00', {
       zone: 'America/Los_Angeles'
@@ -69,6 +75,13 @@ test('DateTime#minus({ years: 1 }) subtracts a year', () => {
   expect(dt.year).toBe(2009);
 });
 
+test('DateTime#minus({ quarters: 1 }) subtracts a quarter', () => {
+  const dt = createDateTime().minus({ quarters: 1 });
+  expect(dt.year).toBe(2009);
+  expect(dt.quarter).toBe(4);
+  expect(dt.month).toBe(11);
+});
+
 test('DateTime#minus maintains invalidity', () => {
   expect(DateTime.invalid('because').minus({ day: 1 }).isValid).toBe(false);
 });
@@ -78,6 +91,18 @@ test('DateTime#minus maintains invalidity', () => {
 //------
 test("DateTime#startOf('year') goes to the start of the year", () => {
   const dt = createDateTime().startOf('year');
+
+  expect(dt.year).toBe(2010);
+  expect(dt.month).toBe(1);
+  expect(dt.day).toBe(1);
+  expect(dt.hour).toBe(0);
+  expect(dt.minute).toBe(0);
+  expect(dt.second).toBe(0);
+  expect(dt.millisecond).toBe(0);
+});
+
+test("DateTime#startOf('quarter') goes to the start of the month", () => {
+  const dt = createDateTime().startOf('quarter');
 
   expect(dt.year).toBe(2010);
   expect(dt.month).toBe(1);
@@ -177,6 +202,18 @@ test("DateTime#endOf('year') goes to the start of the year", () => {
 
   expect(dt.year).toBe(2010);
   expect(dt.month).toBe(12);
+  expect(dt.day).toBe(31);
+  expect(dt.hour).toBe(23);
+  expect(dt.minute).toBe(59);
+  expect(dt.second).toBe(59);
+  expect(dt.millisecond).toBe(999);
+});
+
+test("DateTime#endOf('quarter') goes to the end of the quarter", () => {
+  const dt = createDateTime().endOf('quarter');
+
+  expect(dt.year).toBe(2010);
+  expect(dt.month).toBe(3);
   expect(dt.day).toBe(31);
   expect(dt.hour).toBe(23);
   expect(dt.minute).toBe(59);

--- a/test/datetime/toFormat.test.js
+++ b/test/datetime/toFormat.test.js
@@ -318,6 +318,16 @@ test("DateTime#toFormat('ooo') returns an unpadded ordinal", () => {
   expect(dt.set({ month: 1, day: 8 }).toFormat('ooo')).toBe('008');
 });
 
+test("DateTime#toFormat('q') returns an unpadded quarter", () => {
+  expect(dt.toFormat('q')).toBe('2');
+  expect(dt.set({ month: 2 }).toFormat('q')).toBe('1');
+});
+
+test("DateTime#toFormat('qq') returns a padded quarter", () => {
+  expect(dt.toFormat('qq')).toBe('02');
+  expect(dt.set({ month: 2 }).toFormat('qq')).toBe('01');
+});
+
 test("DateTime#toFormat('D') returns a short date representation", () => {
   expect(dt.toFormat('D')).toBe('5/25/1982');
   expect(dt.reconfigure({ locale: 'fr' }).toFormat('D')).toBe('25/05/1982');

--- a/test/duration/accuracy.test.js
+++ b/test/duration/accuracy.test.js
@@ -17,3 +17,8 @@ test('There are slightly more than 30 days in a month', () => {
   expect(convert(1, 'month', 'days', 'casual')).toBeCloseTo(30, 4);
   expect(convert(1, 'month', 'days', 'longterm')).toBeCloseTo(30.4369, 4);
 });
+
+test('There are slightly more than 91 days in a quarter', () => {
+  expect(convert(1, 'quarter', 'days', 'casual')).toBeCloseTo(91, 4);
+  expect(convert(1, 'quarter', 'days', 'longterm')).toBeCloseTo(91.3106, 4);
+});

--- a/test/duration/getters.test.js
+++ b/test/duration/getters.test.js
@@ -4,6 +4,7 @@ import { Duration } from '../../src/luxon';
 
 const dur = Duration.fromObject({
     years: 1,
+    quarters: 2,
     months: 2,
     days: 3,
     hours: 4,
@@ -21,6 +22,11 @@ const dur = Duration.fromObject({
 test('Duration#years returns the years', () => {
   expect(dur.years).toBe(1);
   expect(inv.years).toBeFalsy();
+});
+
+test('Duration#quarters returns the quarters', () => {
+  expect(dur.quarters).toBe(2);
+  expect(inv.quarters).toBeFalsy();
 });
 
 test('Duration#months returns the (1-indexed) months', () => {


### PR DESCRIPTION
Added quarter unit support in 'startOf', 'endOf' and 'plus' methods.
Added quarter formatting tokens 'q' and 'qq' -
q - single digit quarter
qq - 2 digits padded quarter