### PR TITLE
Duration.fromObject() patched and  support valueOf() for duration

### DIFF
--- a/src/duration.js
+++ b/src/duration.js
@@ -236,11 +236,24 @@ export default class Duration {
    * @return {Duration}
    */
   static fromObject(obj) {
-    return new Duration({
-      values: normalizeObject(obj, Duration.normalizeUnit, true),
-      loc: Locale.fromObject(obj),
-      conversionAccuracy: obj.conversionAccuracy
-    });
+    if (obj == null || typeof obj !== 'object') {
+      throw new InvalidArgumentError('Duration.fromObject(arg): argument expected to be an object.');
+    }
+    // If Argument is empty object {} then create zero Duration;
+    if (Object.getOwnPropertyNames(obj).length == 0)
+      return new Duration({ values:{} });
+    const val = normalizeObject(obj, Duration.normalizeUnit, true);
+    const hasUnits = Object.keys(val).length > 0;
+    if (hasUnits) {
+      return new Duration({
+        values: val,
+        loc: Locale.fromObject(obj),
+        conversionAccuracy: obj.conversionAccuracy
+      });
+    }
+    else {
+      throw new InvalidArgumentError('Duration.fromObject(arg): argument expected to be an object with units.');
+    }
   }
 
   /**
@@ -405,6 +418,10 @@ export default class Duration {
    */
   toString() {
     return this.toISO();
+  }
+
+  valueOf() {
+    return this.as('milliseconds');
   }
 
   /**

--- a/src/duration.js
+++ b/src/duration.js
@@ -242,8 +242,7 @@ export default class Duration {
         'Duration.fromObject(arg): argument expected to be an object.'
       );
     }
-    // If Argument is empty object {} then create zero Duration;
-    if (Object.getOwnPropertyNames(obj).length === 0) {
+    if (Object.keys(obj).length === 0) {
       return new Duration({ values: {} });
     }
     const val = normalizeObject(obj, Duration.normalizeUnit, true);

--- a/src/duration.js
+++ b/src/duration.js
@@ -237,11 +237,14 @@ export default class Duration {
    */
   static fromObject(obj) {
     if (obj == null || typeof obj !== 'object') {
-      throw new InvalidArgumentError('Duration.fromObject(arg): argument expected to be an object.');
+      throw new InvalidArgumentError(
+        'Duration.fromObject(arg): argument expected to be an object.'
+      );
     }
     // If Argument is empty object {} then create zero Duration;
-    if (Object.getOwnPropertyNames(obj).length == 0)
-      return new Duration({ values:{} });
+    if (Object.getOwnPropertyNames(obj).length === 0) {
+      return new Duration({ values: {} });
+    }
     const val = normalizeObject(obj, Duration.normalizeUnit, true);
     const hasUnits = Object.keys(val).length > 0;
     if (hasUnits) {
@@ -250,9 +253,10 @@ export default class Duration {
         loc: Locale.fromObject(obj),
         conversionAccuracy: obj.conversionAccuracy
       });
-    }
-    else {
-      throw new InvalidArgumentError('Duration.fromObject(arg): argument expected to be an object with units.');
+    } else {
+      throw new InvalidArgumentError(
+        'Duration.fromObject(arg): argument expected to be an object with units.'
+      );
     }
   }
 

--- a/src/duration.js
+++ b/src/duration.js
@@ -219,8 +219,8 @@ export default class Duration {
   }
 
   /**
-   * Create an Duration from a Javascript object with keys like 'years' and 'hours. 
-   * If this object is empty than zero milliscends duration is returned.
+   * Create a Duration from a Javascript object with keys like 'years' and 'hours. 
+   * If this object is empty then zero  milliseconds duration is returned.
    * @param {Object} obj - the object to create the DateTime from
    * @param {number} obj.years
    * @param {number} obj.quarters

--- a/src/duration.js
+++ b/src/duration.js
@@ -254,9 +254,8 @@ export default class Duration {
         conversionAccuracy: obj.conversionAccuracy
       });
     } else {
-      throw new InvalidArgumentError(
-        'Duration.fromObject(arg): argument expected to be an object with units.'
-      );
+      const reason = 'Duration.fromObject(arg): argument expected to be an object with units';
+      return Duration.invalid(reason);
     }
   }
 

--- a/src/duration.js
+++ b/src/duration.js
@@ -219,7 +219,8 @@ export default class Duration {
   }
 
   /**
-   * Create an Duration from a Javascript object with keys like 'years' and 'hours'.
+   * Create an Duration from a Javascript object with keys like 'years' and 'hours. 
+   * If this object is empty than zero milliscends duration is returned.
    * @param {Object} obj - the object to create the DateTime from
    * @param {number} obj.years
    * @param {number} obj.quarters
@@ -424,6 +425,10 @@ export default class Duration {
     return this.toISO();
   }
 
+  /**
+   * Returns an milliseconds value of this Duration.
+   * @return {number}
+   */
   valueOf() {
     return this.as('milliseconds');
   }

--- a/src/impl/diff.js
+++ b/src/impl/diff.js
@@ -70,7 +70,12 @@ export default function(earlier, later, units, opts) {
     }
   }
 
-  const duration = Duration.fromObject(Object.assign(results, opts));
+  const isNotEmptyObject =function (obj) {
+    return (typeof obj === "object") && (Object.getOwnPropertyNames(obj).length > 0);
+  }
+  const duration = isNotEmptyObject(results) ? 
+    Duration.fromObject(Object.assign(results, opts)) :
+    Duration.fromObject({});
 
   if (lowerOrderUnits.length > 0) {
     return Duration.fromMillis(remainingMillis, opts)

--- a/src/impl/diff.js
+++ b/src/impl/diff.js
@@ -70,12 +70,12 @@ export default function(earlier, later, units, opts) {
     }
   }
 
-  const isNotEmptyObject =function (obj) {
-    return (typeof obj === "object") && (Object.getOwnPropertyNames(obj).length > 0);
+  function isNotEmptyObject(obj) {
+    return typeof obj === 'object' && Object.getOwnPropertyNames(obj).length > 0;
   }
-  const duration = isNotEmptyObject(results) ? 
-    Duration.fromObject(Object.assign(results, opts)) :
-    Duration.fromObject({});
+  const duration = isNotEmptyObject(results)
+    ? Duration.fromObject(Object.assign(results, opts))
+    : Duration.fromObject({});
 
   if (lowerOrderUnits.length > 0) {
     return Duration.fromMillis(remainingMillis, opts)

--- a/src/impl/diff.js
+++ b/src/impl/diff.js
@@ -71,7 +71,7 @@ export default function(earlier, later, units, opts) {
   }
 
   function isNotEmptyObject(obj) {
-    return typeof obj === 'object' && Object.getOwnPropertyNames(obj).length > 0;
+    return typeof obj === 'object' && Object.keys(obj).length > 0;
   }
   const duration = isNotEmptyObject(results)
     ? Duration.fromObject(Object.assign(results, opts))

--- a/test/duration/create.test.js
+++ b/test/duration/create.test.js
@@ -49,3 +49,7 @@ test('Duration.fromObject({}) costructs zero duration', () => {
 test('Duration.fromObject() throws if the initial object has no units', () => {
   expect(() => Duration.fromObject({ foo: 0 })).toThrow();
 });
+
+test('Duration.fromObject() throws if providing options only', () => {
+  expect(() => Duration.fromObject({ conversionAccuracy: 'longterm' })).toThrow();
+});

--- a/test/duration/create.test.js
+++ b/test/duration/create.test.js
@@ -47,5 +47,5 @@ test('Duration.fromObject({}) costructs zero duration', () => {
 });
 
 test('Duration.fromObject() throws if the initial object has no units', () => {
-  expect(() => Duration.fromObject({foo: 0})).toThrow();
+  expect(() => Duration.fromObject({ foo: 0 })).toThrow();
 });

--- a/test/duration/create.test.js
+++ b/test/duration/create.test.js
@@ -46,10 +46,12 @@ test('Duration.fromObject({}) costructs zero duration', () => {
   expect(dur.milliseconds).toBe(0);
 });
 
-test('Duration.fromObject() throws if the initial object has no units', () => {
-  expect(() => Duration.fromObject({ foo: 0 })).toThrow();
+test('Duration.fromObject invlid if the initial object has no units', () => {
+  const dur = Duration.fromObject({ foo: 0 });
+  expect(dur.isValid).toBe(false);
 });
 
-test('Duration.fromObject() throws if providing options only', () => {
-  expect(() => Duration.fromObject({ conversionAccuracy: 'longterm' })).toThrow();
+test('Duration.fromObject invlid if providing options only', () => {
+  const dur = Duration.fromObject({ conversionAccuracy: 'longterm' });
+  expect(dur.isValid).toBe(false);
 });

--- a/test/duration/create.test.js
+++ b/test/duration/create.test.js
@@ -28,3 +28,24 @@ test('Duration.fromObject accepts a conversionAccuracy', () => {
   const dur = Duration.fromObject({ days: 1, conversionAccuracy: 'longterm' });
   expect(dur.conversionAccuracy).toBe('longterm');
 });
+
+test('Duration.fromObject throws if the argument is not an object', () => {
+  expect(() => Duration.fromObject()).toThrow();
+  expect(() => Duration.fromObject(null)).toThrow();
+  expect(() => Duration.fromObject('foo')).toThrow();
+});
+
+test('Duration.fromObject({}) costructs zero duration', () => {
+  const dur = Duration.fromObject({});
+  expect(dur.years).toBe(0);
+  expect(dur.months).toBe(0);
+  expect(dur.days).toBe(0);
+  expect(dur.hours).toBe(0);
+  expect(dur.minutes).toBe(0);
+  expect(dur.seconds).toBe(0);
+  expect(dur.milliseconds).toBe(0);
+});
+
+test('Duration.fromObject() throws if the initial object has no units', () => {
+  expect(() => Duration.fromObject({foo: 0})).toThrow();
+});

--- a/test/duration/units.test.js
+++ b/test/duration/units.test.js
@@ -122,11 +122,11 @@ test('Duration#valueOf value of zero duration', () => {
 });
 
 test('Duration#valueOf returns as millisecond value (lower order units)', () => {
-  const dur = Duration.fromObject({hours:1, minutes:36, seconds:0});
+  const dur = Duration.fromObject({ hours: 1, minutes: 36, seconds: 0 });
   expect(dur.valueOf()).toBe(5760000);
 });
 
 test('Duration#valueOf value of the duration with lower and higher order units', () => {
-  const dur = Duration.fromObject({days:2, seconds:1});
+  const dur = Duration.fromObject({ days: 2, seconds: 1 });
   expect(dur.valueOf()).toBe(172801000);
 });

--- a/test/duration/units.test.js
+++ b/test/duration/units.test.js
@@ -111,3 +111,22 @@ test('Duration#as shifts to one unit and returns it', () => {
 test('Duration#as returns null for invalid durations', () => {
   expect(Duration.invalid('because').as('hours')).toBeFalsy();
 });
+
+//------
+// #valueOf()
+//-------
+
+test('Duration#valueOf value of zero duration', () => {
+  const dur = Duration.fromObject({});
+  expect(dur.valueOf()).toBe(0);
+});
+
+test('Duration#valueOf returns as millisecond value (lower order units)', () => {
+  const dur = Duration.fromObject({hours:1, minutes:36, seconds:0});
+  expect(dur.valueOf()).toBe(5760000);
+});
+
+test('Duration#valueOf value of the duration with lower and higher order units', () => {
+  const dur = Duration.fromObject({days:2, seconds:1});
+  expect(dur.valueOf()).toBe(172801000);
+});


### PR DESCRIPTION
1. Duration.fromObject() argument verification. see: #186 
2. duration.valueOf() implemented. see: #235 