### PR TITLE
 Added DATETIME_MED_WITH_WEEKDAY preset for formatting toLocaleString

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -2012,6 +2012,14 @@ export default class DateTime {
   }
 
   /**
+   * {@link toLocaleString} format like 'Fri, 14 Oct 1983, 9:30 AM'. Only 12-hour if the locale is.
+   * @type {Object}
+   */
+  static get DATETIME_MED_WITH_WEEKDAY() {
+    return Formats.DATETIME_MED_WITH_WEEKDAY;
+  }
+
+  /**
    * {@link toLocaleString} format like 'October 14, 1983, 9:30 AM EDT'. Only 12-hour if the locale is.
    * @type {Object}
    */

--- a/src/impl/english.js
+++ b/src/impl/english.js
@@ -211,6 +211,8 @@ export function formatString(knownFormat) {
       return "M/d/yyyy, h:mm:ss a";
     case stringify(Formats.DATETIME_MED_WITH_SECONDS):
       return "LLL d, yyyy, h:mm:ss a";
+    case stringify(Formats.DATETIME_MED_WITH_WEEKDAY):
+      return "EEE, d LLL yyyy, h:mm a";
     case stringify(Formats.DATETIME_FULL_WITH_SECONDS):
       return "LLLL d, yyyy, h:mm:ss a";
     case stringify(Formats.DATETIME_HUGE_WITH_SECONDS):

--- a/src/impl/formats.js
+++ b/src/impl/formats.js
@@ -135,6 +135,15 @@ export const DATETIME_MED_WITH_SECONDS = {
   second: d2
 };
 
+export const DATETIME_MED_WITH_WEEKDAY = {
+  year: n,
+  month: s,
+  day: n,
+  weekday: s,
+  hour: n,
+  minute: d2
+};
+
 export const DATETIME_FULL = {
   year: n,
   month: l,

--- a/src/impl/util.js
+++ b/src/impl/util.js
@@ -31,7 +31,11 @@ export function isDate(o) {
 // CAPABILITIES
 
 export function hasIntl() {
-  return typeof Intl !== "undefined" && Intl.DateTimeFormat;
+  try {
+    return typeof Intl !== "undefined" && Intl.DateTimeFormat;
+  } catch (e) {
+    return false;
+  }
 }
 
 export function hasFormatToParts() {
@@ -39,7 +43,11 @@ export function hasFormatToParts() {
 }
 
 export function hasRelative() {
-  return typeof Intl !== "undefined" && !!Intl.RelativeTimeFormat;
+  try {
+    return typeof Intl !== "undefined" && !!Intl.RelativeTimeFormat;
+  } catch (e) {
+    return false;
+  }
 }
 
 // OBJECTS AND ARRAYS

--- a/test/datetime/degrade.test.js
+++ b/test/datetime/degrade.test.js
@@ -45,6 +45,7 @@ Helpers.withoutIntl("DateTime#toLocaleString supports known configurations", () 
   expected.set(DateTime.DATETIME_HUGE, "Wednesday, August 6, 2014, 9:15 AM");
   expected.set(DateTime.DATETIME_SHORT_WITH_SECONDS, "8/6/2014, 9:15:36 AM");
   expected.set(DateTime.DATETIME_MED_WITH_SECONDS, "Aug 6, 2014, 9:15:36 AM");
+  expected.set(DateTime.DATETIME_MED_WITH_WEEKDAY, "Wed, 6 Aug 2014, 9:15 AM");
   expected.set(DateTime.DATETIME_FULL_WITH_SECONDS, "August 6, 2014, 9:15:36 AM");
   expected.set(DateTime.DATETIME_HUGE_WITH_SECONDS, "Wednesday, August 6, 2014, 9:15:36 AM");
 


### PR DESCRIPTION
With reference to this [issue](https://github.com/moment/luxon/issues/283)

- Added DATETIME_MED_WITH_WEEKDAY preset in src/datetime.js

- Added support for env without Intl in src/impl/english.js

- Added DATETIME_MED_WITH_WEEKDAY preset format in src/impl/formats.js

- Added a test case in test/datetime/degrade.test.js