### PR TITLE
Remove Meteor from install docs

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -107,7 +107,3 @@ npm install --save-dev @types/luxon
 ## React Native
 
 React Native works just fine, but React Native for Android doesn't ship with Intl support, which you need for [a lot of Luxon's functionality](matrix.html). Use [jsc-android-buildscripts](https://github.com/SoftwareMansion/jsc-android-buildscripts) to fix it.
-
-## Meteor
-
-[Help wanted.]


### PR DESCRIPTION
Meteor has had support for npm for a few years now, and package installation and use is the same as for Webpack. Just replaced Moment with Luxon in my Meteor app, very easy transition and the reduction in bundle size is great.