### PR TITLE
Update DateTime#toSQL example to includeZone

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1483,7 +1483,7 @@ export default class DateTime {
    * @example DateTime.utc(2014, 7, 13).toSQL() //=> '2014-07-13 00:00:00.000 Z'
    * @example DateTime.local(2014, 7, 13).toSQL() //=> '2014-07-13 00:00:00.000 -04:00'
    * @example DateTime.local(2014, 7, 13).toSQL({ includeOffset: false }) //=> '2014-07-13 00:00:00.000'
-   * @example DateTime.local(2014, 7, 13).toSQL({ includeZone: false }) //=> '2014-07-13 00:00:00.000 America/New_York'
+   * @example DateTime.local(2014, 7, 13).toSQL({ includeZone: true }) //=> '2014-07-13 00:00:00.000 America/New_York'
    * @return {string}
    */
   toSQL(opts = {}) {


### PR DESCRIPTION
Fixes #349 

# What's in this PR
Looks like one of the examples for `DateTime#toSQL` had an incorrect argument. This fixes that.

## Test Plan
- [x] Confirm example is update on `DateTime` reference page.
- [x] No new tests were added as this was just an example.

