### PR TITLE
combined regexes and extractors are created in advance to speed up fromISO() and fromSQL()

### DIFF
--- a/benchmarks/datetime.js
+++ b/benchmarks/datetime.js
@@ -17,6 +17,12 @@ suite
   .add("DateTime.local with numbers", () => {
     DateTime.local(2017, 5, 15);
   })
+  .add("DateTime.fromISO", () => {
+    DateTime.fromISO("1982-05-25T09:10:11.445Z");
+  })
+  .add("DateTime.fromSQL", () => {
+    DateTime.fromSQL("2016-05-14 10:23:54.2346");
+  })
   .add("DateTime.fromString", () => {
     DateTime.fromString("1982/05/25 09:10:11.445", "yyyy/MM/dd HH:mm:ss.SSS");
   })

--- a/src/impl/regexParser.js
+++ b/src/impl/regexParser.js
@@ -230,6 +230,24 @@ function extractASCII(match) {
   return [result, FixedOffsetZone.utcInstance];
 }
 
+const isoYmdWithTimeExtensionRegex = combineRegexes(isoYmdRegex, isoTimeExtensionRegex);
+const isoWeekWithTimeExtensionRegex = combineRegexes(isoWeekRegex, isoTimeExtensionRegex);
+const isoOrdinalWithTimeExtensionRegex = combineRegexes(isoOrdinalRegex, isoTimeExtensionRegex);
+const isoTimeCombinedRegex = combineRegexes(isoTimeRegex);
+
+const extractISOYmdTimeAndOffset = combineExtractors(
+  extractISOYmd,
+  extractISOTime,
+  extractISOOffset
+);
+const extractISOWeekTimeAndOffset = combineExtractors(
+  extractISOWeekData,
+  extractISOTime,
+  extractISOOffset
+);
+const extractISOOrdinalDataAndTime = combineExtractors(extractISOOrdinalData, extractISOTime);
+const extractISOTimeAndOffset = combineExtractors(extractISOTime, extractISOOffset);
+
 /**
  * @private
  */
@@ -237,19 +255,10 @@ function extractASCII(match) {
 export function parseISODate(s) {
   return parse(
     s,
-    [
-      combineRegexes(isoYmdRegex, isoTimeExtensionRegex),
-      combineExtractors(extractISOYmd, extractISOTime, extractISOOffset)
-    ],
-    [
-      combineRegexes(isoWeekRegex, isoTimeExtensionRegex),
-      combineExtractors(extractISOWeekData, extractISOTime, extractISOOffset)
-    ],
-    [
-      combineRegexes(isoOrdinalRegex, isoTimeExtensionRegex),
-      combineExtractors(extractISOOrdinalData, extractISOTime)
-    ],
-    [combineRegexes(isoTimeRegex), combineExtractors(extractISOTime, extractISOOffset)]
+    [isoYmdWithTimeExtensionRegex, extractISOYmdTimeAndOffset],
+    [isoWeekWithTimeExtensionRegex, extractISOWeekTimeAndOffset],
+    [isoOrdinalWithTimeExtensionRegex, extractISOOrdinalDataAndTime],
+    [isoTimeCombinedRegex, extractISOTimeAndOffset]
   );
 }
 
@@ -270,16 +279,25 @@ export function parseISODuration(s) {
   return parse(s, [isoDuration, extractISODuration]);
 }
 
+const sqlYmdWithTimeExtensionRegex = combineRegexes(sqlYmdRegex, sqlTimeExtensionRegex);
+const sqlTimeCombinedRegex = combineRegexes(sqlTimeRegex);
+
+const extractISOYmdTimeOffsetAndIANAZone = combineExtractors(
+  extractISOYmd,
+  extractISOTime,
+  extractISOOffset,
+  extractIANAZone
+);
+const extractISOTimeOffsetAndIANAZone = combineExtractors(
+  extractISOTime,
+  extractISOOffset,
+  extractIANAZone
+);
+
 export function parseSQL(s) {
   return parse(
     s,
-    [
-      combineRegexes(sqlYmdRegex, sqlTimeExtensionRegex),
-      combineExtractors(extractISOYmd, extractISOTime, extractISOOffset, extractIANAZone)
-    ],
-    [
-      combineRegexes(sqlTimeRegex),
-      combineExtractors(extractISOTime, extractISOOffset, extractIANAZone)
-    ]
+    [sqlYmdWithTimeExtensionRegex, extractISOYmdTimeOffsetAndIANAZone],
+    [sqlTimeCombinedRegex, extractISOTimeOffsetAndIANAZone]
   );
 }


### PR DESCRIPTION
This PR tweaks the internal implementation of `DateTime.fromISO()` and `DateTime.fromSQL()` such that the regexes and extractors used during parsing are created once _in advance_ and not with every invocation of these functions. This resulted in a speedup of about +25% on my machine for both functions (from ~55,000 ops/sec to ~67,000 ops/sec).