### PR TITLE
fromFormat handles non breakable spaces. Fixes #714

### DIFF
--- a/src/impl/tokenParser.js
+++ b/src/impl/tokenParser.js
@@ -12,20 +12,20 @@ function intUnit(regex, post = i => i) {
   return { regex, deser: ([s]) => post(parseDigits(s)) };
 }
 
+const NBSP = String.fromCharCode(160);
+const spaceOrNBSP = `( |${NBSP})`;
+const spaceOrNBSPRegExp = new RegExp(spaceOrNBSP, "g");
+
 function fixListRegex(s) {
-  const nbsp = String.fromCharCode(160);
-  const spaceOrNBSP = `( |${nbsp})`;
   // make dots optional and also make them literal
   // make space and non breakable space characters interchangeable
-  return s.replace(/\./g, "\\.?").replace(new RegExp(spaceOrNBSP, "g"), spaceOrNBSP);
+  return s.replace(/\./g, "\\.?").replace(spaceOrNBSPRegExp, spaceOrNBSP);
 }
 
 function stripInsensitivities(s) {
-  const nbsp = String.fromCharCode(160);
-  const spaceOrNBSP = `( |${nbsp})`;
   return s
     .replace(/\./g, "") // ignore dots that were made optional
-    .replace(new RegExp(spaceOrNBSP, "g"), " ") // interchange space and nbsp
+    .replace(spaceOrNBSPRegExp, " ") // interchange space and nbsp
     .toLowerCase();
 }
 

--- a/src/impl/tokenParser.js
+++ b/src/impl/tokenParser.js
@@ -13,12 +13,20 @@ function intUnit(regex, post = i => i) {
 }
 
 function fixListRegex(s) {
+  const nbsp = String.fromCharCode(160);
+  const spaceOrNBSP = `( |${nbsp})`;
   // make dots optional and also make them literal
-  return s.replace(/\./, "\\.?");
+  // make space and non breakable space characters interchangeable
+  return s.replace(/\./g, "\\.?").replace(new RegExp(spaceOrNBSP, "g"), spaceOrNBSP);
 }
 
 function stripInsensitivities(s) {
-  return s.replace(/\./, "").toLowerCase();
+  const nbsp = String.fromCharCode(160);
+  const spaceOrNBSP = `( |${nbsp})`;
+  return s
+    .replace(/\./g, "") // ignore dots that were made optional
+    .replace(new RegExp(spaceOrNBSP, "g"), " ") // interchange space and nbsp
+    .toLowerCase();
 }
 
 function oneOf(strings, startIndex) {

--- a/test/datetime/create.test.js
+++ b/test/datetime/create.test.js
@@ -3,7 +3,7 @@
 import { DateTime } from "../../src/luxon";
 import Helpers from "../helpers";
 
-const withDefaultLocale = Helpers.setUnset("defaultLocale"),
+const withDefaultLocale = Helpers.withDefaultLocale,
   withDefaultNumberingSystem = Helpers.setUnset("defaultNumberingSystem"),
   withDefaultOutputCalendar = Helpers.setUnset("defaultOutputCalendar"),
   withthrowOnInvalid = Helpers.setUnset("throwOnInvalid");


### PR DESCRIPTION
The problem was the the `es-ES` meridiem strings are _"a. m."_ and _"p. m."_, but with a **non breakable space** in the middle (char code 160). Since the input string used a regular space, it was not matched correctly.

This PR changes the RegExp to consider spaces and non breakable spaces characters interchangeably.

It also adds a `global` flag to the dots, so that they are *all* considered optional.