### PR TITLE
throw error on invalid date if throwOnInvalid  is true

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -506,9 +506,19 @@ export default class DateTime {
    * @return {DateTime}
    */
   static fromJSDate(date, options = {}) {
+    const ts = isDate(date) ? date.valueOf() : NaN;
+    if (Number.isNaN(ts)) {
+      return DateTime.invalid("invalid input");
+    }
+
+    const zoneToUse = normalizeZone(options.zone, Settings.defaultZone);
+    if (!zoneToUse.isValid) {
+      return DateTime.invalid(unsupportedZone(zoneToUse));
+    }
+
     return new DateTime({
-      ts: isDate(date) ? date.valueOf() : NaN,
-      zone: normalizeZone(options.zone, Settings.defaultZone),
+      ts: ts,
+      zone: zoneToUse,
       loc: Locale.fromObject(options)
     });
   }

--- a/test/datetime/create.test.js
+++ b/test/datetime/create.test.js
@@ -6,7 +6,8 @@ const Helpers = require("../helpers");
 
 const withDefaultLocale = Helpers.setUnset("defaultLocale"),
   withDefaultNumberingSystem = Helpers.setUnset("defaultNumberingSystem"),
-  withDefaultOutputCalendar = Helpers.setUnset("defaultOutputCalendar");
+  withDefaultOutputCalendar = Helpers.setUnset("defaultOutputCalendar"),
+  withthrowOnInvalid = Helpers.setUnset("throwOnInvalid");
 
 //------
 // .local()
@@ -229,6 +230,16 @@ test("DateTime.fromJSDate(date) returns invalid for invalid values", () => {
 
 test("DateTime.fromJSDate accepts the default locale", () => {
   withDefaultLocale("fr", () => expect(DateTime.fromJSDate(new Date()).locale).toBe("fr"));
+});
+
+test("DateTime.fromJSDate(date) throw errors for invalid values when throwOnInvalid is true", () => {
+  withthrowOnInvalid(true, () => {
+    expect(() => DateTime.fromJSDate("")).toThrow();
+    expect(() => DateTime.fromJSDate(new Date(""))).toThrow();
+    expect(() => DateTime.fromJSDate(new Date().valueOf())).toThrow();
+    expect(() => DateTime.fromJSDate(new Date(), { zone: "America/Blorp" })).toThrow();
+    expect(() => DateTime.fromJSDate("2019-04-16T11:32:32Z")).toThrow();
+  });
 });
 
 //------


### PR DESCRIPTION
fix issue : #494 

if Settings.throwOnInvalid is true, then DateTime.fromJSDate will throw error for invalid dates