### PR TITLE
fix npm script reference table for correct rendering

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -68,7 +68,7 @@ Luxon uses [Husky](https://github.com/typicode/husky) to run the formatter on yo
 ## npm script reference
 
 | Command              | Function                                |
-|----------------------+-----------------------------------------|
+|----------------------|-----------------------------------------|
 | `npm run build`      | Build all the distributable files       |
 | `npm run build-node` | Build just for Node                     |
 | `npm run test`       | Run the test suite, but see notes above |


### PR DESCRIPTION
Github and many other markdown processors won't render the npm script reference table correctly as it was. This makes it render correctly in Github and others.