### PR TITLE
Update datetime.js

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1812,20 +1812,20 @@ export default class DateTime {
       })
     );
   }
-  
+
   /**
-   * Returns the time zone difference, in minutes, from current locale (host system settings) to UTC. 
-   * Mimics behaviour of getTimezoneOffset in JavaScript, improving compatibility with frameworks 
+   * Returns the time zone difference, in minutes, from current locale (host system settings) to UTC.
+   * Mimics behaviour of getTimezoneOffset in JavaScript, improving compatibility with frameworks
    * and UI components that rely on this method (i.e. Angular dateFormat filter, date pickers, etc.)
    */
   getTimezoneOffset() {
     return DateTime.local().offset * -1;
   }
-  
- /**
-   * Returns the milliseconds since Jan 1, 1970, 00:00:00.000 GMT as a numeric value corresponding 
-   * to the time for the specified date according to universal time. 
-   * Mimics behaviour of getTime in JavaScript, improving compatibility with frameworks 
+
+  /**
+   * Returns the milliseconds since Jan 1, 1970, 00:00:00.000 GMT as a numeric value corresponding
+   * to the time for the specified date according to universal time.
+   * Mimics behaviour of getTime in JavaScript, improving compatibility with frameworks
    * and UI components that rely on this method (i.e. Angular dateFormat filter, date pickers, etc.)
    */
   getTime() {

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1812,6 +1812,25 @@ export default class DateTime {
       })
     );
   }
+  
+  /**
+   * Returns the time zone difference, in minutes, from current locale (host system settings) to UTC. 
+   * Mimics behaviour of getTimezoneOffset in JavaScript, improving compatibility with frameworks 
+   * and UI components that rely on this method (i.e. Angular dateFormat filter, date pickers, etc.)
+   */
+  getTimezoneOffset() {
+    return DateTime.local().offset * -1;
+  }
+  
+ /**
+   * Returns the milliseconds since Jan 1, 1970, 00:00:00.000 GMT as a numeric value corresponding 
+   * to the time for the specified date according to universal time. 
+   * Mimics behaviour of getTime in JavaScript, improving compatibility with frameworks 
+   * and UI components that rely on this method (i.e. Angular dateFormat filter, date pickers, etc.)
+   */
+  getTime() {
+    return this.toMillis();
+  }
 
   /**
    * Return the min of several date times


### PR DESCRIPTION
I have been using prototype extentions in my code to make luxon objects compatible with various components that interrogate standard JS date objects (Angular's formatDate filter, uib-datepicker, etc)
Would the community be interested in adding them to the component by default to increase compatibility with JS component ecosystem, without resorting to toJSDate, which strips a lot of information from the object?