### PR TITLE
Use Symbol for Node's custom inspect

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -16,6 +16,7 @@ import {
   daysInYear,
   isLeapYear,
   weeksInWeekYear,
+  customInspectSymbol,
   normalizeObject
 } from './impl/util';
 import { normalizeZone } from './impl/zoneUtil';
@@ -1496,7 +1497,7 @@ export default class DateTime {
    * Returns a string representation of this DateTime appropriate for the REPL.
    * @return {string}
    */
-  inspect() {
+  [customInspectSymbol]() {
     if (this.isValid) {
       return `DateTime {\n  ts: ${this.toISO()},\n  zone: ${this.zone.name},\n  locale: ${this
         .locale} }`;

--- a/src/duration.js
+++ b/src/duration.js
@@ -1,4 +1,4 @@
-import { isUndefined, isNumber, normalizeObject } from './impl/util';
+import { isUndefined, isNumber, normalizeObject, customInspectSymbol } from './impl/util';
 import Locale from './impl/locale';
 import Formatter from './impl/formatter';
 import { parseISODuration } from './impl/regexParser';
@@ -411,7 +411,7 @@ export default class Duration {
    * Returns a string representation of this Duration appropriate for the REPL.
    * @return {string}
    */
-  inspect() {
+  [customInspectSymbol]() {
     if (this.isValid) {
       const valsInspect = JSON.stringify(this.toObject());
       return `Duration {\n  values: ${valsInspect},\n  locale: ${this

--- a/src/impl/util.js
+++ b/src/impl/util.js
@@ -203,3 +203,11 @@ export function normalizeObject(obj, normalizer, ignoreUnknown = false) {
 export function timeObject(obj) {
   return pick(obj, ['hour', 'minute', 'second', 'millisecond']);
 }
+
+export const customInspectSymbol = (() => {
+  try {
+    return require('util').inspect.custom; // eslint-disable-line global-require
+  } catch (_err) {
+    return Symbol('util.inspect.custom');
+  }
+})();

--- a/src/interval.js
+++ b/src/interval.js
@@ -1,3 +1,4 @@
+import { customInspectSymbol } from './impl/util';
 import DateTime, { friendlyDateTime } from './datetime';
 import Duration, { friendlyDuration } from './duration';
 import Settings from './settings';
@@ -445,7 +446,7 @@ export default class Interval {
    * Returns a string representation of this Interval appropriate for the REPL.
    * @return {string}
    */
-  inspect() {
+  [customInspectSymbol]() {
     if (this.isValid) {
       return `Interval {\n  start: ${this.start.toISO()},\n  end: ${this.end.toISO()},\n  zone:   ${this
         .start.zone.name},\n  locale:   ${this.start.locale} }`;


### PR DESCRIPTION
Resolves #276.

Node's `inspect` is fairly useful, let's try to keep it. I don't exceptionally like the solution at hand, but I have an idea how we can make it better if Node.js would support it.