### PR TITLE
formatOffset handles signed offsets. Fixes #665

### DIFF
--- a/src/impl/util.js
+++ b/src/impl/util.js
@@ -265,7 +265,7 @@ export function normalizeObject(obj, normalizer, nonUnitKeys) {
 export function formatOffset(offset, format) {
   const hours = Math.trunc(offset / 60),
     minutes = Math.abs(offset % 60),
-    sign = hours >= 0 && !Object.is(hours, -0) ? "+" : "-",
+    sign = offset >= 0 ? "+" : "-",
     base = `${sign}${Math.abs(hours)}`;
 
   switch (format) {

--- a/test/zones/fixedOffset.test.js
+++ b/test/zones/fixedOffset.test.js
@@ -53,6 +53,16 @@ test("FixedOffsetZone.formatOffset is consistent despite the provided timestamp"
   expect(zone.formatOffset(1552280400, "techie")).toBe("-0500");
 });
 
+test("FixedOffsetZone.formatOffset prints the correct sign before the offset", () => {
+  expect(FixedOffsetZone.instance(-300).formatOffset(0, "short")).toBe("-05:00");
+  expect(FixedOffsetZone.instance(-30).formatOffset(0, "short")).toBe("-00:30");
+  // Note the negative zero results in a + sign
+  expect(FixedOffsetZone.instance(-0).formatOffset(0, "short")).toBe("+00:00");
+  expect(FixedOffsetZone.instance(0).formatOffset(0, "short")).toBe("+00:00");
+  expect(FixedOffsetZone.instance(30).formatOffset(0, "short")).toBe("+00:30");
+  expect(FixedOffsetZone.instance(300).formatOffset(0, "short")).toBe("+05:00");
+});
+
 test("FixedOffsetZone.equals requires both zones to be fixed", () => {
   expect(FixedOffsetZone.utcInstance.equals(IANAZone.create("UTC"))).toBe(false);
 });


### PR DESCRIPTION
Making a -0 offset display as "+00:00", while keeping the negative sign for other negative values.

From the [ISO 8601 web page](https://en.wikipedia.org/wiki/ISO_8601) : _"+00:00" (but not "-00:00") for London (UTC±00:00)_