### PR TITLE
fixed special character issue in format string

### DIFF
--- a/src/impl/tokenParser.js
+++ b/src/impl/tokenParser.js
@@ -38,6 +38,11 @@ function simple(regex) {
   return { regex, deser: ([s]) => s };
 }
 
+function escapeToken(value) {
+  // eslint-disable-next-line no-useless-escape
+  return value.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, "\\$&");
+}
+
 function unitForToken(token, loc) {
   const one = /\d/,
     two = /\d{2}/,
@@ -46,7 +51,7 @@ function unitForToken(token, loc) {
     oneOrTwo = /\d{1,2}/,
     oneToThree = /\d{1,3}/,
     twoToFour = /\d{2,4}/,
-    literal = t => ({ regex: RegExp(t.val), deser: ([s]) => s, literal: true }),
+    literal = t => ({ regex: RegExp(escapeToken(t.val)), deser: ([s]) => s, literal: true }),
     unitate = t => {
       if (token.literal) {
         return literal(t);

--- a/test/datetime/tokenParse.test.js
+++ b/test/datetime/tokenParse.test.js
@@ -488,6 +488,27 @@ test("DateTime.fromFormat validates weekdays", () => {
   expect(dt.isValid).toBe(false);
 });
 
+test("DateTime.fromFormat containg special regex token", () => {
+  const ianaFormat = "yyyy-MM-dd'T'HH-mm[z]";
+  const dt = DateTime.fromFormat("2019-01-14T11-30[Indian/Maldives]", ianaFormat, {
+    setZone: true
+  });
+  expect(dt.isValid).toBe(true);
+  expect(dt.zoneName).toBe("Indian/Maldives");
+
+  expect(
+    DateTime.fromFormat("2019-01-14T11-30[[Indian/Maldives]]", "yyyy-MM-dd'T'HH-mm[[z]]").isValid
+  ).toBe(true);
+
+  expect(
+    DateTime.fromFormat("2019-01-14T11-30tIndian/Maldivest", "yyyy-MM-dd'T'HH-mm't'z't'").isValid
+  ).toBe(true);
+
+  expect(
+    DateTime.fromFormat("2019-01-14T11-30\tIndian/Maldives\t", "yyyy-MM-dd'T'HH-mm't'z't'").isValid
+  ).toBe(false);
+});
+
 //------
 // .fromFormatExplain
 //-------


### PR DESCRIPTION
Fixes issue #408 

```javascript
// 😥 Should print "Indian/Maldives", but throws exception "Invalid regular expression:
// /[/: Unterminated character class"
const { DateTime } = require('luxon');
console.log(DateTime.fromFormat('2019-01-14T11-30[Indian/Maldives]', ianaFormat, 
{ 
   setZone: true 
}).zoneName);

```