### PR TITLE
Move full-icu to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
     "immutable"
   ],
   "repository": "https://github.com/moment/luxon",
-  "dependencies": {
-    "full-icu": "^1.2.0"
-  },
   "scripts": {
     "build": "babel-node tasks/build.js",
     "test": "babel-node tasks/unit.js",
@@ -45,6 +42,7 @@
     "eslint-plugin-import": "latest",
     "eslint-plugin-prettier": "latest",
     "fs-extra": "latest",
+    "full-icu": "^1.2.0",
     "husky": "^0.14.3",
     "jest": "^21.2.1",
     "jest-cli": "latest",


### PR DESCRIPTION
It's not used in sources.

This is critical for me because I can't install deps when I'm on a local network with a custom npm registry. `full-icu` runs a `post-install` script that tries to install additional deps, but it doesn't respect a custom registry.