### PR TITLE
Throw error when specifying 24-hour format with meridiem

### DIFF
--- a/src/impl/tokenParser.js
+++ b/src/impl/tokenParser.js
@@ -4,6 +4,7 @@ import FixedOffsetZone from "../zones/fixedOffsetZone.js";
 import IANAZone from "../zones/IANAZone.js";
 import DateTime from "../datetime.js";
 import { digitRegex, parseDigits } from "./digits.js";
+import { ConflictingSpecificationError } from "../errors.js";
 
 const MISSING_FTP = "missing Intl.DateTimeFormat.formatToParts support";
 
@@ -400,7 +401,13 @@ export function explainFromTokens(locale, input, format) {
       regex = RegExp(regexString, "i"),
       [rawMatches, matches] = match(input, regex, handlers),
       [result, zone] = matches ? dateTimeFromMatches(matches) : [null, null];
-
+    const includes24Hr = hasOwnProperty(matches, "H");
+    const includesMeridiem = rawMatches && rawMatches.some(m => m === "AM" || m === "PM");
+    if (includes24Hr && includesMeridiem) {
+      throw new ConflictingSpecificationError(
+        "Can't include meridiem when specifying 24-hour format"
+      );
+    }
     return { input, tokens, regex, rawMatches, matches, result, zone };
   }
 }

--- a/src/impl/tokenParser.js
+++ b/src/impl/tokenParser.js
@@ -401,9 +401,7 @@ export function explainFromTokens(locale, input, format) {
       regex = RegExp(regexString, "i"),
       [rawMatches, matches] = match(input, regex, handlers),
       [result, zone] = matches ? dateTimeFromMatches(matches) : [null, null];
-    const includes24Hr = hasOwnProperty(matches, "H");
-    const includesMeridiem = rawMatches && rawMatches.some(m => m === "AM" || m === "PM");
-    if (includes24Hr && includesMeridiem) {
+    if (hasOwnProperty(matches, "a") && hasOwnProperty(matches, "H")) {
       throw new ConflictingSpecificationError(
         "Can't include meridiem when specifying 24-hour format"
       );

--- a/test/datetime/tokenParse.test.js
+++ b/test/datetime/tokenParse.test.js
@@ -1,5 +1,6 @@
 /* global test expect */
 import { DateTime } from "../../src/luxon";
+import { ConflictingSpecificationError } from "../../src/errors";
 
 //------
 // .fromFormat
@@ -59,6 +60,10 @@ test("DateTime.fromFormat() parses meridiems", () => {
   expect(i.month).toBe(5);
   expect(i.day).toBe(25);
   expect(i.hour).toBe(12);
+});
+
+test("DateTime.fromFormat() throws if you specify meridiem with 24-hour time", () => {
+  expect(() => DateTime.fromFormat("930PM", "Hmma")).toThrow(ConflictingSpecificationError);
 });
 
 test("DateTime.fromFormat() parses variable-digit years", () => {


### PR DESCRIPTION
Closes https://github.com/moment/luxon/issues/617

I'm getting two failing tests but I think they are unrelated.

<details>
  <summary>Failing tests</summary>
  
![Selection_252](https://user-images.githubusercontent.com/13897419/71375936-d907b980-258d-11ea-81ca-716d715e7fc5.png)

</details>

I've tested it out in the browser with the line of code from that issue and it throws as it should