### PR TITLE
fix some issues with Zone design

### DIFF
--- a/src/zone.js
+++ b/src/zone.js
@@ -38,10 +38,10 @@ export default class Zone {
    * @param {number} ts - Epoch milliseconds for which to get the name
    * @param {Object} opts - Options to affect the format
    * @param {string} opts.format - What style of offset to return. Accepts 'long' or 'short'.
-   * @param {string} opts.localeCode - What locale to return the offset name in. Defaults to us-en
+   * @param {string} opts.locale - What locale to return the offset name in.
    * @return {string}
    */
-  static offsetName(ts, opts) {
+  offsetName(ts, opts) {
     throw new ZoneIsAbstractError();
   }
 

--- a/src/zones/IANAZone.js
+++ b/src/zones/IANAZone.js
@@ -48,10 +48,6 @@ function partsOffset(dtf, date) {
   return filled;
 }
 
-/**
- * @private
- */
-
 export default class IANAZone extends Zone {
   static isValidSpecifier(s) {
     return s && s.match(/^[a-z_+-]{1,256}\/[a-z_+-]{1,256}(\/[a-z_+-]{1,256})?$/i);

--- a/src/zones/fixedOffsetZone.js
+++ b/src/zones/fixedOffsetZone.js
@@ -11,10 +11,6 @@ function hoursMinutesOffset(z) {
   return minutes > 0 ? `${base}:${padStart(minutes, 2)}` : base;
 }
 
-/**
- * @private
- */
-
 export default class FixedOffsetZone extends Zone {
   static get utcInstance() {
     if (singleton === null) {

--- a/src/zones/localZone.js
+++ b/src/zones/localZone.js
@@ -3,10 +3,6 @@ import Zone from '../zone';
 
 let singleton = null;
 
-/**
- * @private
- */
-
 export default class LocalZone extends Zone {
   static get instance() {
     if (singleton === null) {


### PR DESCRIPTION
 - offsetName is an instance method, not a static method
 - the locale option is locale, not localeCode as previously documented
 - the default value of the locale doesn't seem to be en-us as documented: there is no default value
 - the classes are not private anymore as previously documented

fix #241