### PR TITLE
Interval.fromISO to allow relative durations.

### DIFF
--- a/test/interval/parse.test.js
+++ b/test/interval/parse.test.js
@@ -57,10 +57,62 @@ test("Interval.fromISO can parse a variety of ISO formats", () => {
       millisecond: 0
     }
   );
+
+  check(
+    "2007-03-01T13:00:00/P1Y2M10DT2H30M",
+    {
+      year: 2007,
+      month: 3,
+      day: 1,
+      hour: 13,
+      minute: 0,
+      second: 0,
+      millisecond: 0
+    },
+    {
+      year: 2008,
+      month: 5,
+      day: 11,
+      hour: 15,
+      minute: 30,
+      second: 0,
+      millisecond: 0
+    }
+  );
+
+  check(
+    "P1Y2M10DT2H30M/2008-05-11T15:30:00",
+    {
+      year: 2007,
+      month: 3,
+      day: 1,
+      hour: 13,
+      minute: 0,
+      second: 0,
+      millisecond: 0
+    },
+    {
+      year: 2008,
+      month: 5,
+      day: 11,
+      hour: 15,
+      minute: 30,
+      second: 0,
+      millisecond: 0
+    }
+  );
 });
 
-test("Interval.fromISO will return invalid for junk", () => {
-  const i = Interval.fromISO("hello");
+const badInputs = [
+  null,
+  "",
+  "hello",
+  "foo/bar",
+  "R5/2008-03-01T13:00:00Z/P1Y2M10DT2H30M" // valid ISO 8601 interval with a repeat, but not supported here
+];
+
+test.each(badInputs)("Interval.fromISO will return invalid for [%s]", s => {
+  const i = Interval.fromISO(s);
   expect(i.isValid).toBe(false);
   expect(i.invalidReason).toBe("invalid ISO format");
 });


### PR DESCRIPTION
Fixes #340.

Start accepting `<start>/<duration>` and `<duration>/<end>` formats of [ISO 8601 intervals](https://en.wikipedia.org/wiki/ISO_8601#Time_intervals).

One very minor breaking change is that an invalid input with a slash now
has a `invalidReason` of `invalid ISO format` instead of `invalid endpoints`.

```js
const i = Interval.fromISO("foo/bar");
i.invalidReason; // invalid ISO format
```