### PR TITLE
Fixed typos in docs where 'month' was used in place of 'weekday'

### DIFF
--- a/src/info.js
+++ b/src/info.js
@@ -95,7 +95,7 @@ export default class Info {
   /**
    * Return an array of standalone week names.
    * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat
-   * @param {string} [length='long'] - the length of the month representation, such as "narrow", "short", "long".
+   * @param {string} [length='long'] - the length of the weekday representation, such as "narrow", "short", "long".
    * @param {Object} opts - options
    * @param {string} [opts.locale] - the locale code
    * @param {string} [opts.numberingSystem=null] - the numbering system
@@ -114,7 +114,7 @@ export default class Info {
    * Format weekdays differ from standalone weekdays in that they're meant to appear next to more date information. In some languages, that
    * changes the string.
    * See {@link weekdays}
-   * @param {string} [length='long'] - the length of the month representation, such as "narrow", "short", "long".
+   * @param {string} [length='long'] - the length of the weekday representation, such as "narrow", "short", "long".
    * @param {Object} opts - options
    * @param {string} [opts.locale=null] - the locale code
    * @param {string} [opts.numberingSystem=null] - the numbering system


### PR DESCRIPTION
This is a tiny update to the Info docs that fixes places where 'month' was used in place of 'weekday' in the annotations for `Info.weekdays()` and `Info.weekdaysFormat()`.  