### PR TITLE
Fixes DateTime.toRFC2822 using 12h instead of 24h format

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1432,7 +1432,7 @@ export default class DateTime {
    * @return {string}
    */
   toRFC2822() {
-    return toTechFormat(this, "EEE, dd LLL yyyy hh:mm:ss ZZZ");
+    return toTechFormat(this, "EEE, dd LLL yyyy HH:mm:ss ZZZ");
   }
 
   /**

--- a/test/datetime/format.test.js
+++ b/test/datetime/format.test.js
@@ -115,6 +115,7 @@ test("DateTime#toISOTime() returns null for invalid DateTimes", () => {
 test("DateTime#toRFC2822() returns an RFC 2822 date", () => {
   expect(dt.toUTC().toRFC2822()).toBe("Tue, 25 May 1982 09:23:54 +0000");
   expect(dt.setZone("America/New_York").toRFC2822()).toBe("Tue, 25 May 1982 05:23:54 -0400");
+  expect(dt.set({ hour: 15 }).toRFC2822()).toBe("Tue, 25 May 1982 15:23:54 +0000");
 });
 
 test("DateTime#toRFC2822() returns null for invalid DateTimes", () => {


### PR DESCRIPTION
According to [RFC2822](https://www.ietf.org/rfc/rfc2822.txt) hours must be in 00-23 range. Current implementation was using `hh` which is 00-12. 

This was causing, for example a 3pm and a 3am date to print the same RFC2822 value:

```
> DateTime.local().set({ hour: 3 }).toRFC2822()
'Mon, 08 Oct 2018 03:53:26 -0400'
> DateTime.local().set({ hour: 15 }).toRFC2822()
'Mon, 08 Oct 2018 03:53:26 -0400'
```

With this change, the second one is correctly printed to have hour 15.