### PR TITLE
Add missing values in conversion matrices

### DIFF
--- a/src/duration.js
+++ b/src/duration.js
@@ -37,6 +37,7 @@ const lowOrderMatrix = {
   casualMatrix = Object.assign(
     {
       years: {
+        quarters: 4,
         months: 12,
         weeks: 52,
         days: 365,
@@ -51,6 +52,7 @@ const lowOrderMatrix = {
         days: 91,
         hours: 91 * 24,
         minutes: 91 * 24 * 60,
+        seconds: 91 * 24 * 60 * 60,
         milliseconds: 91 * 24 * 60 * 60 * 1000
       },
       months: {
@@ -69,6 +71,7 @@ const lowOrderMatrix = {
   accurateMatrix = Object.assign(
     {
       years: {
+        quarters: 4,
         months: 12,
         weeks: daysInYearAccurate / 7,
         days: daysInYearAccurate,

--- a/test/duration/units.test.js
+++ b/test/duration/units.test.js
@@ -125,6 +125,34 @@ test("Duration#normalize maintains invalidity", () => {
   expect(dur.invalidReason).toBe("because");
 });
 
+test("Duration#normalize can convert all unit pairs", () => {
+  const units = [
+    "years",
+    "quarters",
+    "months",
+    "weeks",
+    "days",
+    "hours",
+    "minutes",
+    "seconds",
+    "milliseconds"
+  ];
+
+  for (let i = 0; i < units.length; i++) {
+    for (let j = i + 1; j < units.length; j++) {
+      const duration = Duration.fromObject({ [units[i]]: 1, [units[j]]: 2 });
+      const normalizedDuration = duration.normalize().toObject();
+      expect(normalizedDuration[units[i]]).not.toBe(NaN);
+      expect(normalizedDuration[units[j]]).not.toBe(NaN);
+
+      const accurateDuration = duration.reconfigure({ conversionAccuracy: "longterm" });
+      const normalizedAccurateDuration = accurateDuration.normalize().toObject();
+      expect(normalizedAccurateDuration[units[i]]).not.toBe(NaN);
+      expect(normalizedAccurateDuration[units[j]]).not.toBe(NaN);
+    }
+  }
+});
+
 //------
 // #as()
 //-------


### PR DESCRIPTION
And a test to check all values are defined.

Note the conversion `toObject` in the test :

`Duration.fromObject({ seconds: Nan }).get('seconds')` returns 0, which may be considered a bug.