### PR TITLE
Make available via CDNs

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,8 @@
   "main": "build/node/luxon.js",
   "module": "src/luxon.js",
   "browser": "build/cjs-browser/luxon.js",
+  "jsdelivr": "build/global/luxon.min.js",
+  "unpkg": "build/global/luxon.min.js",
   "engines": {
     "node": "*"
   },


### PR DESCRIPTION
This will make `build/global/luxon.min.js` be the file that users get when loading via `jsdelivr` or `unpkg`

Closes https://github.com/moment/luxon/issues/443