### PR TITLE
Validate Duration.toObject() argument

### DIFF
--- a/src/duration.js
+++ b/src/duration.js
@@ -6,7 +6,8 @@ import { Settings } from './settings';
 import { InvalidArgumentError, InvalidDurationError, InvalidUnitError } from './errors';
 
 const INVALID = 'Invalid Duration',
- UNPARSABLE = 'unparsable';
+  INVALID_INPUT = 'invalid input',
+  UNPARSABLE = 'unparsable';
 
 // unit conversion constants
 const lowOrderMatrix = {
@@ -197,8 +198,26 @@ export class Duration {
    * @return {Duration}
    */
   static fromObject(obj) {
+    if (obj == null || typeof obj !== 'object') {
+      return Duration.invalid(INVALID_INPUT);
+    }
+
+    const values = Util.normalizeObject(obj, Duration.normalizeUnit, true);
+
+    let hasUnits = false;
+    for (let i = 0, l = orderedUnits.length; i < l; i++) {
+      if (values[orderedUnits[i]]) {
+        hasUnits = true;
+        break;
+      }
+    }
+
+    if (hasUnits === false) {
+      return Duration.invalid(INVALID_INPUT);
+    }
+
     return new Duration({
-      values: Util.normalizeObject(obj, Duration.normalizeUnit, true),
+      values,
       loc: Locale.fromObject(obj),
       conversionAccuracy: obj.conversionAccuracy
     });

--- a/src/duration.js
+++ b/src/duration.js
@@ -6,7 +6,6 @@ import { Settings } from './settings';
 import { InvalidArgumentError, InvalidDurationError, InvalidUnitError } from './errors';
 
 const INVALID = 'Invalid Duration',
-  INVALID_INPUT = 'invalid input',
   UNPARSABLE = 'unparsable';
 
 // unit conversion constants

--- a/src/duration.js
+++ b/src/duration.js
@@ -199,28 +199,22 @@ export class Duration {
    */
   static fromObject(obj) {
     if (obj == null || typeof obj !== 'object') {
-      return Duration.invalid(INVALID_INPUT);
+      throw new InvalidArgumentError('Argument expected to be an object with units.');
     }
 
     const values = Util.normalizeObject(obj, Duration.normalizeUnit, true);
+    const hasUnits = Object.keys(values).length > 0;
 
-    let hasUnits = false;
-    for (let i = 0, l = orderedUnits.length; i < l; i++) {
-      if (values[orderedUnits[i]]) {
-        hasUnits = true;
-        break;
-      }
+    if (hasUnits) {
+      return new Duration({
+        values,
+        loc: Locale.fromObject(obj),
+        conversionAccuracy: obj.conversionAccuracy
+      });
     }
-
-    if (hasUnits === false) {
-      return Duration.invalid(INVALID_INPUT);
+    else {
+      throw new InvalidArgumentError('Argument expected to be an object with units.');
     }
-
-    return new Duration({
-      values,
-      loc: Locale.fromObject(obj),
-      conversionAccuracy: obj.conversionAccuracy
-    });
   }
 
   /**

--- a/test/duration/create.test.js
+++ b/test/duration/create.test.js
@@ -28,3 +28,23 @@ test('Duration.fromObject accepts a conversionAccuracy', () => {
   const dur = Duration.fromObject({ days: 1, conversionAccuracy: 'longterm' });
   expect(dur.conversionAccuracy).toBe('longterm');
 });
+
+test('Duration.fromObject returns invalid duration if the argument is not an object', () => {
+  const dur1 = Duration.fromObject();
+  expect(dur1.isValid).toBe(false);
+  expect(dur1.invalidReason).toBe('invalid input');
+
+  const dur2 = Duration.fromObject(null);
+  expect(dur2.isValid).toBe(false);
+  expect(dur2.invalidReason).toBe('invalid input');
+
+  const dur3 = Duration.fromObject('foo');
+  expect(dur3.isValid).toBe(false);
+  expect(dur3.invalidReason).toBe('invalid input');
+});
+
+test('Duration.fromObject returns invalid duration if the initial object has no units', () => {
+  const dur = Duration.fromObject({});
+  expect(dur.isValid).toBe(false);
+  expect(dur.invalidReason).toBe('invalid input');
+});

--- a/test/duration/create.test.js
+++ b/test/duration/create.test.js
@@ -1,6 +1,6 @@
 /* global test expect */
 
-import { Duration, Settings } from '../../src/luxon';
+import { Duration } from '../../src/luxon';
 
 //------
 // .fromObject()
@@ -29,22 +29,12 @@ test('Duration.fromObject accepts a conversionAccuracy', () => {
   expect(dur.conversionAccuracy).toBe('longterm');
 });
 
-test('Duration.fromObject returns invalid duration if the argument is not an object', () => {
-  const dur1 = Duration.fromObject();
-  expect(dur1.isValid).toBe(false);
-  expect(dur1.invalidReason).toBe('invalid input');
-
-  const dur2 = Duration.fromObject(null);
-  expect(dur2.isValid).toBe(false);
-  expect(dur2.invalidReason).toBe('invalid input');
-
-  const dur3 = Duration.fromObject('foo');
-  expect(dur3.isValid).toBe(false);
-  expect(dur3.invalidReason).toBe('invalid input');
+test('Duration.fromObject throws if the argument is not an object', () => {
+  expect(() => Duration.fromObject()).toThrow();
+  expect(() => Duration.fromObject(null)).toThrow();
+  expect(() => Duration.fromObject('foo')).toThrow();
 });
 
-test('Duration.fromObject returns invalid duration if the initial object has no units', () => {
-  const dur = Duration.fromObject({});
-  expect(dur.isValid).toBe(false);
-  expect(dur.invalidReason).toBe('invalid input');
+test('Duration.fromObject throws if the initial object has no units', () => {
+  expect(() => Duration.fromObject({})).toThrow();
 });


### PR DESCRIPTION
Check that the argument is an object and has any units, otherwise create an invalid Duration.

Related to #186.