### PR TITLE
changes made for toLocal to accept the default Zone

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1226,7 +1226,7 @@ export default class DateTime {
    * @return {DateTime}
    */
   toLocal() {
-    return this.setZone(new LocalZone());
+    return this.setZone(Settings.defaultZone || new LocalZone());
   }
 
   /**

--- a/test/datetime/create.test.js
+++ b/test/datetime/create.test.js
@@ -16,7 +16,8 @@ function setUnset(prop) {
 
 const withDefaultLocale = setUnset("defaultLocale"),
   withDefaultNumberingSystem = setUnset("defaultNumberingSystem"),
-  withDefaultOutputCalendar = setUnset("defaultOutputCalendar");
+  withDefaultOutputCalendar = setUnset("defaultOutputCalendar"),
+  withdefaultZone = setUnset("defaultZoneName");
 
 //------
 // .local()
@@ -113,6 +114,13 @@ test("DateTime.local accepts the default numbering system", () => {
 
 test("DateTime.local accepts the default output calendar", () => {
   withDefaultOutputCalendar("hebrew", () => expect(DateTime.local().outputCalendar).toBe("hebrew"));
+});
+
+//------
+// #toLocal()
+//-------
+test("DateTime#toLocal accepts the default locale", () => {
+  withdefaultZone("UTC", () => expect(DateTime.local().zoneName).toBe("UTC"));
 });
 
 //------

--- a/test/datetime/zone.test.js
+++ b/test/datetime/zone.test.js
@@ -52,6 +52,13 @@ test("DateTime#toLocal() sets the calendar back to local", () => {
   expect(relocaled.hour).toBe(expected);
 });
 
+test("DateTime#toLocal() accepts the default locale", () => {
+  Helpers.withDefaultZone("Asia/Tokyo", () => {
+    Settings.defaultZoneName = "UTC";
+    expect(DateTime.local().toLocal().zoneName).toBe("UTC");
+  });
+});
+
 //------
 // #setZone()
 //------
@@ -111,9 +118,11 @@ test('DateTime#setZone accepts "utc-3:30"', () => {
 });
 
 test("DateTime#setZone does not accept dumb things", () => {
-  const zoned = DateTime.local().setZone("utc-yo");
-  // this is questionable; should this be invalid instead?
-  expect(zoned.zone.type).toBe("local");
+  Helpers.withDefaultZone("local", () => {
+    const zoned = DateTime.local().setZone("utc-yo");
+    // this is questionable; should this be invalid instead?
+    expect(zoned.zone.type).toBe("local");
+  });
 });
 
 test("DateTime#setZone accepts IANA zone names", () => {


### PR DESCRIPTION
Fixed issue #377 

toLocal will accepts `Settings.defaultZone` as default timezone if it is defined.  