### PR TITLE
Add support for Unix timestamps in seconds.

### DIFF
--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -30,6 +30,16 @@ dt.toRFC2822(); //=> 'Thu, 20 Apr 2017 11:32:00 -0400'
 dt.toHTTP(); //=> 'Thu, 20 Apr 2017 03:32:00 GMT'
 ```
 
+### Unix timestamps
+
+DateTime objects can also be converted to numerical [Unix timestamps](https://en.wikipedia.org/wiki/Unix_time):
+
+```js
+dt.toMillis(); //=> 1492702320000
+dt.toSeconds(); //=> 1492702320
+dt.valueOf(); //=> 1492702320000, same as .toMillis()
+```
+
 ## toLocaleString (strings for humans)
 
 ### The basics

--- a/docs/parsing.md
+++ b/docs/parsing.md
@@ -70,6 +70,18 @@ DateTime.fromSQL('09:24:15');
 
 It works similarly to `fromISO`, so see above for additional notes.
 
+### Unix timestamps
+
+Luxon can parse numerical [Unix timestamps](https://en.wikipedia.org/wiki/Unix_time):
+
+```js
+DateTime.fromMillis(1542674993410);
+DateTime.fromSeconds(1542674993);
+```
+
+Both methods accept the same options, which allow you to specify a timezone, calendar, and/or numbering system.
+
+
 ## Ad-hoc parsing
 
 ### Consider alternatives

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -520,6 +520,28 @@ export default class DateTime {
   }
 
   /**
+   * Create a DateTime from a number of seconds since the epoch (i.e. since 1 January 1970 00:00:00 UTC). Uses the default zone.
+   * @param {number} seconds - a number of seconds since 1970 UTC
+   * @param {Object} options - configuration options for the DateTime
+   * @param {string|Zone} [options.zone='local'] - the zone to place the DateTime into
+   * @param {string} [options.locale] - a locale to set on the resulting DateTime instance
+   * @param {string} options.outputCalendar - the output calendar to set on the resulting DateTime instance
+   * @param {string} options.numberingSystem - the numbering system to set on the resulting DateTime instance
+   * @return {DateTime}
+   */
+  static fromSeconds(seconds, options = {}) {
+    if (!isNumber(seconds)) {
+      throw new InvalidArgumentError("fromSeconds requires a numerical input");
+    } else {
+      return new DateTime({
+        ts: seconds * 1000,
+        zone: normalizeZone(options.zone, Settings.defaultZone),
+        loc: Locale.fromObject(options)
+      });
+    }
+  }
+
+  /**
    * Create a DateTime from a Javascript object with keys like 'year' and 'hour' with reasonable defaults.
    * @param {Object} obj - the object to create the DateTime from
    * @param {number} obj.year - a year, such as 1987
@@ -1550,6 +1572,14 @@ export default class DateTime {
    */
   toMillis() {
     return this.isValid ? this.ts : NaN;
+  }
+
+  /**
+   * Returns the epoch seconds of this DateTime.
+   * @return {number}
+   */
+  toSeconds() {
+    return this.isValid ? this.ts / 1000 : NaN;
   }
 
   /**

--- a/test/datetime/create.test.js
+++ b/test/datetime/create.test.js
@@ -261,6 +261,32 @@ test("DateTime.fromMillis(ms) throws InvalidArgumentError for non-numeric input"
 });
 
 //------
+// .fromSeconds()
+//-------
+test("DateTime.fromSeconds(seconds) has a value of 1000 * seconds", () => {
+  const seconds = 391147200;
+  expect(DateTime.fromSeconds(seconds).valueOf()).toBe(1000 * seconds);
+
+  expect(DateTime.fromSeconds(0).valueOf()).toBe(0);
+});
+
+test("DateTime.fromSeconds(ms) accepts a zone option", () => {
+  const seconds = 391147200,
+    dateTime = DateTime.fromSeconds(seconds, { zone: "America/Santiago" });
+
+  expect(dateTime.valueOf()).toBe(1000 * seconds);
+  expect(dateTime.zoneName).toBe("America/Santiago");
+});
+
+test("DateTime.fromSeconds accepts the default locale", () => {
+  withDefaultLocale("fr", () => expect(DateTime.fromSeconds(391147200).locale).toBe("fr"));
+});
+
+test("DateTime.fromSeconds(seconds) throws InvalidArgumentError for non-numeric input", () => {
+  expect(() => DateTime.fromSeconds("slurp")).toThrow();
+});
+
+//------
 // .fromObject()
 //-------
 const baseObject = {

--- a/test/datetime/transform.test.js
+++ b/test/datetime/transform.test.js
@@ -29,6 +29,19 @@ test("DateTime#toMillis() returns NaN for invalid DateTimes", () => {
 });
 
 //------
+// #toSeconds()
+//------
+test("DateTime#toSeconds() returns seconds for valid DateTimes", () => {
+  const js = dt.toJSDate();
+  expect(dt.toSeconds()).toBe(js.getTime() / 1000);
+});
+
+test("DateTime#toSeconds() returns NaN for invalid DateTimes", () => {
+  const invalid = DateTime.invalid("reason");
+  expect(invalid.toSeconds()).toBe(NaN);
+});
+
+//------
 // #valueOf()
 //------
 test("DateTime#valueOf() just does toMillis()", () => {


### PR DESCRIPTION
This pull request adds `toSeconds` and `fromSeconds` methods for working with Unix timestamps. 

Now, I saw that https://github.com/moment/luxon/pull/319 added support for timestamps inside the `.toFormat` function, but didn't add explicit timestamp support. And, I've read the contribution guidelines, which state that:

> Luxon shouldn't contain simple conveniences that bloat the library to save callers a couple lines of code. Write those lines in your own code.

However, I think supporting Unix timestamps is an important use case. This is because many other systems and specifications use Unix timestamps in seconds as their primary date format. For example:

- Python's `time()`
- Ruby's `Time.now.to_i`
- Bash's `date +%s`
- C's `time(null)`

Because of this, many APIs specify timestamps in seconds. Currently, working with these times is a bit cumbersome, and prone to errors.

```js
const inputSeconds = 1542674993;
const inputDT = DateTime.fromMillis(inputSeconds * 1000);

const outputDT = dt.plus({days: 1});
const outputSeconds = Math.floor(dt.toMillis() / 1000);
// or
const outputSeconds = Number(dt.toFormat("X"));
```

It's easy to forget to multiply or divide by 1000, or to cast the `toFormat` result as a string, and this can lead to subtle bugs. I think having built-in support for seconds is pretty light-weight and makes working with timestamps much easier. An example use case is comparing a Luxon DateTime object to an array of GeoJSON features, each of which has numeric `timestamp` property.

We're currently migrating from Moment to Luxon, which has been really nice, except for this. Moment supports unix timestamps directly with `.unix()`, and adding multiplications/divisions everywhere where we used `.unix()` feels less than elegant.

Anyway, I understand your concerns about bloating the library, but it'd be really nice to see this get in.