### PR TITLE
fix zero duration formatting invalid value

### DIFF
--- a/src/duration.js
+++ b/src/duration.js
@@ -409,6 +409,7 @@ export default class Duration {
     if (this.minutes !== 0) s += this.minutes + "M";
     if (this.seconds !== 0 || this.milliseconds !== 0)
       s += this.seconds + this.milliseconds / 1000 + "S";
+    if (s === "P") s += "T0S";
     return s;
   }
 

--- a/test/duration/format.test.js
+++ b/test/duration/format.test.js
@@ -36,6 +36,10 @@ test("Duration#toISO handles mixed negative/positive durations", () => {
   expect(Duration.fromObject({ years: -5, seconds: 34 }).toISO()).toBe("P-5YT34S");
 });
 
+test("Duration#toISO handles zero durations", () => {
+  expect(Duration.fromMillis(0).toISO()).toBe("PT0S");
+});
+
 test("Duration#toISO returns null for invalid durations", () => {
   expect(Duration.invalid("because").toISO()).toBe(null);
 });


### PR DESCRIPTION
from [Wikipedia](https://en.wikipedia.org/wiki/ISO_8601)

>Date and time elements including their designator may be omitted if their value is zero, and lower order elements may also be omitted for reduced precision. For example, "P23DT23H" and "P4Y" are both acceptable duration representations. **However, at least one element must be present, thus "P" is not a valid representation for a duration of 0 seconds. "PT0S" or "P0D", however, are both valid and represent the same duration.**

This PR makes it conform this description.