### PR TITLE
All tests assume America/NewYork timezone

### DIFF
--- a/test/datetime/diff.test.js
+++ b/test/datetime/diff.test.js
@@ -216,12 +216,10 @@ test("DateTime#diff handles fractional days as fractions of those specific days"
 });
 
 test("DateTime#diff is precise for lower order units", () => {
-  if (DateTime.local().zoneName === "America/New_York") {
-    // spring forward skips one hour
-    expect(
-      diffObjs({ year: 2016, month: 5, day: 5 }, { year: 2016, month: 1, day: 1 }, "hours")
-    ).toEqual({ hours: 2999 });
-  }
+  // spring forward skips one hour
+  expect(
+    diffObjs({ year: 2016, month: 5, day: 5 }, { year: 2016, month: 1, day: 1 }, "hours")
+  ).toEqual({ hours: 2999 });
 });
 
 test("DateTime#diff passes through options", () => {

--- a/test/datetime/zone.test.js
+++ b/test/datetime/zone.test.js
@@ -250,10 +250,8 @@ test("Etc/GMT zones work even though V8 does not support them", () => {
 //------
 
 test("The local zone does local stuff", () => {
-  if (DateTime.local().zoneName === "America/New_York") {
-    expect(DateTime.local(2016, 8, 6).offsetNameLong).toBe("Eastern Daylight Time");
-    expect(DateTime.local(2016, 8, 6).offsetNameShort).toBe("EDT");
-  }
+  expect(DateTime.local(2016, 8, 6).offsetNameLong).toBe("Eastern Daylight Time");
+  expect(DateTime.local(2016, 8, 6).offsetNameShort).toBe("EDT");
 });
 
 //------


### PR DESCRIPTION
Some tests require the local timezone to be "America/New_York", relying on the DST of this zone, such as :

_DateTime#diff handles fractional days as fractions of those specific days_

while 2 tests are protected by `if (DateTime.local().zoneName === "America/New_York")`

It seems more consistent to assume all tests require this specific timezone, as is done in `test/zones/local.test.js`:

```
expect(LocalZone.instance.name).toBe("America/New_York");
```