### PR TITLE
Fix Duration#toISO floating point madness

### DIFF
--- a/src/duration.js
+++ b/src/duration.js
@@ -1,10 +1,10 @@
-import { isUndefined, isNumber, normalizeObject, hasOwnProperty, asNumber } from "./impl/util.js";
-import Locale from "./impl/locale.js";
-import Formatter from "./impl/formatter.js";
-import { parseISODuration } from "./impl/regexParser.js";
-import Settings from "./settings.js";
 import { InvalidArgumentError, InvalidDurationError, InvalidUnitError } from "./errors.js";
+import Formatter from "./impl/formatter.js";
 import Invalid from "./impl/invalid.js";
+import Locale from "./impl/locale.js";
+import { parseISODuration } from "./impl/regexParser.js";
+import { asNumber, hasOwnProperty, isNumber, isUndefined, normalizeObject } from "./impl/util.js";
+import Settings from "./settings.js";
 
 const INVALID = "Invalid Duration";
 
@@ -416,7 +416,9 @@ export default class Duration {
     if (this.hours !== 0) s += this.hours + "H";
     if (this.minutes !== 0) s += this.minutes + "M";
     if (this.seconds !== 0 || this.milliseconds !== 0)
-      s += this.seconds + this.milliseconds / 1000 + "S";
+      // this will handle "floating point madness" by removing extra decimal places
+      // https://stackoverflow.com/questions/588004/is-floating-point-math-broken
+      s += Math.round((this.seconds + this.milliseconds / 1000) * 1000) / 1000 + "S";
     if (s === "P") s += "T0S";
     return s;
   }

--- a/src/duration.js
+++ b/src/duration.js
@@ -3,7 +3,14 @@ import Formatter from "./impl/formatter.js";
 import Invalid from "./impl/invalid.js";
 import Locale from "./impl/locale.js";
 import { parseISODuration } from "./impl/regexParser.js";
-import { asNumber, hasOwnProperty, isNumber, isUndefined, normalizeObject } from "./impl/util.js";
+import {
+  asNumber,
+  hasOwnProperty,
+  isNumber,
+  isUndefined,
+  normalizeObject,
+  roundTo
+} from "./impl/util.js";
 import Settings from "./settings.js";
 
 const INVALID = "Invalid Duration";
@@ -418,7 +425,7 @@ export default class Duration {
     if (this.seconds !== 0 || this.milliseconds !== 0)
       // this will handle "floating point madness" by removing extra decimal places
       // https://stackoverflow.com/questions/588004/is-floating-point-math-broken
-      s += Math.round((this.seconds + this.milliseconds / 1000) * 1000) / 1000 + "S";
+      s += roundTo(this.seconds + this.milliseconds / 1000, 3) + "S";
     if (s === "P") s += "T0S";
     return s;
   }

--- a/test/duration/format.test.js
+++ b/test/duration/format.test.js
@@ -49,6 +49,19 @@ test("Duration#toISO handles milliseconds duration", () => {
   expect(Duration.fromObject({ milliseconds: 7 }).toISO()).toBe("PT0.007S");
 });
 
+test("Duration#toISO handles seconds/milliseconds duration", () => {
+  expect(Duration.fromObject({ seconds: 17, milliseconds: 548 }).toISO()).toBe("PT17.548S");
+});
+
+test("Duration#toISO handles negative seconds/milliseconds duration", () => {
+  expect(Duration.fromObject({ seconds: -17, milliseconds: -548 }).toISO()).toBe("PT-17.548S");
+});
+
+test("Duration#toISO handles mixed negative/positive numbers in seconds/milliseconds durations", () => {
+  expect(Duration.fromObject({ seconds: 17, milliseconds: -548 }).toISO()).toBe("PT16.452S");
+  expect(Duration.fromObject({ seconds: -17, milliseconds: 548 }).toISO()).toBe("PT-16.452S");
+});
+
 //------
 // #toJSON()
 //------


### PR DESCRIPTION
This will fix #596 by handling [floating point madness](https://stackoverflow.com/questions/588004/is-floating-point-math-broken) when working with seconds and milliseconds. 