### PR TITLE
Add Math.sign polyfill for IE

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -24,7 +24,7 @@ var DateTime = luxon.DateTime;
 If you're supporting IE 10 or 11, you need some polyfills to get Luxon to work. Use polyfill.io:
 
 ```html
-<script src="https://cdn.polyfill.io/v2/polyfill.js?features=default,String.prototype.repeat,Array.prototype.find,Array.prototype.findIndex,Math.trunc"></script>
+<script src="https://cdn.polyfill.io/v2/polyfill.js?features=default,String.prototype.repeat,Array.prototype.find,Array.prototype.findIndex,Math.trunc,Math.sign"></script>
 ```
 
 See the [support matrix](matrix.html) for more information on what works and what doesn't in IE.

--- a/site/demo/global.html
+++ b/site/demo/global.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <link rel='stylesheet' href='demo.css'/>
-        <script src="https://cdn.polyfill.io/v2/polyfill.js?features=default,String.prototype.repeat,Array.prototype.find,Array.prototype.findIndex,Math.trunc,Intl.~locale.zh,Intl.~locale.fr"></script>
+        <script src="https://cdn.polyfill.io/v2/polyfill.js?features=default,String.prototype.repeat,Array.prototype.find,Array.prototype.findIndex,Math.trunc,Math.sign,Intl.~locale.zh,Intl.~locale.fr"></script>
         <script src='../global/luxon.js'></script>
         <script src='demo.js'></script>
         <script>document.addEventListener("DOMContentLoaded", function(){demo(window.luxon)});</script>


### PR DESCRIPTION
Fixes #434.

Adds `Math.sign` to the polyfill.io url for the global demo, and the IE install docs.