### PR TITLE
added .js to imports

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1,11 +1,11 @@
-import Duration, { friendlyDuration } from "./duration";
-import Interval from "./interval";
-import Settings from "./settings";
-import Info from "./info";
-import Formatter from "./impl/formatter";
-import FixedOffsetZone from "./zones/fixedOffsetZone";
-import LocalZone from "./zones/localZone";
-import Locale from "./impl/locale";
+import Duration, { friendlyDuration } from "./duration.js";
+import Interval from "./interval.js";
+import Settings from "./settings.js";
+import Info from "./info.js";
+import Formatter from "./impl/formatter.js";
+import FixedOffsetZone from "./zones/fixedOffsetZone.js";
+import LocalZone from "./zones/localZone.js";
+import Locale from "./impl/locale.js";
 import {
   isUndefined,
   maybeArray,
@@ -18,11 +18,11 @@ import {
   weeksInWeekYear,
   normalizeObject,
   roundTo
-} from "./impl/util";
-import { normalizeZone } from "./impl/zoneUtil";
-import diff from "./impl/diff";
-import { parseRFC2822Date, parseISODate, parseHTTPDate, parseSQL } from "./impl/regexParser";
-import { parseFromTokens, explainFromTokens } from "./impl/tokenParser";
+} from "./impl/util.js";
+import { normalizeZone } from "./impl/zoneUtil.js";
+import diff from "./impl/diff.js";
+import { parseRFC2822Date, parseISODate, parseHTTPDate, parseSQL } from "./impl/regexParser.js";
+import { parseFromTokens, explainFromTokens } from "./impl/tokenParser.js";
 import {
   gregorianToWeek,
   weekToGregorian,
@@ -32,15 +32,15 @@ import {
   hasInvalidWeekData,
   hasInvalidOrdinalData,
   hasInvalidTimeData
-} from "./impl/conversions";
-import * as Formats from "./impl/formats";
+} from "./impl/conversions.js";
+import * as Formats from "./impl/formats.js";
 import {
   InvalidArgumentError,
   ConflictingSpecificationError,
   InvalidUnitError,
   InvalidDateTimeError
-} from "./errors";
-import Invalid from "./impl/invalid";
+} from "./errors.js";
+import Invalid from "./impl/invalid.js";
 
 const INVALID = "Invalid DateTime";
 

--- a/src/duration.js
+++ b/src/duration.js
@@ -1,10 +1,10 @@
-import { isUndefined, isNumber, normalizeObject } from "./impl/util";
-import Locale from "./impl/locale";
-import Formatter from "./impl/formatter";
-import { parseISODuration } from "./impl/regexParser";
-import Settings from "./settings";
-import { InvalidArgumentError, InvalidDurationError, InvalidUnitError } from "./errors";
-import Invalid from "./impl/invalid";
+import { isUndefined, isNumber, normalizeObject } from "./impl/util.js";
+import Locale from "./impl/locale.js";
+import Formatter from "./impl/formatter.js";
+import { parseISODuration } from "./impl/regexParser.js";
+import Settings from "./settings.js";
+import { InvalidArgumentError, InvalidDurationError, InvalidUnitError } from "./errors.js";
+import Invalid from "./impl/invalid.js";
 
 const INVALID = "Invalid Duration";
 

--- a/src/impl/conversions.js
+++ b/src/impl/conversions.js
@@ -6,8 +6,8 @@ import {
   daysInMonth,
   weeksInWeekYear,
   isNumber
-} from "./util";
-import Invalid from "./invalid";
+} from "./util.js";
+import Invalid from "./invalid.js";
 
 const nonLeapLadder = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334],
   leapLadder = [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335];

--- a/src/impl/diff.js
+++ b/src/impl/diff.js
@@ -1,4 +1,4 @@
-import Duration from "../duration";
+import Duration from "../duration.js";
 
 function dayDiff(earlier, later) {
   const utcDayStart = dt =>

--- a/src/impl/english.js
+++ b/src/impl/english.js
@@ -1,5 +1,5 @@
-import * as Formats from "./formats";
-import { pick } from "./util";
+import * as Formats from "./formats.js";
+import { pick } from "./util.js";
 
 function stringify(obj) {
   return JSON.stringify(obj, Object.keys(obj).sort());

--- a/src/impl/formatter.js
+++ b/src/impl/formatter.js
@@ -1,6 +1,6 @@
-import * as English from "./english";
-import * as Formats from "./formats";
-import { padStart } from "./util";
+import * as English from "./english.js";
+import * as Formats from "./formats.js";
+import { padStart } from "./util.js";
 
 function stringifyTokens(splits, tokenToString) {
   let s = "";

--- a/src/impl/locale.js
+++ b/src/impl/locale.js
@@ -1,8 +1,8 @@
-import { hasFormatToParts, hasIntl, padStart, roundTo, hasRelative } from "./util";
-import * as English from "./english";
-import Settings from "../settings";
-import DateTime from "../datetime";
-import Formatter from "./formatter";
+import { hasFormatToParts, hasIntl, padStart, roundTo, hasRelative } from "./util.js";
+import * as English from "./english.js";
+import Settings from "../settings.js";
+import DateTime from "../datetime.js";
+import Formatter from "./formatter.js";
 
 let intlDTCache = {};
 function getCachedDTF(locString, opts = {}) {

--- a/src/impl/regexParser.js
+++ b/src/impl/regexParser.js
@@ -1,7 +1,7 @@
-import { untruncateYear, signedOffset, parseMillis, ianaRegex } from "./util";
-import * as English from "./english";
-import FixedOffsetZone from "../zones/fixedOffsetZone";
-import IANAZone from "../zones/IANAZone";
+import { untruncateYear, signedOffset, parseMillis, ianaRegex } from "./util.js";
+import * as English from "./english.js";
+import FixedOffsetZone from "../zones/fixedOffsetZone.js";
+import IANAZone from "../zones/IANAZone.js";
 
 /*
  * This file handles parsing for well-specified formats. Here's how it works:

--- a/src/impl/tokenParser.js
+++ b/src/impl/tokenParser.js
@@ -1,7 +1,7 @@
-import { parseMillis, isUndefined, untruncateYear, signedOffset } from "./util";
-import Formatter from "./formatter";
-import FixedOffsetZone from "../zones/fixedOffsetZone";
-import IANAZone from "../zones/IANAZone";
+import { parseMillis, isUndefined, untruncateYear, signedOffset } from "./util.js";
+import Formatter from "./formatter.js";
+import FixedOffsetZone from "../zones/fixedOffsetZone.js";
+import IANAZone from "../zones/IANAZone.js";
 
 const MISSING_FTP = "missing Intl.DateTimeFormat.formatToParts support";
 

--- a/src/impl/zoneUtil.js
+++ b/src/impl/zoneUtil.js
@@ -2,13 +2,13 @@
  * @private
  */
 
-import Zone from "../zone";
-import LocalZone from "../zones/localZone";
-import IANAZone from "../zones/IANAZone";
-import FixedOffsetZone from "../zones/fixedOffsetZone";
-import InvalidZone from "../zones/invalidZone";
+import Zone from "../zone.js";
+import LocalZone from "../zones/localZone.js";
+import IANAZone from "../zones/IANAZone.js";
+import FixedOffsetZone from "../zones/fixedOffsetZone.js";
+import InvalidZone from "../zones/invalidZone.js";
 
-import { isUndefined, isString, isNumber } from "./util";
+import { isUndefined, isString, isNumber } from "./util.js";
 
 export function normalizeZone(input, defaultZone) {
   let offset;

--- a/src/info.js
+++ b/src/info.js
@@ -1,10 +1,10 @@
-import DateTime from "./datetime";
-import Settings from "./settings";
-import Locale from "./impl/locale";
-import IANAZone from "./zones/IANAZone";
-import { normalizeZone } from "./impl/zoneUtil";
+import DateTime from "./datetime.js";
+import Settings from "./settings.js";
+import Locale from "./impl/locale.js";
+import IANAZone from "./zones/IANAZone.js";
+import { normalizeZone } from "./impl/zoneUtil.js";
 
-import { hasFormatToParts, hasIntl, hasRelative } from "./impl/util";
+import { hasFormatToParts, hasIntl, hasRelative } from "./impl/util.js";
 
 /**
  * The Info class contains static methods for retrieving general time and date related data. For example, it has methods for finding out if a time zone has a DST, for listing the months in any supported locale, and for discovering which of Luxon features are available in the current environment.

--- a/src/interval.js
+++ b/src/interval.js
@@ -1,8 +1,8 @@
-import DateTime, { friendlyDateTime } from "./datetime";
-import Duration, { friendlyDuration } from "./duration";
-import Settings from "./settings";
-import { InvalidArgumentError, InvalidIntervalError } from "./errors";
-import Invalid from "./impl/invalid";
+import DateTime, { friendlyDateTime } from "./datetime.js";
+import Duration, { friendlyDuration } from "./duration.js";
+import Settings from "./settings.js";
+import { InvalidArgumentError, InvalidIntervalError } from "./errors.js";
+import Invalid from "./impl/invalid.js";
 
 const INVALID = "Invalid Interval";
 

--- a/src/luxon.js
+++ b/src/luxon.js
@@ -1,13 +1,13 @@
-import DateTime from "./datetime";
-import Duration from "./duration";
-import Interval from "./interval";
-import Info from "./info";
-import Zone from "./zone";
-import FixedOffsetZone from "./zones/fixedOffsetZone";
-import IANAZone from "./zones/IANAZone";
-import InvalidZone from "./zones/invalidZone";
-import LocalZone from "./zones/localZone";
-import Settings from "./settings";
+import DateTime from "./datetime.js";
+import Duration from "./duration.js";
+import Interval from "./interval.js";
+import Info from "./info.js";
+import Zone from "./zone.js";
+import FixedOffsetZone from "./zones/fixedOffsetZone.js";
+import IANAZone from "./zones/IANAZone.js";
+import InvalidZone from "./zones/invalidZone.js";
+import LocalZone from "./zones/localZone.js";
+import Settings from "./settings.js";
 
 export {
   DateTime,

--- a/src/luxonFilled.js
+++ b/src/luxonFilled.js
@@ -1,12 +1,12 @@
 /* eslint import/no-extraneous-dependencies: off */
 
-import "core-js/es6/symbol";
-import "core-js/es6/object";
-import "core-js/fn/symbol/iterator";
-import "core-js/fn/number/is-nan";
-import "core-js/es6/array";
-import "core-js/fn/string/virtual/starts-with";
-import "core-js/fn/string/virtual/repeat";
-import "core-js/fn/math/trunc";
+import "core-js/es6/symbol.js";
+import "core-js/es6/object.js";
+import "core-js/fn/symbol/iterator.js";
+import "core-js/fn/number/is-nan.js";
+import "core-js/es6/array.js";
+import "core-js/fn/string/virtual/starts-with.js";
+import "core-js/fn/string/virtual/repeat.js";
+import "core-js/fn/math/trunc.js";
 
-export * from "./luxon";
+export * from "./luxon.js";

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,7 +1,7 @@
-import LocalZone from "./zones/localZone";
-import Locale from "./impl/locale";
+import LocalZone from "./zones/localZone.js";
+import Locale from "./impl/locale.js";
 
-import { normalizeZone } from "./impl/zoneUtil";
+import { normalizeZone } from "./impl/zoneUtil.js";
 
 let now = () => Date.now(),
   defaultZone = null, // not setting this directly to LocalZone.instance bc loading order issues

--- a/src/zone.js
+++ b/src/zone.js
@@ -1,5 +1,5 @@
 /* eslint no-unused-vars: "off" */
-import { ZoneIsAbstractError } from "./errors";
+import { ZoneIsAbstractError } from "./errors.js";
 
 /**
  * @interface

--- a/src/zones/IANAZone.js
+++ b/src/zones/IANAZone.js
@@ -1,5 +1,5 @@
-import { parseZoneInfo, isUndefined, ianaRegex } from "../impl/util";
-import Zone from "../zone";
+import { parseZoneInfo, isUndefined, ianaRegex } from "../impl/util.js";
+import Zone from "../zone.js";
 
 const matchingRegex = RegExp(`^${ianaRegex.source}$`);
 

--- a/src/zones/fixedOffsetZone.js
+++ b/src/zones/fixedOffsetZone.js
@@ -1,5 +1,5 @@
-import { padStart, signedOffset } from "../impl/util";
-import Zone from "../zone";
+import { padStart, signedOffset } from "../impl/util.js";
+import Zone from "../zone.js";
 
 let singleton = null;
 

--- a/src/zones/invalidZone.js
+++ b/src/zones/invalidZone.js
@@ -1,4 +1,4 @@
-import Zone from "../zone";
+import Zone from "../zone.js";
 
 export default class InvalidZone extends Zone {
   constructor(zoneName) {

--- a/src/zones/localZone.js
+++ b/src/zones/localZone.js
@@ -1,5 +1,5 @@
-import { parseZoneInfo, hasIntl } from "../impl/util";
-import Zone from "../zone";
+import { parseZoneInfo, hasIntl } from "../impl/util.js";
+import Zone from "../zone.js";
 
 let singleton = null;
 


### PR DESCRIPTION
Put the file extension into import statements for all of the files in the src directory. This enables Luxon to be imported as a module by browsers that support the import statement. It currently works with some servers that ad the extension but not all. This should offer much faster download speeds over the HTTP/2 protocol. 
Address the issue #417 