### PR TITLE
Support MongoDB serialization

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1530,6 +1530,14 @@ export default class DateTime {
   }
 
   /**
+   * Returns a BSON serializable equivalent to this DateTime.
+   * @return {Date}
+   */
+  toBSON() {
+    return this.toJSDate();
+  }
+
+  /**
    * Returns a Javascript object with this DateTime's year, month, day, and so on.
    * @param opts - options for generating the object
    * @param {boolean} [opts.includeConfig=false] - include configuration attributes in the output

--- a/test/datetime/transform.test.js
+++ b/test/datetime/transform.test.js
@@ -30,3 +30,12 @@ test('DateTime#toJSDate() returns a native Date equivalent', () => {
   expect(js).toBeInstanceOf(Date);
   expect(js.getTime()).toBe(dt.toMillis());
 });
+
+//------
+// #toBSON()
+//------
+test('DateTime#toBSON() return a BSON serializable equivalent', () => {
+  const js = dt.toJSDate();
+  expect(js).toBeInstanceOf(Date);
+  expect(js.getTime()).toBe(dt.toMillis());
+});

--- a/test/datetime/transform.test.js
+++ b/test/datetime/transform.test.js
@@ -21,3 +21,12 @@ const dtMaker = () =>
 test('DateTime#toMillis() just does valueOf()', () => {
   expect(dt.toMillis()).toBe(dt.valueOf());
 });
+
+//------
+// #toJSDate()
+//------
+test('DateTime#toJSDate() returns a native Date equivalent', () => {
+  const js = dt.toJSDate();
+  expect(js).toBeInstanceOf(Date);
+  expect(js.getTime()).toBe(dt.toMillis());
+});


### PR DESCRIPTION
While BSON being off the standards track and the whole `toBSON` thing is merely a [feature](https://mongodb.github.io/node-mongodb-native/driver-articles/anintroductionto1_1and2_2.html#tobson-method) of MongoDB Node driver, this patch adds support for quite popular database solution with little effort.

EDIT: Inspired by https://github.com/boosterfuels/mongodb-moment.