### PR TITLE
Add formatOffset method to Zones.

### DIFF
--- a/src/impl/formatter.js
+++ b/src/impl/formatter.js
@@ -132,21 +132,7 @@ export default class Formatter {
           return "Z";
         }
 
-        const hours = Math.trunc(dt.offset / 60),
-          minutes = Math.abs(dt.offset % 60),
-          sign = hours >= 0 ? "+" : "-",
-          base = `${sign}${Math.abs(hours)}`;
-
-        switch (opts.format) {
-          case "short":
-            return `${sign}${this.num(Math.abs(hours), 2)}:${this.num(minutes, 2)}`;
-          case "narrow":
-            return minutes > 0 ? `${base}:${minutes}` : base;
-          case "techie":
-            return `${sign}${this.num(Math.abs(hours), 2)}${this.num(minutes, 2)}`;
-          default:
-            throw new RangeError(`Value format ${opts.format} is out of range for property format`);
-        }
+        return dt.isValid ? dt.zone.formatOffset(dt.ts, opts.format) : "";
       },
       meridiem = () =>
         knownEnglish

--- a/src/impl/util.js
+++ b/src/impl/util.js
@@ -239,6 +239,24 @@ export function normalizeObject(obj, normalizer, nonUnitKeys) {
   return normalized;
 }
 
+export function formatOffset(offset, format) {
+  const hours = Math.trunc(offset / 60),
+    minutes = Math.abs(offset % 60),
+    sign = hours >= 0 ? "+" : "-",
+    base = `${sign}${Math.abs(hours)}`;
+
+  switch (format) {
+    case "short":
+      return `${sign}${padStart(Math.abs(hours), 2)}:${padStart(minutes, 2)}`;
+    case "narrow":
+      return minutes > 0 ? `${base}:${minutes}` : base;
+    case "techie":
+      return `${sign}${padStart(Math.abs(hours), 2)}${padStart(minutes, 2)}`;
+    default:
+      throw new RangeError(`Value format ${format} is out of range for property format`);
+  }
+}
+
 export function timeObject(obj) {
   return pick(obj, ["hour", "minute", "second", "millisecond"]);
 }

--- a/src/info.js
+++ b/src/info.js
@@ -29,7 +29,7 @@ export default class Info {
    * @return {boolean}
    */
   static isValidIANAZone(zone) {
-    return !!IANAZone.isValidSpecifier(zone) && IANAZone.isValidZone(zone);
+    return IANAZone.isValidSpecifier(zone) && IANAZone.isValidZone(zone);
   }
 
   /**

--- a/src/zone.js
+++ b/src/zone.js
@@ -46,6 +46,18 @@ export default class Zone {
   }
 
   /**
+   * Returns the offset's value as a string
+   * @abstract
+   * @param {number} ts - Epoch milliseconds for which to get the offset
+   * @param {string} format - What style of offset to return.
+   *                          Accepts 'narrow', 'short', or 'techie'. Returning '+6', '+06:00', or '+0600' respectively
+   * @return {string}
+   */
+  formatOffset(ts, format) {
+    throw new ZoneIsAbstractError();
+  }
+
+  /**
    * Return the offset in minutes for this zone at the specified timestamp.
    * @abstract
    * @param {number} ts - Epoch milliseconds for which to compute the offset

--- a/src/zones/IANAZone.js
+++ b/src/zones/IANAZone.js
@@ -83,7 +83,7 @@ export default class IANAZone extends Zone {
    * @return {boolean}
    */
   static isValidSpecifier(s) {
-    return s && s.match(matchingRegex);
+    return !!(s && s.match(matchingRegex));
   }
 
   /**

--- a/src/zones/IANAZone.js
+++ b/src/zones/IANAZone.js
@@ -1,4 +1,4 @@
-import { parseZoneInfo, isUndefined, ianaRegex, objToLocalTS } from "../impl/util.js";
+import { formatOffset, parseZoneInfo, isUndefined, ianaRegex, objToLocalTS } from "../impl/util.js";
 import Zone from "../zone.js";
 
 const matchingRegex = RegExp(`^${ianaRegex.source}$`);
@@ -141,6 +141,11 @@ export default class IANAZone extends Zone {
   /** @override **/
   offsetName(ts, { format, locale }) {
     return parseZoneInfo(ts, format, locale, this.name);
+  }
+
+  /** @override **/
+  formatOffset(ts, format) {
+    return formatOffset(this.offset(ts), format);
   }
 
   /** @override **/

--- a/src/zones/fixedOffsetZone.js
+++ b/src/zones/fixedOffsetZone.js
@@ -1,15 +1,7 @@
-import { padStart, signedOffset } from "../impl/util.js";
+import { formatOffset, signedOffset } from "../impl/util.js";
 import Zone from "../zone.js";
 
 let singleton = null;
-
-function hoursMinutesOffset(z) {
-  const hours = Math.trunc(z.fixed / 60),
-    minutes = Math.abs(z.fixed % 60),
-    sign = hours > 0 ? "+" : "-",
-    base = sign + Math.abs(hours);
-  return minutes > 0 ? `${base}:${padStart(minutes, 2)}` : base;
-}
 
 /**
  * A zone with a fixed offset (i.e. no DST)
@@ -67,12 +59,17 @@ export default class FixedOffsetZone extends Zone {
 
   /** @override **/
   get name() {
-    return this.fixed === 0 ? "UTC" : `UTC${hoursMinutesOffset(this)}`;
+    return this.fixed === 0 ? "UTC" : `UTC${formatOffset(this.fixed, "narrow")}`;
   }
 
   /** @override **/
   offsetName() {
     return this.name;
+  }
+
+  /** @override **/
+  formatOffset(ts, format) {
+    return formatOffset(this.fixed, format);
   }
 
   /** @override **/

--- a/src/zones/invalidZone.js
+++ b/src/zones/invalidZone.js
@@ -32,6 +32,11 @@ export default class InvalidZone extends Zone {
   }
 
   /** @override **/
+  formatOffset() {
+    return "";
+  }
+
+  /** @override **/
   offset() {
     return NaN;
   }

--- a/src/zones/localZone.js
+++ b/src/zones/localZone.js
@@ -1,4 +1,4 @@
-import { parseZoneInfo, hasIntl } from "../impl/util.js";
+import { formatOffset, parseZoneInfo, hasIntl } from "../impl/util.js";
 import Zone from "../zone.js";
 
 let singleton = null;
@@ -39,6 +39,11 @@ export default class LocalZone extends Zone {
   /** @override **/
   offsetName(ts, { format, locale }) {
     return parseZoneInfo(ts, format, locale);
+  }
+
+  /** @override **/
+  formatOffset(ts, format) {
+    return formatOffset(this.offset(ts), format);
   }
 
   /** @override **/

--- a/test/info/zones.test.js
+++ b/test/info/zones.test.js
@@ -59,21 +59,6 @@ test("Info.isValidIANAZone returns false for well-specified but invalid zones li
 });
 
 //------
-// IANAZone.create()
-//------
-
-test("IANAZone.create should be memoized", () => {
-  const instance1 = IANAZone.create("America/Cancun");
-  const instance2 = IANAZone.create("America/Cancun");
-  expect(instance1).toBe(instance2);
-});
-
-test("IANAZone.create should return IANAZone instance", () => {
-  const result = IANAZone.create("America/Cancun");
-  expect(result).toBeInstanceOf(IANAZone);
-});
-
-//------
 // .normalizeZone()
 //------
 

--- a/test/zones/IANA.test.js
+++ b/test/zones/IANA.test.js
@@ -1,0 +1,125 @@
+/* global test expect */
+import { FixedOffsetZone, IANAZone } from "../../src/luxon";
+import { withoutIntl } from "../helpers";
+
+test("IANAZone.create returns a singleton per zone name", () => {
+  expect(IANAZone.create("UTC")).toBe(IANAZone.create("UTC"));
+  expect(IANAZone.create("America/New_York")).toBe(IANAZone.create("America/New_York"));
+
+  expect(IANAZone.create("UTC")).not.toBe(IANAZone.create("America/New_York"));
+
+  // hold true even for invalid zone names
+  expect(IANAZone.create("blorp")).toBe(IANAZone.create("blorp"));
+});
+
+test("IANAZone.create should return IANAZone instance", () => {
+  const result = IANAZone.create("America/Cancun");
+  expect(result).toBeInstanceOf(IANAZone);
+});
+
+test("IANAZone.isValidSpecifier", () => {
+  expect(IANAZone.isValidSpecifier("America/New_York")).toBe(true);
+  expect(IANAZone.isValidSpecifier("Fantasia/Castle")).toBe(true);
+  expect(IANAZone.isValidSpecifier("Sport~~blorp")).toBe(false);
+  expect(IANAZone.isValidSpecifier(null)).toBe(false);
+});
+
+test("IANAZone.isValidZone", () => {
+  expect(IANAZone.isValidZone("America/New_York")).toBe(true);
+  expect(IANAZone.isValidZone("Fantasia/Castle")).toBe(false);
+  expect(IANAZone.isValidZone("Sport~~blorp")).toBe(false);
+  expect(IANAZone.isValidZone("")).toBe(false);
+});
+
+test("IANAZone.parseGMTOffset returns a number for a valid input", () => {
+  expect(IANAZone.parseGMTOffset("Etc/GMT+8")).toBe(-480);
+});
+
+test("IANAZone.parseGMTOffset returns null for invalid input", () => {
+  expect(IANAZone.parseGMTOffset()).toBe(null);
+  expect(IANAZone.parseGMTOffset(null)).toBe(null);
+  expect(IANAZone.parseGMTOffset("")).toBe(null);
+  expect(IANAZone.parseGMTOffset("foo")).toBe(null);
+  expect(IANAZone.parseGMTOffset("Etc/GMT+blorp")).toBe(null);
+});
+
+test("IANAZone.type returns a static string", () => {
+  expect(new IANAZone("America/Santiago").type).toBe("iana");
+  expect(new IANAZone("America/Blorp").type).toBe("iana");
+});
+
+test("IANAZone.name returns the zone name passed to the constructor", () => {
+  expect(new IANAZone("America/Santiago").name).toBe("America/Santiago");
+  expect(new IANAZone("America/Blorp").name).toBe("America/Blorp");
+  expect(new IANAZone("foo").name).toBe("foo");
+});
+
+test("IANAZone is not universal", () => {
+  expect(new IANAZone("America/Santiago").universal).toBe(false);
+});
+
+test("IANAZone.offsetName with a long format", () => {
+  const zone = new IANAZone("America/Santiago");
+  const offsetName = zone.offsetName(1552089600, { format: "long", locale: "en-US" });
+  expect(offsetName).toBe("Chile Summer Time");
+});
+
+test("IANAZone.offsetName with a short format", () => {
+  const zone = new IANAZone("America/Santiago");
+  const offsetName = zone.offsetName(1552089600, { format: "short", locale: "en-US" });
+  expect(offsetName).toBe("GMT-3");
+});
+
+withoutIntl("IANAZone.offsetName returns null", () => {
+  const zone = new IANAZone("America/Santiago");
+  const offsetName = zone.offsetName(1552089600, { format: "short", locale: "en-US" });
+  expect(offsetName).toBe(null);
+});
+
+test("IANAZone.formatOffset with a short format", () => {
+  const zone = new IANAZone("America/Santiago");
+  const offsetName = zone.formatOffset(1552089600, "short");
+  expect(offsetName).toBe("-03:00");
+});
+
+test("IANAZone.formatOffset with a narrow format", () => {
+  const zone = new IANAZone("America/Santiago");
+  const offsetName = zone.formatOffset(1552089600, "narrow");
+  expect(offsetName).toBe("-3");
+});
+
+test("IANAZone.formatOffset with a techie format", () => {
+  const zone = new IANAZone("America/Santiago");
+  const offsetName = zone.formatOffset(1552089600, "techie");
+  expect(offsetName).toBe("-0300");
+});
+
+test("IANAZone.formatOffset throws for an invalid format", () => {
+  const zone = new IANAZone("America/Santiago");
+  expect(() => zone.formatOffset(1552089600, "blorp")).toThrow();
+});
+
+test("IANAZone.equals requires both zones to be iana", () => {
+  expect(IANAZone.create("UTC").equals(FixedOffsetZone.utcInstance)).toBe(false);
+});
+
+test("IANAZone.equals returns false even if the two share offsets", () => {
+  const luxembourg = IANAZone.create("Europe/Luxembourg");
+  const rome = IANAZone.create("Europe/Rome");
+  expect(luxembourg.equals(rome)).toBe(false);
+});
+
+test("IANAZone.isValid returns true for valid zone names", () => {
+  expect(new IANAZone("UTC").isValid).toBe(true);
+  expect(new IANAZone("America/Santiago").isValid).toBe(true);
+  expect(new IANAZone("Europe/Paris").isValid).toBe(true);
+});
+
+test("IANAZone.isValid returns false for invalid zone names", () => {
+  expect(new IANAZone("").isValid).toBe(false);
+  expect(new IANAZone("foo").isValid).toBe(false);
+  expect(new IANAZone("CEDT").isValid).toBe(false);
+  expect(new IANAZone("GMT+2").isValid).toBe(false);
+  expect(new IANAZone("America/Blorp").isValid).toBe(false);
+  expect(new IANAZone(null).isValid).toBe(false);
+});

--- a/test/zones/fixedOffset.test.js
+++ b/test/zones/fixedOffset.test.js
@@ -1,0 +1,63 @@
+/* global test expect */
+import { FixedOffsetZone, IANAZone } from "../../src/luxon";
+
+test("FixedOffsetZone.utcInstance returns a singleton", () => {
+  expect(FixedOffsetZone.utcInstance).toBe(FixedOffsetZone.utcInstance);
+});
+
+test("FixedOffsetZone.utcInstance provides valid UTC data", () => {
+  expect(FixedOffsetZone.utcInstance.type).toBe("fixed");
+  expect(FixedOffsetZone.utcInstance.name).toBe("UTC");
+  expect(FixedOffsetZone.utcInstance.offsetName()).toBe("UTC");
+  expect(FixedOffsetZone.utcInstance.formatOffset(0, "short")).toBe("+00:00");
+  expect(FixedOffsetZone.utcInstance.universal).toBe(true);
+  expect(FixedOffsetZone.utcInstance.offset()).toBe(0);
+  expect(FixedOffsetZone.utcInstance.isValid).toBe(true);
+});
+
+test("FixedOffsetZone.parseSpecifier returns a valid instance from a UTC offset string", () => {
+  let zone = FixedOffsetZone.parseSpecifier("UTC+6");
+  expect(zone.isValid).toBe(true);
+  expect(zone.offset()).toBe(360);
+  expect(zone.name).toBe("UTC+6");
+
+  zone = FixedOffsetZone.parseSpecifier("UTC+06");
+  expect(zone.isValid).toBe(true);
+  expect(zone.offset()).toBe(360);
+  expect(zone.name).toBe("UTC+6");
+
+  zone = FixedOffsetZone.parseSpecifier("UTC-6:00");
+  expect(zone.isValid).toBe(true);
+  expect(zone.offset()).toBe(-360);
+  expect(zone.name).toBe("UTC-6");
+});
+
+test("FixedOffsetZone.parseSpecifier returns null for invalid data", () => {
+  expect(FixedOffsetZone.parseSpecifier()).toBe(null);
+  expect(FixedOffsetZone.parseSpecifier(null)).toBe(null);
+  expect(FixedOffsetZone.parseSpecifier("")).toBe(null);
+  expect(FixedOffsetZone.parseSpecifier("foo")).toBe(null);
+  expect(FixedOffsetZone.parseSpecifier("UTC+blorp")).toBe(null);
+});
+
+test("FixedOffsetZone.formatOffset is consistent despite the provided timestamp", () => {
+  // formatOffset accepts a timestamp to maintain the call signature of the abstract Zone class,
+  // but because of the nature of a fixed offset zone instance, the TS is ignored.
+  const zone = FixedOffsetZone.instance(-300);
+  expect(zone.formatOffset(0, "techie")).toBe("-0500");
+
+  // March 9th 2019. A day before DST started
+  expect(zone.formatOffset(1552089600, "techie")).toBe("-0500");
+
+  // March 11th 2019. A day after DST started
+  expect(zone.formatOffset(1552280400, "techie")).toBe("-0500");
+});
+
+test("FixedOffsetZone.equals requires both zones to be fixed", () => {
+  expect(FixedOffsetZone.utcInstance.equals(IANAZone.create("UTC"))).toBe(false);
+});
+
+test("FixedOffsetZone.equals compares fixed offset values", () => {
+  expect(FixedOffsetZone.utcInstance.equals(FixedOffsetZone.instance(0))).toBe(true);
+  expect(FixedOffsetZone.instance(60).equals(FixedOffsetZone.instance(-60))).toBe(false);
+});

--- a/test/zones/invalid.test.js
+++ b/test/zones/invalid.test.js
@@ -1,0 +1,15 @@
+/* global test expect */
+import { InvalidZone } from "../../src/luxon";
+
+test("InvalidZone", () => {
+  const zone = new InvalidZone("foo");
+
+  expect(zone.type).toBe("invalid");
+  expect(zone.name).toBe("foo");
+  expect(zone.offsetName()).toBe(null); // the abstract class states this returns a string, yet InvalidZones return null :(
+  expect(zone.formatOffset(0, "short")).toBe("");
+  expect(zone.universal).toBe(false);
+  expect(zone.offset()).toBe(NaN);
+  expect(zone.isValid).toBe(false);
+  expect(zone.equals(zone)).toBe(false); // always false even if it has the same name
+});

--- a/test/zones/local.test.js
+++ b/test/zones/local.test.js
@@ -1,0 +1,24 @@
+/* global test expect */
+import { LocalZone } from "../../src/luxon";
+import { withoutIntl } from "../helpers";
+
+test("LocalZone.instance returns a singleton", () => {
+  expect(LocalZone.instance).toBe(LocalZone.instance);
+});
+
+test("LocalZone.instance provides valid ...", () => {
+  expect(LocalZone.instance.type).toBe("local");
+  expect(LocalZone.instance.universal).toBe(false);
+  expect(LocalZone.instance.isValid).toBe(true);
+  expect(LocalZone.instance.equals(LocalZone.instance)).toBe(true);
+
+  // todo: figure out how to test these without inadvertently testing IANAZone
+  expect(LocalZone.instance.name).toBe("America/New_York"); // this is true for the provided Docker container, what's the right way to test it?
+  // expect(LocalZone.instance.offsetName()).toBe("UTC");
+  // expect(LocalZone.instance.formatOffset(0, "short")).toBe("+00:00");
+  // expect(LocalZone.instance.offset()).toBe(0);
+});
+
+withoutIntl("LocalZone.name simply returns 'local'", () => {
+  expect(LocalZone.instance.name).toBe("local");
+});


### PR DESCRIPTION
For feature request #504.

Moves the existing formatting logic from formatter.js to util.js so it can be utilized by all the zone subclasses.

@icambron I'd be happy to add docs and/or tests but I don't see any that deal with interacting with Zone instances directly, so I wasn't sure which files to update.