### PR TITLE
Add method Duration#times

### DIFF
--- a/src/duration.js
+++ b/src/duration.js
@@ -478,6 +478,26 @@ export default class Duration {
   }
 
   /**
+   * Scale this Duration by the specified amount. Return a newly-constructed Duration.
+   * @param {number} scalar - The amount to multiply by.
+   * @example Duration.fromObject({ hours: 1, minutes: 30 }).times(2) //=> { hours: 2, minutes: 60 }
+   * @return {Duration}
+   */
+  times(scalar) {
+    if (!this.isValid) return this;
+
+    const result = {};
+
+    for (const k of orderedUnits) {
+      if (hasOwnProperty(this.values, k)) {
+        result[k] = this.get(k) * scalar;
+      }
+    }
+
+    return clone(this, { values: result }, true);
+  }
+
+  /**
    * Get the value of unit.
    * @param {string} unit - a unit such as 'minute' or 'day'
    * @example Duration.fromObject({years: 2, days: 3}).years //=> 2

--- a/test/duration/math.test.js
+++ b/test/duration/math.test.js
@@ -103,6 +103,26 @@ test("Duration#minus maintains invalidity", () => {
 });
 
 //------
+// #times()
+//------
+
+test("Duration#times multiplies durations", () => {
+  const dur = Duration.fromObject({ hours: 1, minutes: 2, seconds: -3, milliseconds: -4 }),
+    result = dur.times(5);
+
+  expect(result.hours).toBe(5);
+  expect(result.minutes).toBe(10);
+  expect(result.seconds).toBe(-15);
+  expect(result.milliseconds).toBe(-20);
+});
+
+test("Duration#times maintains invalidity", () => {
+  const dur = Duration.invalid("because").times(5);
+  expect(dur.isValid).toBe(false);
+  expect(dur.invalidReason).toBe("because");
+});
+
+//------
 // #negate()
 //------
 


### PR DESCRIPTION
This PR introduces a new method, `Duration#times()`, which multiplies a Duration by a scalar.

The original feature request (#557) called the proposed method `multiply`, but I felt `times` was more consistent with the existing `plus` and `minus` methods.

Closes #557.