### PR TITLE
fix inconsistency within constructor

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -440,9 +440,12 @@ export default class DateTime {
    * @return {DateTime}
    */
   static local(year, month, day, hour, minute, second, millisecond) {
-    if (isUndefined(year)) {
+    if (arguments.length == 0) {
       return new DateTime({ ts: Settings.now() });
     } else {
+      if (isUndefined(year)) {
+        year = null;
+      }
       return quickDT(
         {
           year,
@@ -478,12 +481,15 @@ export default class DateTime {
    * @return {DateTime}
    */
   static utc(year, month, day, hour, minute, second, millisecond) {
-    if (isUndefined(year)) {
+    if (arguments.length == 0) {
       return new DateTime({
         ts: Settings.now(),
         zone: FixedOffsetZone.utcInstance
       });
     } else {
+      if (isUndefined(year)) {
+        year = null;
+      }
       return quickDT(
         {
           year,


### PR DESCRIPTION
const x = require("luxon").DateTime;

console.log(x.local().toISO());
console.log(x.local(undefined).toISO());
console.log(x.local(null).toISO());
