### PR TITLE
Ensure prototype getters can be addressed without throwing

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -779,7 +779,7 @@ export class DateTime {
    * @type {string}
    */
   get locale() {
-    return this.loc.locale;
+    return this.isValid ? this.loc.locale : null;
   }
 
   /**
@@ -788,7 +788,7 @@ export class DateTime {
    * @type {string}
    */
   get numberingSystem() {
-    return this.loc.numberingSystem;
+    return this.isValid ? this.loc.numberingSystem : null;
   }
 
   /**
@@ -797,7 +797,7 @@ export class DateTime {
    * @type {string}
    */
   get outputCalendar() {
-    return this.loc.outputCalendar;
+    return this.isValid ? this.loc.outputCalendar : null;
   }
 
   /**
@@ -805,7 +805,7 @@ export class DateTime {
    * @type {string}
    */
   get zoneName() {
-    return this.invalid ? null : this.zone.name;
+    return this.isValid ? this.zone.name : null;
   }
 
   /**
@@ -1006,7 +1006,7 @@ export class DateTime {
    * @type {boolean}
    */
   get isOffsetFixed() {
-    return this.zone.universal;
+    return this.isValid ? this.zone.universal : null;
   }
 
   /**

--- a/src/duration.js
+++ b/src/duration.js
@@ -278,7 +278,7 @@ export class Duration {
    * @type {string}
    */
   get locale() {
-    return this.loc.locale;
+    return this.isValid ? this.loc.locale : null;
   }
 
   /**
@@ -287,7 +287,7 @@ export class Duration {
    * @type {string}
    */
   get numberingSystem() {
-    return this.loc.numberingSystem;
+    return this.isValid ? this.loc.numberingSystem : null;
   }
 
   /**

--- a/test/datetime/proto.test.js
+++ b/test/datetime/proto.test.js
@@ -1,0 +1,9 @@
+/* global test expect */
+import { DateTime } from '../../src/luxon';
+
+test('DateTime prototype properties should not throw when accessed', () => {
+  const d = DateTime.local();
+  expect(() =>
+    Object.getOwnPropertyNames(d.__proto__).forEach(name => d.__proto__[name])
+  ).not.toThrow();
+});

--- a/test/duration/proto.test.js
+++ b/test/duration/proto.test.js
@@ -1,0 +1,9 @@
+/* global test expect */
+import { Duration } from '../../src/luxon';
+
+test('Duration prototype properties should not throw when addressed', () => {
+  const d = Duration.fromObject({ hours: 1 });
+  expect(() =>
+    Object.getOwnPropertyNames(d.__proto__).forEach(name => d.__proto__[name])
+  ).not.toThrow();
+});

--- a/test/interval/proto.test.js
+++ b/test/interval/proto.test.js
@@ -1,0 +1,9 @@
+/* global test expect */
+import { Interval, DateTime } from '../../src/luxon';
+
+test('Interval prototype properties should not throw when addressed', () => {
+  const i = DateTime.fromISO('2018-01-01').until(DateTime.fromISO('2018-01-02'));
+  expect(() =>
+    Object.getOwnPropertyNames(i.__proto__).forEach(name => i.__proto__[name])
+  ).not.toThrow();
+});


### PR DESCRIPTION
Updates that allow Luxon classes to be expanded in the React dev tools. This addresses [#182](https://github.com/moment/luxon/issues/182)