### PR TITLE
Mark first parameters in DateTime.local() and DateTime.utc() as optional

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -422,7 +422,7 @@ export default class DateTime {
 
   /**
    * Create a local DateTime
-   * @param {number} year - The calendar year. If omitted (as in, call `local()` with no arguments), the current time will be used
+   * @param {number} [year] - The calendar year. If omitted (as in, call `local()` with no arguments), the current time will be used
    * @param {number} [month=1] - The month, 1-indexed
    * @param {number} [day=1] - The day of the month
    * @param {number} [hour=0] - The hour of the day, in 24-hour time
@@ -460,7 +460,7 @@ export default class DateTime {
 
   /**
    * Create a DateTime in UTC
-   * @param {number} year - The calendar year. If omitted (as in, call `utc()` with no arguments), the current time will be used
+   * @param {number} [year] - The calendar year. If omitted (as in, call `utc()` with no arguments), the current time will be used
    * @param {number} [month=1] - The month, 1-indexed
    * @param {number} [day=1] - The day of the month
    * @param {number} [hour=0] - The hour of the day, in 24-hour time


### PR DESCRIPTION
Since the `year` parameters are officially optional, this hints to IDEs that it's safe to use empty calls like `DateTime.local()`.

Fixes #566.