### PR TITLE
DateTime.fromObject silently accepts any wrong value #448

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -71,13 +71,13 @@ Luxon uses [Husky](https://github.com/typicode/husky) to run the formatter on yo
 
 ## npm script reference
 
-| Command                  | Function                                |
-| ------------------------ | --------------------------------------- |
-| `npm run build`          | Build all the distributable files       |
-| `npm run build-node`     | Build just for Node                     |
-| `npm run test`           | Run the test suite, but see notes above |
-| `npm run format`         | Run the Prettier formatter              |
-| `npm run lint!`          | Run the formatter and the linter        |
-| `npm run docs`           | Build the doc pages                     |
-| `npm run site`           | Build the Luxon website                 |
-| `npm check-doc-coverage` | Check whether there's full doc coverage |
+| Command                      | Function                                |
+| ---------------------------- | --------------------------------------- |
+| `npm run build`              | Build all the distributable files       |
+| `npm run build-node`         | Build just for Node                     |
+| `npm run test`               | Run the test suite, but see notes above |
+| `npm run format`             | Run the Prettier formatter              |
+| `npm run lint!`              | Run the formatter and the linter        |
+| `npm run docs`               | Build the doc pages                     |
+| `npm run site`               | Build the Luxon website                 |
+| `npm run check-doc-coverage` | Check whether there's full doc coverage |

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -155,12 +155,13 @@ function parseDataToDateTime(parsed, parsedZone, opts, format, text) {
   const { setZone, zone } = opts;
   if (parsed && Object.keys(parsed).length !== 0) {
     const interpretationZone = parsedZone || zone,
-      obj = Object.assign(parsed, opts, {
-        zone: interpretationZone
-      });
-    // setZone is a valid option in calling methods, but not in fromObject
-    delete obj.setZone;
-    const inst = DateTime.fromObject(obj);
+      inst = DateTime.fromObject(
+        Object.assign(parsed, opts, {
+          zone: interpretationZone,
+          // setZone is a valid option in the calling methods, but not in fromObject
+          setZone: undefined
+        })
+      );
     return setZone ? inst : inst.setZone(zone);
   } else {
     return DateTime.invalid(
@@ -590,20 +591,14 @@ export default class DateTime {
       return DateTime.invalid(unsupportedZone(zoneToUse));
     }
 
-    let normalized;
-    try {
+    const tsNow = Settings.now(),
+      offsetProvis = zoneToUse.offset(tsNow),
       normalized = normalizeObject(obj, normalizeUnit, [
         "zone",
         "locale",
         "outputCalendar",
         "numberingSystem"
-      ]);
-    } catch (error) {
-      return DateTime.invalid(error.message);
-    }
-
-    const tsNow = Settings.now(),
-      offsetProvis = zoneToUse.offset(tsNow),
+      ]),
       containsOrdinal = !isUndefined(normalized.ordinal),
       containsGregorYear = !isUndefined(normalized.year),
       containsGregorMD = !isUndefined(normalized.month) || !isUndefined(normalized.day),

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1788,7 +1788,7 @@ export default class DateTime {
   }
 
   /**
-   * Returns a string representation this date relative to today, such as "yesterday" or "next month"
+   * Returns a string representation of this date relative to today, such as "yesterday" or "next month"
    * platform supports Intl.RelativeDateFormat.
    * @param {Object} options - options that affect the output
    * @param {DateTime} [options.base=DateTime.local()] - the DateTime to use as the basis to which this time is compared. Defaults to now.

--- a/src/duration.js
+++ b/src/duration.js
@@ -207,7 +207,7 @@ export default class Duration {
 
   /**
    * Create a Duration from a Javascript object with keys like 'years' and 'hours.
-   * If this object is empty then zero  milliseconds duration is returned.
+   * If this object is empty then a zero milliseconds duration is returned.
    * @param {Object} obj - the object to create the DateTime from
    * @param {number} obj.years
    * @param {number} obj.quarters

--- a/src/duration.js
+++ b/src/duration.js
@@ -493,6 +493,8 @@ export default class Duration {
    * @return {Duration}
    */
   set(values) {
+    if (!this.isValid) return this;
+
     const mixed = Object.assign(this.values, normalizeObject(values, Duration.normalizeUnit, []));
     return clone(this, { values: mixed });
   }

--- a/src/duration.js
+++ b/src/duration.js
@@ -230,7 +230,11 @@ export default class Duration {
       );
     }
     return new Duration({
-      values: normalizeObject(obj, Duration.normalizeUnit, true),
+      values: normalizeObject(obj, Duration.normalizeUnit, [
+        "locale",
+        "numberingSystem",
+        "conversionAccuracy"
+      ]),
       loc: Locale.fromObject(obj),
       conversionAccuracy: obj.conversionAccuracy
     });
@@ -282,7 +286,7 @@ export default class Duration {
   /**
    * @private
    */
-  static normalizeUnit(unit, ignoreUnknown = false) {
+  static normalizeUnit(unit) {
     const normalized = {
       year: "years",
       years: "years",
@@ -304,7 +308,7 @@ export default class Duration {
       milliseconds: "milliseconds"
     }[unit ? unit.toLowerCase() : unit];
 
-    if (!ignoreUnknown && !normalized) throw new InvalidUnitError(unit);
+    if (!normalized) throw new InvalidUnitError(unit);
 
     return normalized;
   }
@@ -489,7 +493,7 @@ export default class Duration {
    * @return {Duration}
    */
   set(values) {
-    const mixed = Object.assign(this.values, normalizeObject(values, Duration.normalizeUnit));
+    const mixed = Object.assign(this.values, normalizeObject(values, Duration.normalizeUnit, []));
     return clone(this, { values: mixed });
   }
 

--- a/src/impl/regexParser.js
+++ b/src/impl/regexParser.js
@@ -155,10 +155,7 @@ const obsOffsets = {
 function fromStrings(weekdayStr, yearStr, monthStr, dayStr, hourStr, minuteStr, secondStr) {
   const result = {
     year: yearStr.length === 2 ? untruncateYear(parseInteger(yearStr)) : parseInteger(yearStr),
-    month:
-      monthStr.length === 2
-        ? parseInteger(monthStr, 10)
-        : English.monthsShort.indexOf(monthStr) + 1,
+    month: English.monthsShort.indexOf(monthStr) + 1,
     day: parseInteger(dayStr),
     hour: parseInteger(hourStr),
     minute: parseInteger(minuteStr)

--- a/src/impl/regexParser.js
+++ b/src/impl/regexParser.js
@@ -1,4 +1,4 @@
-import { untruncateYear, signedOffset, parseMillis, ianaRegex } from "./util.js";
+import { untruncateYear, signedOffset, parseInteger, parseMillis, ianaRegex } from "./util.js";
 import * as English from "./english.js";
 import FixedOffsetZone from "../zones/fixedOffsetZone.js";
 import IANAZone from "../zones/IANAZone.js";
@@ -51,7 +51,7 @@ function simpleParse(...keys) {
     let i;
 
     for (i = 0; i < keys.length; i++) {
-      ret[keys[i]] = parseInt(match[cursor + i]);
+      ret[keys[i]] = parseInteger(match[cursor + i]);
     }
     return [ret, null, cursor + i];
   };
@@ -75,9 +75,9 @@ const offsetRegex = /(?:(Z)|([+-]\d\d)(?::?(\d\d))?)/,
 
 function extractISOYmd(match, cursor) {
   const item = {
-    year: parseInt(match[cursor]),
-    month: parseInt(match[cursor + 1]) || 1,
-    day: parseInt(match[cursor + 2]) || 1
+    year: parseInteger(match[cursor]),
+    month: parseInteger(match[cursor + 1]) || 1,
+    day: parseInteger(match[cursor + 2]) || 1
   };
 
   return [item, null, cursor + 3];
@@ -85,9 +85,9 @@ function extractISOYmd(match, cursor) {
 
 function extractISOTime(match, cursor) {
   const item = {
-    hour: parseInt(match[cursor]) || 0,
-    minute: parseInt(match[cursor + 1]) || 0,
-    second: parseInt(match[cursor + 2]) || 0,
+    hour: parseInteger(match[cursor]) || 0,
+    minute: parseInteger(match[cursor + 1]) || 0,
+    second: parseInteger(match[cursor + 2]) || 0,
     millisecond: parseMillis(match[cursor + 3])
   };
 
@@ -125,13 +125,13 @@ function extractISODuration(match) {
 
   return [
     {
-      years: parseInt(yearStr),
-      months: parseInt(monthStr),
-      weeks: parseInt(weekStr),
-      days: parseInt(dayStr),
-      hours: parseInt(hourStr),
-      minutes: parseInt(minuteStr),
-      seconds: parseInt(secondStr),
+      years: parseInteger(yearStr),
+      months: parseInteger(monthStr),
+      weeks: parseInteger(weekStr),
+      days: parseInteger(dayStr),
+      hours: parseInteger(hourStr),
+      minutes: parseInteger(minuteStr),
+      seconds: parseInteger(secondStr),
       milliseconds: parseMillis(millisecondsStr)
     }
   ];
@@ -154,15 +154,17 @@ const obsOffsets = {
 
 function fromStrings(weekdayStr, yearStr, monthStr, dayStr, hourStr, minuteStr, secondStr) {
   const result = {
-    year: yearStr.length === 2 ? untruncateYear(parseInt(yearStr)) : parseInt(yearStr),
+    year: yearStr.length === 2 ? untruncateYear(parseInteger(yearStr)) : parseInteger(yearStr),
     month:
-      monthStr.length === 2 ? parseInt(monthStr, 10) : English.monthsShort.indexOf(monthStr) + 1,
-    day: parseInt(dayStr),
-    hour: parseInt(hourStr),
-    minute: parseInt(minuteStr)
+      monthStr.length === 2
+        ? parseInteger(monthStr, 10)
+        : English.monthsShort.indexOf(monthStr) + 1,
+    day: parseInteger(dayStr),
+    hour: parseInteger(hourStr),
+    minute: parseInteger(minuteStr)
   };
 
-  if (secondStr) result.second = parseInt(secondStr);
+  if (secondStr) result.second = parseInteger(secondStr);
   if (weekdayStr) {
     result.weekday =
       weekdayStr.length > 3

--- a/src/impl/util.js
+++ b/src/impl/util.js
@@ -4,6 +4,8 @@
   it up into, say, parsingUtil.js and basicUtil.js and so on. But they are divided up by feature area.
 */
 
+import { InvalidArgumentError } from "../errors.js";
+
 /**
  * @private
  */
@@ -97,6 +99,7 @@ export function parseInteger(string) {
 }
 
 export function parseMillis(fraction) {
+  // Return undefined (instead of 0) in these cases, where fraction is not set
   if (isUndefined(fraction) || fraction === null || fraction === "") {
     return undefined;
   } else {
@@ -219,7 +222,7 @@ export function signedOffset(offHourStr, offMinuteStr) {
 function asNumber(value) {
   const numericValue = Number(value);
   if (typeof value === "boolean" || value === "" || Number.isNaN(numericValue))
-    throw new Error(`Invalid unit value ${value}`);
+    throw new InvalidArgumentError(`Invalid unit value ${value}`);
   return numericValue;
 }
 
@@ -227,8 +230,9 @@ export function normalizeObject(obj, normalizer, nonUnitKeys) {
   const normalized = {};
   for (const u in obj) {
     if (obj.hasOwnProperty(u)) {
+      if (nonUnitKeys.indexOf(u) >= 0) continue;
       const v = obj[u];
-      if (v === undefined || v === null || nonUnitKeys.includes(u)) continue;
+      if (v === undefined || v === null) continue;
       normalized[normalizer(u)] = asNumber(v);
     }
   }

--- a/src/impl/util.js
+++ b/src/impl/util.js
@@ -88,9 +88,17 @@ export function padStart(input, n = 2) {
   }
 }
 
+export function parseInteger(string) {
+  if (isUndefined(string) || string === null || string === "") {
+    return undefined;
+  } else {
+    return parseInt(string, 10);
+  }
+}
+
 export function parseMillis(fraction) {
-  if (isUndefined(fraction)) {
-    return NaN;
+  if (isUndefined(fraction) || fraction === null || fraction === "") {
+    return undefined;
   } else {
     const f = parseFloat("0." + fraction) * 1000;
     return Math.floor(f);
@@ -208,18 +216,20 @@ export function signedOffset(offHourStr, offMinuteStr) {
 
 // COERCION
 
-export function normalizeObject(obj, normalizer, ignoreUnknown = false) {
+function asNumber(value) {
+  const numericValue = Number(value);
+  if (typeof value === "boolean" || value === "" || Number.isNaN(numericValue))
+    throw new Error(`Invalid unit value ${value}`);
+  return numericValue;
+}
+
+export function normalizeObject(obj, normalizer, nonUnitKeys) {
   const normalized = {};
   for (const u in obj) {
     if (obj.hasOwnProperty(u)) {
       const v = obj[u];
-      const numericValue = Number(v);
-      if (v !== null && !Number.isNaN(numericValue)) {
-        const mapped = normalizer(u, ignoreUnknown);
-        if (mapped) {
-          normalized[mapped] = numericValue;
-        }
-      }
+      if (v === undefined || v === null || nonUnitKeys.includes(u)) continue;
+      normalized[normalizer(u)] = asNumber(v);
     }
   }
   return normalized;

--- a/test/datetime/create.test.js
+++ b/test/datetime/create.test.js
@@ -386,6 +386,47 @@ test("DateTime.fromObject() rejects invalid zones", () => {
   expect(dt.invalidReason).toBe("unsupported zone");
 });
 
+test("DateTime.fromObject() ignores the case of object keys", () => {
+  const dt = DateTime.fromObject({ Year: 2019, MONTH: 4, daYs: 10 });
+  expect(dt.isValid).toBe(true);
+  expect(dt.year).toBe(2019);
+  expect(dt.month).toBe(4);
+  expect(dt.day).toBe(10);
+});
+
+test("DateTime.fromObject() rejects invalid keys", () => {
+  const dt = DateTime.fromObject({ invalidUnit: 42 });
+  expect(dt.isValid).toBe(false);
+  expect(dt.invalidReason).toBe("Invalid unit invalidUnit");
+});
+
+test("DateTime.fromObject() rejects invalid values", () => {
+  const dt = DateTime.fromObject({ year: "blorp" });
+  expect(dt.isValid).toBe(false);
+  expect(dt.invalidReason).toBe("Invalid unit value blorp");
+
+  expect(DateTime.fromObject({ month: "" }).isValid).toBe(false);
+  expect(DateTime.fromObject({ ordinal: 5000 }).isValid).toBe(false);
+  expect(DateTime.fromObject({ minute: -6 }).isValid).toBe(false);
+  expect(DateTime.fromObject({ millisecond: new Date() }).isValid).toBe(false);
+});
+
+test("DateTime.fromObject() rejects boolean values", () => {
+  const dtTrue = DateTime.fromObject({ year: true });
+  expect(dtTrue.isValid).toBe(false);
+  expect(dtTrue.invalidReason).toBe("Invalid unit value true");
+
+  const dtFalse = DateTime.fromObject({ year: false });
+  expect(dtFalse.isValid).toBe(false);
+  expect(dtFalse.invalidReason).toBe("Invalid unit value false");
+});
+
+test("DateTime.fromObject() rejects NaN values", () => {
+  const dt = DateTime.fromObject({ year: NaN });
+  expect(dt.isValid).toBe(false);
+  expect(dt.invalidReason).toBe("Invalid unit value NaN");
+});
+
 test("DateTime.fromObject() defaults high-order values to the current date", () => {
   const dateTime = DateTime.fromObject({}),
     now = DateTime.local();
@@ -571,13 +612,4 @@ test("DateTime.fromObject handles null as a language tag", () => {
     expect(res.outputCalendar).toBe("islamic");
     expect(res.numberingSystem).toBe("thai");
   });
-});
-
-test("DateTime.fromObject overrides invalid date part with the current date part", () => {
-  const dt = DateTime.fromObject({ year: "hello" });
-  const localDt = DateTime.local();
-  expect(dt.isValid).toBe(true);
-  expect(dt.year).toBe(localDt.year);
-  expect(dt.months).toBe(localDt.months);
-  expect(dt.day).toBe(localDt.day);
 });

--- a/test/datetime/create.test.js
+++ b/test/datetime/create.test.js
@@ -394,37 +394,24 @@ test("DateTime.fromObject() ignores the case of object keys", () => {
   expect(dt.day).toBe(10);
 });
 
-test("DateTime.fromObject() rejects invalid keys", () => {
-  const dt = DateTime.fromObject({ invalidUnit: 42 });
-  expect(dt.isValid).toBe(false);
-  expect(dt.invalidReason).toBe("Invalid unit invalidUnit");
+test("DateTime.fromObject() throws with invalid object key", () => {
+  expect(() => DateTime.fromObject({ invalidUnit: 42 })).toThrow();
 });
 
-test("DateTime.fromObject() rejects invalid values", () => {
-  const dt = DateTime.fromObject({ year: "blorp" });
-  expect(dt.isValid).toBe(false);
-  expect(dt.invalidReason).toBe("Invalid unit value blorp");
+test("DateTime.fromObject() throws with invalid value types", () => {
+  expect(() => DateTime.fromObject({ year: "blorp" })).toThrow();
+  expect(() => DateTime.fromObject({ year: "" })).toThrow();
+  expect(() => DateTime.fromObject({ month: NaN })).toThrow();
+  expect(() => DateTime.fromObject({ day: true })).toThrow();
+  expect(() => DateTime.fromObject({ day: false })).toThrow();
+  expect(() => DateTime.fromObject({ hour: {} })).toThrow();
+  expect(() => DateTime.fromObject({ hour: { unit: 42 } })).toThrow();
+});
 
-  expect(DateTime.fromObject({ month: "" }).isValid).toBe(false);
+test("DateTime.fromObject() reject invalid values", () => {
   expect(DateTime.fromObject({ ordinal: 5000 }).isValid).toBe(false);
   expect(DateTime.fromObject({ minute: -6 }).isValid).toBe(false);
   expect(DateTime.fromObject({ millisecond: new Date() }).isValid).toBe(false);
-});
-
-test("DateTime.fromObject() rejects boolean values", () => {
-  const dtTrue = DateTime.fromObject({ year: true });
-  expect(dtTrue.isValid).toBe(false);
-  expect(dtTrue.invalidReason).toBe("Invalid unit value true");
-
-  const dtFalse = DateTime.fromObject({ year: false });
-  expect(dtFalse.isValid).toBe(false);
-  expect(dtFalse.invalidReason).toBe("Invalid unit value false");
-});
-
-test("DateTime.fromObject() rejects NaN values", () => {
-  const dt = DateTime.fromObject({ year: NaN });
-  expect(dt.isValid).toBe(false);
-  expect(dt.invalidReason).toBe("Invalid unit value NaN");
 });
 
 test("DateTime.fromObject() defaults high-order values to the current date", () => {

--- a/test/datetime/degrade.test.js
+++ b/test/datetime/degrade.test.js
@@ -1,4 +1,4 @@
-/* global expect Intl */
+/* global expect */
 import { DateTime } from "../../src/luxon";
 import { Helpers } from "../helpers";
 

--- a/test/datetime/invalid.test.js
+++ b/test/datetime/invalid.test.js
@@ -4,7 +4,7 @@ import { DateTime, Settings } from "../../src/luxon";
 
 const organic1 = DateTime.utc(2014, 13, 33),
   // not an actual Wednesday
-  organic2 = DateTime.fromObject({ weekday: 3, year: 1982, month: 5, day: 25 }),
+  organic2 = DateTime.fromObject({ weekday: 3, year: 1982, month: 5, day: 25, zone: "UTC" }),
   organic3 = DateTime.fromObject({ year: 1982, month: 5, day: 25, hour: 27 });
 
 test("Explicitly invalid dates are invalid", () => {
@@ -37,7 +37,7 @@ test("Invalid DateTimes can provide an extented explanation", () => {
     "you specified 13 (of type number) as a month, which is invalid"
   );
   expect(organic2.invalidExplanation).toBe(
-    "you can't specify both a weekday of 3 and a date of 1982-05-25T00:00:00.000-04:00"
+    "you can't specify both a weekday of 3 and a date of 1982-05-25T00:00:00.000Z"
   );
   expect(organic3.invalidExplanation).toBe(
     "you specified 27 (of type number) as a hour, which is invalid"

--- a/test/datetime/regexParse.test.js
+++ b/test/datetime/regexParse.test.js
@@ -181,7 +181,7 @@ test("DateTime.fromISO() accepts extend years", () => {
   });
 });
 
-test("DateTime.fromISO() accepts year-moth-dayThour", () => {
+test("DateTime.fromISO() accepts year-month-dayThour", () => {
   isSame("2016-05-25T09", {
     year: 2016,
     month: 5,

--- a/test/datetime/relative.test.js
+++ b/test/datetime/relative.test.js
@@ -140,16 +140,17 @@ Helpers.withoutRTF("DateTime#toRelativeCalendar falls back to English", () => {
   ).toBe("next year");
 });
 
-test("DateTime#toRelativeCalendar works down through the units for diffrent zone than local", () => {
+test("DateTime#toRelativeCalendar works down through the units for different zone than local", () => {
   const target = DateTime.local().setZone(`UTC+3`),
     target1 = target.plus({ days: 1 }),
     target2 = target1.plus({ days: 1 }),
-    target3 = target2.plus({ days: 1 });
+    target3 = target2.plus({ days: 1 }),
+    options = { unit: "days" };
 
-  expect(target.toRelativeCalendar()).toBe("today");
-  expect(target1.toRelativeCalendar()).toBe("tomorrow");
-  expect(target2.toRelativeCalendar()).toBe("in 2 days");
-  expect(target3.toRelativeCalendar()).toBe("in 3 days");
+  expect(target.toRelativeCalendar(options)).toBe("today");
+  expect(target1.toRelativeCalendar(options)).toBe("tomorrow");
+  expect(target2.toRelativeCalendar(options)).toBe("in 2 days");
+  expect(target3.toRelativeCalendar(options)).toBe("in 3 days");
 });
 
 test("DateTime#toRelative works down through the units for diffrent zone than local", () => {

--- a/test/datetime/set.test.js
+++ b/test/datetime/set.test.js
@@ -117,6 +117,12 @@ test("DateTime#set throws for invalid units", () => {
   expect(() => dt.set({ glorb: 200 })).toThrow();
 });
 
+test("DateTime#set throws for metadata", () => {
+  expect(() => dt.set({ zone: "UTC" })).toThrow();
+  expect(() => dt.set({ locale: "be" })).toThrow();
+  expect(() => dt.set({ invalid: true })).toThrow();
+});
+
 test("DateTime#set maintains invalidity", () => {
   expect(DateTime.invalid("because").set({ ordinal: 200 }).isValid).toBe(false);
 });

--- a/test/duration/create.test.js
+++ b/test/duration/create.test.js
@@ -54,7 +54,7 @@ test("Duration.fromObject throws if the argument is not an object", () => {
   expect(() => Duration.fromObject("foo")).toThrow();
 });
 
-test("Duration.fromObject({}) costructs zero duration", () => {
+test("Duration.fromObject({}) constructs zero duration", () => {
   const dur = Duration.fromObject({});
   expect(dur.years).toBe(0);
   expect(dur.months).toBe(0);

--- a/test/duration/create.test.js
+++ b/test/duration/create.test.js
@@ -65,15 +65,18 @@ test("Duration.fromObject({}) constructs zero duration", () => {
   expect(dur.milliseconds).toBe(0);
 });
 
-test("Duration.fromObject is invalid if the initial object has no units", () => {
-  const dur = Duration.fromObject({ foo: 0 });
-  expect(dur.years).toBe(0);
-  expect(dur.months).toBe(0);
-  expect(dur.days).toBe(0);
-  expect(dur.hours).toBe(0);
-  expect(dur.minutes).toBe(0);
-  expect(dur.seconds).toBe(0);
-  expect(dur.milliseconds).toBe(0);
+test("Duration.fromObject throws if the initial object has invalid keys", () => {
+  expect(() => Duration.fromObject({ foo: 0 })).toThrow();
+  expect(() => Duration.fromObject({ years: 1, foo: 0 })).toThrow();
+});
+
+test("Duration.fromObject throws if the initial object has invalid values", () => {
+  expect(() => Duration.fromObject({ years: {} })).toThrow();
+  expect(() => Duration.fromObject({ months: "some" })).toThrow();
+  expect(() => Duration.fromObject({ days: NaN })).toThrow();
+  expect(() => Duration.fromObject({ hours: true })).toThrow();
+  expect(() => Duration.fromObject({ minutes: false })).toThrow();
+  expect(() => Duration.fromObject({ seconds: "" })).toThrow();
 });
 
 test("Duration.fromObject is valid if providing options only", () => {

--- a/test/duration/set.test.js
+++ b/test/duration/set.test.js
@@ -24,3 +24,9 @@ test("Duration#set() sets the values", () => {
   expect(dur().set({ seconds: 45 }).seconds).toBe(45);
   expect(dur().set({ milliseconds: 86 }).milliseconds).toBe(86);
 });
+
+test("Duration#set() throws for metadata", () => {
+  expect(() => dur.set({ locale: "be" })).toThrow();
+  expect(() => dur.set({ numberingSystem: "thai" })).toThrow();
+  expect(() => dur.set({ invalid: 42 })).toThrow();
+});

--- a/test/duration/set.test.js
+++ b/test/duration/set.test.js
@@ -30,3 +30,7 @@ test("Duration#set() throws for metadata", () => {
   expect(() => dur.set({ numberingSystem: "thai" })).toThrow();
   expect(() => dur.set({ invalid: 42 })).toThrow();
 });
+
+test("Duration#set maintains invalidity", () => {
+  expect(Duration.invalid("because").set({ hours: 200 }).isValid).toBe(false);
+});


### PR DESCRIPTION
Make the `fromObject()` and `set` methods on `DateTime` and `Duration` more strict.

Invalid keys in the object parameter, as well as invalid values for units (such as `NaN`, `true` or `""`) now throw an error (or create an invalid `DateTime`). See the updated tests for details.

Various other minor changes.