### PR TITLE
Support for midnight or 24:00

### DIFF
--- a/src/impl/conversions.js
+++ b/src/impl/conversions.js
@@ -137,7 +137,7 @@ export function hasInvalidGregorianData(obj) {
 }
 
 export function hasInvalidTimeData(obj) {
-  const validHour = numberBetween(obj.hour, 0, 23),
+  const validHour = numberBetween(obj.hour, 0, 24),
     validMinute = numberBetween(obj.minute, 0, 59),
     validSecond = numberBetween(obj.second, 0, 59),
     validMillisecond = numberBetween(obj.millisecond, 0, 999);

--- a/test/datetime/regexParse.test.js
+++ b/test/datetime/regexParse.test.js
@@ -475,6 +475,18 @@ test("DateTime.fromISO() accepts hour:minute", () => {
   });
 });
 
+test("DateTime.fromISO() accepts 24:00", () => {
+  isSame("2018-01-04T24:00", {
+    year: 2018,
+    month: 1,
+    day: 5,
+    hour: 0,
+    minute: 0,
+    second: 0,
+    millisecond: 0
+  });
+});
+
 test("DateTime.fromISO() accepts some technically incorrect stuff", () => {
   // these are formats that aren't technically valid but we parse anyway.
   // Testing them more to document them than anything else


### PR DESCRIPTION
ISO8601 treats midnight in a specific way. It treats 00:00 as start of the day. 24:00 is 00:00 of the next day, or the end of the current day. Luxon prohibits using 24:00 totally.

Case to check is DateTime.fromISO('24:00'). For today (2018-01-04) it should return "2018-01-05 00:00".

This is of utter importance for intervals. One should be able to specify an interval till the end of the day. Interval.fromIso('23:00/24:00') currently throws an error, while it is expected to be an hour before midnight.