### PR TITLE
Replace all `instanceof Object` checks

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1860,7 +1860,7 @@ export function friendlyDateTime(dateTimeish) {
     return dateTimeish;
   } else if (dateTimeish.valueOf && isNumber(dateTimeish.valueOf())) {
     return DateTime.fromJSDate(dateTimeish);
-  } else if (dateTimeish instanceof Object) {
+  } else if (typeof dateTimeish === 'object') {
     return DateTime.fromObject(dateTimeish);
   } else {
     throw new InvalidArgumentError('Unknown datetime argument');

--- a/src/duration.js
+++ b/src/duration.js
@@ -157,7 +157,7 @@ export function friendlyDuration(duration) {
     return Duration.fromMillis(duration);
   } else if (duration instanceof Duration) {
     return duration;
-  } else if (duration instanceof Object) {
+  } else if (typeof duration === 'object') {
     return Duration.fromObject(duration);
   } else {
     throw new InvalidArgumentError('Unknown duration argument');
@@ -219,7 +219,7 @@ export default class Duration {
   }
 
   /**
-   * Create a Duration from a Javascript object with keys like 'years' and 'hours. 
+   * Create a Duration from a Javascript object with keys like 'years' and 'hours.
    * If this object is empty then zero  milliseconds duration is returned.
    * @param {Object} obj - the object to create the DateTime from
    * @param {number} obj.years


### PR DESCRIPTION
Those assertions fail (even if we're giving actual objects) while working across different JS contexts.

Not sure that `typeof` is the best option for that though. I would just remove that check altogether since there are other subsequent checks in `fromObject` that will fail if the thing is not an object.