### PR TITLE
Fix `relative` method documentation

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1784,7 +1784,7 @@ export default class DateTime {
 
   /**
    * Returns a string representation of a this time relative to now, such as "in two days". Can only internationalize if your
-   * platform supports Intl.RelativeDateFormat, **which it probably doesn't yet!** (As of this writing, only Chrome supports that). Rounds down by default.
+   * platform supports Intl.RelativeTimeFormat. Rounds down by default.
    * @param {Object} options - options that affect the output
    * @param {DateTime} [options.base=DateTime.local()] - the DateTime to use as the basis to which this time is compared. Defaults to now.
    * @param {string} [options.style="long"] - the style of units, must be "long", "short", or "narrow"
@@ -1815,8 +1815,8 @@ export default class DateTime {
   }
 
   /**
-   * Returns a string representation of this date relative to today, such as "yesterday" or "next month"
-   * platform supports Intl.RelativeDateFormat.
+   * Returns a string representation of this date relative to today, such as "yesterday" or "next month".
+   * Only works on platforms that supports Intl.RelativeTimeFormat.
    * @param {Object} options - options that affect the output
    * @param {DateTime} [options.base=DateTime.local()] - the DateTime to use as the basis to which this time is compared. Defaults to now.
    * @param {string} options.locale - override the locale of this DateTime

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1816,7 +1816,7 @@ export default class DateTime {
 
   /**
    * Returns a string representation of this date relative to today, such as "yesterday" or "next month".
-   * Only works on platforms that supports Intl.RelativeTimeFormat.
+   * Only internationalizes on platforms that supports Intl.RelativeTimeFormat.
    * @param {Object} options - options that affect the output
    * @param {DateTime} [options.base=DateTime.local()] - the DateTime to use as the basis to which this time is compared. Defaults to now.
    * @param {string} options.locale - override the locale of this DateTime


### PR DESCRIPTION
`RelativeTimeFormat` vs ` on RelativeDateFormat`