### PR TITLE
Handle undefined DTF locale

### DIFF
--- a/src/impl/locale.js
+++ b/src/impl/locale.js
@@ -44,7 +44,7 @@ function systemLocale() {
   } else if (hasIntl()) {
     const computedSys = new Intl.DateTimeFormat().resolvedOptions().locale;
     // node sometimes defaults to "und". Override that because that is dumb
-    sysLocaleCache = computedSys === "und" ? "en-US" : computedSys;
+    sysLocaleCache = (!computedSys || computedSys === "und") ? "en-US" : computedSys;
     return sysLocaleCache;
   } else {
     sysLocaleCache = "en-US";


### PR DESCRIPTION
Trying to fix #571, no easy repro case. Specs seem to imply that locale should always be defined though, but since there was already a special case for 'und'...