### PR TITLE
Duration from ISO leading minus

### DIFF
--- a/src/impl/regexParser.js
+++ b/src/impl/regexParser.js
@@ -3,7 +3,6 @@ import {
   signedOffset,
   parseInteger,
   parseMillis,
-  invertNumber,
   ianaRegex,
   isUndefined
 } from "./util.js";
@@ -138,18 +137,18 @@ function extractISODuration(match) {
 
   const hasNegativePrefix = s[0] === "-";
 
+  const maybeNegate = num => (num && hasNegativePrefix ? -num : num);
+
   return [
     {
-      years: hasNegativePrefix ? invertNumber(parseInteger(yearStr)) : parseInteger(yearStr),
-      months: hasNegativePrefix ? invertNumber(parseInteger(monthStr)) : parseInteger(monthStr),
-      weeks: hasNegativePrefix ? invertNumber(parseInteger(weekStr)) : parseInteger(weekStr),
-      days: hasNegativePrefix ? invertNumber(parseInteger(dayStr)) : parseInteger(dayStr),
-      hours: hasNegativePrefix ? invertNumber(parseInteger(hourStr)) : parseInteger(hourStr),
-      minutes: hasNegativePrefix ? invertNumber(parseInteger(minuteStr)) : parseInteger(minuteStr),
-      seconds: hasNegativePrefix ? invertNumber(parseInteger(secondStr)) : parseInteger(secondStr),
-      milliseconds: hasNegativePrefix
-        ? invertNumber(parseMillis(millisecondsStr))
-        : parseMillis(millisecondsStr)
+      years: maybeNegate(parseInteger(yearStr)),
+      months: maybeNegate(parseInteger(monthStr)),
+      weeks: maybeNegate(parseInteger(weekStr)),
+      days: maybeNegate(parseInteger(dayStr)),
+      hours: maybeNegate(parseInteger(hourStr)),
+      minutes: maybeNegate(parseInteger(minuteStr)),
+      seconds: maybeNegate(parseInteger(secondStr)),
+      milliseconds: maybeNegate(parseMillis(millisecondsStr))
     }
   ];
 }

--- a/src/impl/regexParser.js
+++ b/src/impl/regexParser.js
@@ -3,6 +3,7 @@ import {
   signedOffset,
   parseInteger,
   parseMillis,
+  invertNumber,
   ianaRegex,
   isUndefined
 } from "./util.js";
@@ -120,11 +121,11 @@ function extractIANAZone(match, cursor) {
 
 // ISO duration parsing
 
-const isoDuration = /^P(?:(?:(-?\d{1,9})Y)?(?:(-?\d{1,9})M)?(?:(-?\d{1,9})W)?(?:(-?\d{1,9})D)?(?:T(?:(-?\d{1,9})H)?(?:(-?\d{1,9})M)?(?:(-?\d{1,9})(?:[.,](-?\d{1,9}))?S)?)?)$/;
+const isoDuration = /^-?P(?:(?:(-?\d{1,9})Y)?(?:(-?\d{1,9})M)?(?:(-?\d{1,9})W)?(?:(-?\d{1,9})D)?(?:T(?:(-?\d{1,9})H)?(?:(-?\d{1,9})M)?(?:(-?\d{1,9})(?:[.,](-?\d{1,9}))?S)?)?)$/;
 
 function extractISODuration(match) {
   const [
-    ,
+    s,
     yearStr,
     monthStr,
     weekStr,
@@ -135,16 +136,20 @@ function extractISODuration(match) {
     millisecondsStr
   ] = match;
 
+  const hasNegativePrefix = s[0] === "-";
+
   return [
     {
-      years: parseInteger(yearStr),
-      months: parseInteger(monthStr),
-      weeks: parseInteger(weekStr),
-      days: parseInteger(dayStr),
-      hours: parseInteger(hourStr),
-      minutes: parseInteger(minuteStr),
-      seconds: parseInteger(secondStr),
-      milliseconds: parseMillis(millisecondsStr)
+      years: hasNegativePrefix ? invertNumber(parseInteger(yearStr)) : parseInteger(yearStr),
+      months: hasNegativePrefix ? invertNumber(parseInteger(monthStr)) : parseInteger(monthStr),
+      weeks: hasNegativePrefix ? invertNumber(parseInteger(weekStr)) : parseInteger(weekStr),
+      days: hasNegativePrefix ? invertNumber(parseInteger(dayStr)) : parseInteger(dayStr),
+      hours: hasNegativePrefix ? invertNumber(parseInteger(hourStr)) : parseInteger(hourStr),
+      minutes: hasNegativePrefix ? invertNumber(parseInteger(minuteStr)) : parseInteger(minuteStr),
+      seconds: hasNegativePrefix ? invertNumber(parseInteger(secondStr)) : parseInteger(secondStr),
+      milliseconds: hasNegativePrefix
+        ? invertNumber(parseMillis(millisecondsStr))
+        : parseMillis(millisecondsStr)
     }
   ];
 }

--- a/src/impl/util.js
+++ b/src/impl/util.js
@@ -130,14 +130,6 @@ export function roundTo(number, digits, towardZero = false) {
   return rounder(number * factor) / factor;
 }
 
-export function invertNumber(num) {
-  if (!isNumber(num) || Number.isNaN(num)) {
-    return undefined;
-  } else {
-    return num * -1;
-  }
-}
-
 // DATE BASICS
 
 export function isLeapYear(year) {

--- a/src/impl/util.js
+++ b/src/impl/util.js
@@ -130,6 +130,14 @@ export function roundTo(number, digits, towardZero = false) {
   return rounder(number * factor) / factor;
 }
 
+export function invertNumber(num) {
+  if (!isNumber(num) || Number.isNaN(num)) {
+    return undefined;
+  } else {
+    return num * -1;
+  }
+}
+
 // DATE BASICS
 
 export function isLeapYear(year) {

--- a/test/duration/parse.test.js
+++ b/test/duration/parse.test.js
@@ -26,6 +26,10 @@ test("Duration.fromISO can parse mixed or negative durations", () => {
   check("P1YT-34000S", { years: 1, seconds: -34000 });
   check("P-1W1DT13H23M34S", { weeks: -1, days: 1, hours: 13, minutes: 23, seconds: 34 });
   check("P-2W", { weeks: -2 });
+  check("-P1D", { days: -1 });
+  check("-P5Y3M", { years: -5, months: -3 });
+  check("-P-5Y-3M", { years: 5, months: 3 });
+  check("-P-1W1DT13H-23M34S", { weeks: 1, days: -1, hours: -13, minutes: 23, seconds: -34 });
 });
 
 test("Duration.fromISO can parse fractions of seconds", () => {


### PR DESCRIPTION
This PR fixes [moment/luxon#681](https://github.com/moment/luxon/issues/681).

The issue above links to a similar issue with moment ([moment/moment#2408](https://github.com/moment/moment/issues/2408)) which was resolved.

Although the [ISO 8601 duration format](https://www.digi.com/resources/documentation/digidocs/90001437-13/reference/r_iso_8601_duration_format.htm) does not mention support for a leading minus, there are many other libraries that support ISO duration parsing in this way.

The assumed rule is that a leading minus sign inverts the sign of all values.

Examples of leading-minus ISO strings and their equivalent non-leading-minus ISO strings:

 -P1D == P-1D
  -P5Y3M == P-5Y-3M
  -P-5Y-3M == P5Y3M
  -P-1W1DT13H-23M34S == P1W-1DT-13H23M-34S
