### PR TITLE
Include AMD build in npm tarball so Ember can use luxon directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,8 @@
     "build/node/luxon.js.map",
     "build/cjs-browser/luxon.js",
     "build/cjs-browser/luxon.js.map",
+    "build/amd/luxon.js",
+    "build/amd/luxon.js.map",
     "build/global/luxon.js",
     "build/global/luxon.js.map",
     "src"


### PR DESCRIPTION
Hello! Thanks for this wonderful library.

This is more of a suggested PR, since [ember-luxon](https://github.com/willrax/ember-luxon) exists.

Essentially, I would like to import luxon directly into my Ember application, so I can keep up to date with the most recent versions of luxon without depending on another package to be published. The change here adds an AMD output, which would allow Ember apps / addons to directly import luxon into their application without running rollup. I understand that adding this build file will result in some bloat in the npm tarball, so I've added that info below:

| Before | After |
|--------|------|
| 410704 bytes | 532358 bytes |

This adds ~100K to the npm tarball.

Once again, thanks for this library ❤️