### PR TITLE
Introduce DateTime.now()

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Luxon is a library for working with dates and times in Javascript.
 
 ```js
-DateTime.local().setZone('America/New_York').minus({ weeks: 1 }).endOf('day').toISO();
+DateTime.now().setZone("America/New_York").minus({ weeks: 1 }).endOf("day").toISO();
 ```
 
 ## Features

--- a/benchmarks/datetime.js
+++ b/benchmarks/datetime.js
@@ -6,11 +6,11 @@ import Settings from "../src/settings";
 
 const suite = new Benchmark.Suite();
 
-const dt = DateTime.local();
+const dt = DateTime.now();
 
 suite
   .add("DateTime.local", () => {
-    DateTime.local();
+    DateTime.now();
   })
   .add("DateTime.fromObject with locale", () => {
     DateTime.fromObject({ locale: "fr" });
@@ -55,7 +55,7 @@ suite
     dt.toLocaleString();
   })
   .add("DateTime#toRelativeCalendar", () => {
-    dt.toRelativeCalendar({ base: DateTime.local(), locale: "fi" });
+    dt.toRelativeCalendar({ base: DateTime.now(), locale: "fi" });
   })
   .on("cycle", event => {
     console.log(String(event.target));

--- a/docs/calendars.md
+++ b/docs/calendars.md
@@ -21,7 +21,7 @@ In practice this is pretty useful; you can show users the date in their preferre
 The output calendar is a property of the DateTime itself. For example:
 
 ```js
-var dtHebrew = DateTime.local().reconfigure({ outputCalendar: 'hebrew' })
+var dtHebrew = DateTime.now().reconfigure({ outputCalendar: "hebrew" });
 dtHebrew.outputCalendar; //=> 'hebrew'
 dtHebrew.toLocaleString() //=> '4 Tishri 5778'
 ```

--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -146,7 +146,7 @@ DateTime.fromISO('2014-08-06T13:07:04.054')
 You may escape strings using single quotes:
 
 ```js
-DateTime.local().toFormat("HH 'hours and' mm 'minutes'"); //=> '20 hours and 55 minutes'
+DateTime.now().toFormat("HH 'hours and' mm 'minutes'"); //=> '20 hours and 55 minutes'
 ```
 
 ### Standalone vs format tokens

--- a/docs/intl.md
+++ b/docs/intl.md
@@ -3,7 +3,7 @@
 Luxon uses the native Intl API to provide easy-to-use internationalization. A quick example:
 
 ```js
-DateTime.local()
+DateTime.now()
   .setLocale("el")
   .toLocaleString(DateTime.DATE_FULL); //=>  '24 Σεπτεμβρίου 2017'
 ```
@@ -34,13 +34,13 @@ In this case, the specified locale didn't change the how the parsing worked (the
 You can change the locale of a DateTime instance (meaning, create a clone DateTime with a different locale) using `setLocale`:
 
 ```js
-DateTime.local().setLocale("fr").locale; //=> 'fr'
+DateTime.now().setLocale("fr").locale; //=> 'fr'
 ```
 
 `setLocale` is just a convenience for `reconfigure`:
 
 ```js
-DateTime.local().reconfigure({ locale: "fr" }).locale; //=> 'fr'
+DateTime.now().reconfigure({ locale: "fr" }).locale; //=> 'fr'
 ```
 
 ## Default locale
@@ -59,7 +59,7 @@ You can set a default locale so that news instances will always be created with 
 
 ```js
 Settings.defaultLocale = "fr";
-DateTime.local().locale; //=> 'fr'
+DateTime.now().locale; //=> 'fr'
 ```
 
 Note that this also alters the behavior of `DateTime#toFormat` and `DateTime#fromFormat`.
@@ -69,7 +69,7 @@ Note that this also alters the behavior of `DateTime#toFormat` and `DateTime#fro
 You generally don't want `DateTime#fromFormat` and `DateTime#toFormat` to use the system's locale, since your format won't be sensitive to the locale's string ordering. That's why Luxon doesn't behave that way by default. But if you really want that behavior, you can always do this:
 
 ```js
-Settings.defaultLocale = DateTime.local().resolvedLocaleOpts().locale;
+Settings.defaultLocale = DateTime.now().resolvedLocaleOpts().locale;
 ```
 
 ## Checking what you got
@@ -127,7 +127,7 @@ Info.eras("long", { locale: "fr" }); //=> [ 'avant Jésus-Christ', 'après Jésu
 DateTimes also have a `numberingSystem` setting that lets you control what system of numerals is used in formatting. In general, you shouldn't override the numbering system provided by the locale. For example, no extra work is needed to get Arabic numbers to show up in Arabic-speaking locales:
 
 ```js
-var dt = DateTime.local().setLocale("ar");
+var dt = DateTime.now().setLocale("ar");
 
 dt.resolvedLocaleOpts(); //=> { locale: 'ar',
 //     numberingSystem: 'arab',
@@ -139,7 +139,7 @@ dt.toLocaleString(); //=> '٢٤‏/٩‏/٢٠١٧'
 For this reason, Luxon defaults its own `numberingSystem` property to null, by which it means "let the Intl API decide". However, you can override it if you want. This example is admittedly ridiculous:
 
 ```js
-var dt = DateTime.local().reconfigure({ locale: "it", numberingSystem: "beng" });
+var dt = DateTime.now().reconfigure({ locale: "it", numberingSystem: "beng" });
 dt.toLocaleString(DateTime.DATE_FULL); //=> '২৪ settembre ২০১৭'
 ```
 

--- a/docs/math.md
+++ b/docs/math.md
@@ -219,8 +219,8 @@ This is because 12 * 30 != 365. These errors can be annoying, but they can also 
 
 ```js
 var dur = Duration.fromObject({ years: 50000 });
-DateTime.local().plus(dur.shiftTo('milliseconds')).year //=> 51984
-DateTime.local().plus(dur).year                         //=> 52017
+DateTime.now().plus(dur.shiftTo('milliseconds')).year //=> 51984
+DateTime.now().plus(dur).year                         //=> 52017
 ```
 
 Those are 33 years apart! So Luxon offers an alternative conversion scheme called "longterm", based on the 400-year calendar cycle:

--- a/docs/moment.md
+++ b/docs/moment.md
@@ -15,7 +15,7 @@ m1.valueOf() === m2.valueOf(); //=> true
 This happens because `m1` and `m2` are really the same object; `add()` *mutated* the object to be an hour later. Compare that to Luxon:
 
 ```js
-var d1 = DateTime.local();
+var d1 = DateTime.now();
 var d2 = d1.plus({ hours: 1 });
 d1.valueOf() === d2.valueOf(); //=> false
 ```
@@ -47,7 +47,7 @@ Here's a rough mapping of DateTime methods in Moment to ones in Luxon. I haven't
 
 | Operation               | Moment                   | Luxon                                 | Notes                                                                                                                                 |
 | ----------------------- | ------------------------ | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| Now                     | `moment()`               | `DateTime.local()`                    |                                                                                                                                       |
+| Now                     | `moment()`               | `DateTime.now()`                      |                                                                                                                                       |
 | From ISO                | `moment(String)`         | `DateTime.fromISO(String)`            |                                                                                                                                       |
 | From RFC 2822           | `moment(String)`         | `DateTime.fromRFC2822(String)`        |                                                                                                                                       |
 | From custom format      | `moment(String, String)` | `DateTime.fromFormat(String, String)` | The format tokens differ between Moment and Luxon, such that the same format string cannot be used between the two.                   |
@@ -76,8 +76,8 @@ Here's a rough mapping of DateTime methods in Moment to ones in Luxon. I haven't
 | Year                   | `year()`                             | `year`        |                                        |
 | Month                  | `month()`                            | `month`       |                                        |
 | Day of month           | `date()`                             | `day`         |                                        |
-| Day of week            | `day()`, `weekday()`, `isoWeekday()` | `weekday `    | 1-7, Monday is 1, Sunday is 7, per ISO |
-| Day of year            | `dayOfYear()`                        | `ordinal `    |                                        |
+| Day of week            | `day()`, `weekday()`, `isoWeekday()` | `weekday`     | 1-7, Monday is 1, Sunday is 7, per ISO |
+| Day of year            | `dayOfYear()`                        | `ordinal`     |                                        |
 | Hour of day            | `hour()`                             | `hour`        |                                        |
 | Minute of hour         | `minute()`                           | `minute`      |                                        |
 | Second of minute       | `second()`                           | `second`      |                                        |
@@ -149,7 +149,7 @@ See the [formatting guide](formatting.html) for more about the string-outputting
 
 #### Humanization
 
-Luxon has `toRelative` and `toRelativeCalendar`. For internationalization, they use Intl.RelativeTimeFormat, which isn't currently supported by most browsers; in those cases, they fall back to English.
+Luxon has `toRelative` and `toRelativeCalendar`. For internationalization, they use Intl.RelativeTimeFormat (or fall back to English when it is not supported by the browser).
 
 | Operation            | Moment         | Luxon                                         |
 | -------------------- | -------------- | --------------------------------------------- |
@@ -163,9 +163,9 @@ Luxon has `toRelative` and `toRelativeCalendar`. For internationalization, they 
 
 Moment Durations and Luxon Durations are broadly similar in purpose and capabilities. The main differences are:
 
- 1. Luxon durations have more sophisticated conversion capabilities. They can convert from one set of units to another using `shiftTo`. They can also be configured to use different unit conversions. See [Duration Math](math.html#duration-math) for more.
- 1. Luxon does not (yet) have an equivalent of Moment's Duration `humanize` method. Luxon will add that when [Intl.UnitFormat](https://github.com/tc39/proposal-intl-unit-format) is supported by browsers.
- 1. Like DateTimes, Luxon Durations have separate methods for creating objects from different sources.
+1.  Luxon durations have more sophisticated conversion capabilities. They can convert from one set of units to another using `shiftTo`. They can also be configured to use different unit conversions. See [Duration Math](math.html#duration-math) for more.
+1.  Luxon does not (yet) have an equivalent of Moment's Duration `humanize` method. Luxon will add that when [Intl.UnitFormat](https://github.com/tc39/proposal-intl-unit-format) is supported by browsers.
+1.  Like DateTimes, Luxon Durations have separate methods for creating objects from different sources.
 
 See the [Duration API docs](../class/src/duration.js~Duration.html) for more.
 

--- a/docs/plugin.js
+++ b/docs/plugin.js
@@ -10,7 +10,7 @@ exports.onHandleContent = function(ev) {
   // Add Luxon to the page so you can play with it while browsing the docs
   $("body").append("<script src='https://moment.github.io/luxon/global/luxon.js'/>");
   $("body").append(
-    "<script>console.log('You can try Luxon right here using the `luxon` global, like `luxon.DateTime.local()`.')</script>"
+    "<script>console.log('You can try Luxon right here using the `luxon` global, like `luxon.DateTime.now()`.')</script>"
   );
 
   // The little "100% documented" badge was too prominent.

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -6,23 +6,27 @@ This is going to be a bit brisk, but keep in mind that the API docs are comprehe
 
 ## Your first DateTime
 
-The most important class in Luxon is [DateTime](../class/src/datetime.js~DateTime.html). A DateTime represents a specific millisecond in time, along with a time zone and a locale. Here's one that represents May 15, 2017 at 8:30 in the morning:
+The most important class in Luxon is [DateTime](../class/src/datetime.js~DateTime.html). A DateTime represents a specific millisecond in time, along with a time zone and a locale. Here's one that represents May 15, 2017 at 8:30 in the morning in the local time zone:
 
 ```js
 var dt = DateTime.local(2017, 5, 15, 8, 30);
 ```
 
-To get the current time, just do this:
-
-```js
-var now = DateTime.local();
-```
-
-[DateTime.local](../class/src/datetime.js~DateTime.html#static-method-local) takes any number of arguments, all the way out to milliseconds. Underneath, this is just a Javascript Date object. But we've decorated it with lots of useful methods.
+[DateTime.local](../class/src/datetime.js~DateTime.html#static-method-local) takes any number of arguments, all the way out to milliseconds. Underneath, this is similar to a Javascript Date object. But we've decorated it with lots of useful methods.
 
 ## Creating a DateTime
 
-There are lots of ways to create a DateTime by parsing strings or constructing them out of parts. You've already seen one, `DateTime.local()`, but let's talk about two more.
+There are lots of ways to create a DateTime by parsing strings or constructing them out of parts. You've already seen one, `DateTime.local()`, but let's talk about three more.
+
+### Get the current date and time
+
+To get the current time, just do this:
+
+```js
+var now = DateTime.now();
+```
+
+Calling [DateTime.now](../class/src/datetime.js~DateTime.html#static-method-now) is equivalent to calling `local()` with no parameter.
 
 ### Create from an object
 
@@ -55,7 +59,7 @@ Now that we've made some DateTimes, let's see what we can ask of it.
 The first thing we want to see is the DateTime as a string. Luxon returns ISO 8601 strings:
 
 ```js
-DateTime.local().toString() //=> '2017-09-14T03:20:34.091-04:00'
+DateTime.now().toString(); //=> '2017-09-14T03:20:34.091-04:00'
 ```
 
 ### Getting at components
@@ -63,7 +67,7 @@ DateTime.local().toString() //=> '2017-09-14T03:20:34.091-04:00'
 We can get at the components of the time individually through getters. For example:
 
 ```js
-dt = DateTime.local()
+dt = DateTime.now();
 dt.year     //=> 2017
 dt.month    //=> 9
 dt.day      //=> 14
@@ -111,9 +115,9 @@ Luxon objects are immutable. That means that you can't alter them in place, just
 This is easier to show than to tell. All of these calls return new DateTime instances:
 
 ```js
-var dt = DateTime.local();
-dt.plus({hours: 3, minutes: 2});
-dt.minus({days: 7});
+var dt = DateTime.now();
+dt.plus({ hours: 3, minutes: 2 });
+dt.minus({ days: 7 });
 dt.startOf('day');
 dt.endOf('hour');
 ```
@@ -123,7 +127,7 @@ dt.endOf('hour');
 You can create new instances by overriding specific properties:
 
 ```js
-var dt = DateTime.local();
+var dt = DateTime.now();
 dt.set({hour: 3}).hour   //=> 3
 ```
 
@@ -132,12 +136,12 @@ dt.set({hour: 3}).hour   //=> 3
 Luxon provides several different Intl capabilities, but the most important one is in formatting:
 
 ```js
-var dt = DateTime.local();
+var dt = DateTime.now();
 var f = {month: 'long', day: 'numeric'};
 dt.setLocale('fr').toLocaleString(f)      //=> '14 septembre'
 dt.setLocale('en-GB').toLocaleString(f)   //=> '14 September'
 dt.setLocale('en-US').toLocaleString(f)  //=> 'September 14'
- ```
+```
 
 Luxon's Info class can also list months or weekdays for different locales:
 
@@ -151,15 +155,15 @@ Luxon supports time zones. There's a whole [big section](zones) about it. But br
 
 ```js
 DateTime.fromObject({zone: 'America/Los_Angeles'}) // now, but expressed in LA's local time
-DateTime.local().setZone('America/Los_Angeles') // same
+DateTime.now().setZone("America/Los_Angeles"); // same
 ```
 
 Luxon also supports UTC directly:
 
 ```js
 DateTime.utc(2017, 5, 15);
-DateTime.utc();
-DateTime.local().toUTC();
+DateTime.utc(); // now, in UTC time zone
+DateTime.now().toUTC();
 DateTime.utc().toLocal();
 ```
 
@@ -168,7 +172,7 @@ DateTime.utc().toLocal();
 The Duration class represents a quantity of time such as "2 hours and 7 minutes". You create them like this:
 
 ```js
-var dur = Duration.fromObject({hours: 2, minutes: 7});
+var dur = Duration.fromObject({ hours: 2, minutes: 7 });
 ```
 
 They can be add or subtracted from DateTimes like this:
@@ -199,9 +203,8 @@ You can also format, negate, and normalize them. See it all in the [Duration API
 
 Intervals are a specific period of time, such as "between now and midnight". They're really a wrapper for two DateTimes that form its endpoints. Here's what you can do with them:
 
-
 ```js
-now = DateTime.local();
+now = DateTime.now();
 later = DateTime.local(2020, 10, 12);
 i = Interval.fromDateTimes(now, later);
 

--- a/docs/validity.md
+++ b/docs/validity.md
@@ -38,7 +38,7 @@ But there are other ways to do it:
 
 ```js
 // specify a time zone that doesn't exist
-DateTime.local().setZone("America/Blorp").isValid; //=> false
+DateTime.now().setZone("America/Blorp").isValid; //=> false
 
 // provide contradictory information (here, this date is not a Wednesday)
 DateTime.fromObject({ year: 2017, month: 5, day: 25, weekday: 3 }).isValid; //=> false
@@ -47,7 +47,7 @@ DateTime.fromObject({ year: 2017, month: 5, day: 25, weekday: 3 }).isValid; //=>
 Note that some other kinds of mistakes throw, based on our judgment that they are more likely programmer errors than data issues:
 
 ```js
-DateTime.local().set({ blorp: 7 }); //=> kerplosion
+DateTime.now().set({ blorp: 7 }); //=> kerplosion
 ```
 
 ## Debugging invalid DateTimes
@@ -59,7 +59,7 @@ Because DateTimes fail silently, they can be a pain to debug. Luxon has some fea
 Invalid DateTime objects are happy to tell you why they're invalid. `invalidReason` will give you a consistent error code you can use, whereas `invalidExplanation` will spell it out
 
 ```js
-var dt = DateTime.local().setZone("America/Blorp");
+var dt = DateTime.now().setZone("America/Blorp");
 dt.invalidReason; //=>  'unsupported zone'
 dt.invalidExplanation; //=> 'the zone "America/Blorp" is not supported'
 ```
@@ -70,7 +70,7 @@ You can make Luxon throw whenever it creates an invalid DateTime. The message wi
 
 ```js
 Settings.throwOnInvalid = true;
-DateTime.local().setZone("America/Blorp"); //=> Error: Invalid DateTime: unsupported zone: the zone "America/Blorp" is not supported
+DateTime.now().setZone("America/Blorp"); //=> Error: Invalid DateTime: unsupported zone: the zone "America/Blorp" is not supported
 ```
 
 You can of course leave this on in production too, but be sure to try/catch it appropriately.

--- a/site/demo/demo.js
+++ b/site/demo/demo.js
@@ -36,12 +36,12 @@ function demo(luxon) {
     };
 
   example("Info.features()");
-  example("DateTime.local()");
+  example("DateTime.now()");
   example("DateTime.local(2017, 5, 15, 17, 36)");
   example("DateTime.utc(2017, 5, 15, 17, 36)");
-  example("DateTime.local().toUTC()");
+  example("DateTime.now().toUTC()");
   example("DateTime.utc(2017, 5, 15, 17, 36).toLocal()");
-  example("DateTime.local().toObject()");
+  example("DateTime.now().toObject()");
   example("DateTime.fromObject({year: 2017, month: 5, day: 15, hour: 17, minute: 36})");
   example(
     "DateTime.fromObject({year: 2017, month: 5, day: 15, hour: 17, minute: 36, zone: 'America/New_York' })"
@@ -49,33 +49,33 @@ function demo(luxon) {
   example(
     "DateTime.fromObject({year: 2017, month: 5, day: 15, hour: 17, minute: 36, zone: 'Asia/Singapore' })"
   );
-  example("DateTime.local().plus({minutes: 15, seconds: 8})");
-  example("DateTime.local().plus({days: 6})");
-  example("DateTime.local().minus({days: 6})");
-  example("DateTime.local().diff(DateTime.local(1982, 5, 25)).milliseconds");
-  example("DateTime.local().diff(DateTime.local(1982, 5, 25), 'days').days");
-  example("DateTime.local().diff(DateTime.local(1982, 5, 25), ['days', 'hours'])");
-  example("DateTime.local().toLocaleString()");
-  example("DateTime.local().setLocale('zh').toLocaleString()");
-  example("DateTime.local().toLocaleString(DateTime.DATE_MED)");
-  example("DateTime.local().setLocale('zh').toLocaleString(DateTime.DATE_MED)");
-  example("DateTime.local().setLocale('fr').toLocaleString(DateTime.DATE_FULL)");
+  example("DateTime.now().plus({minutes: 15, seconds: 8})");
+  example("DateTime.now().plus({days: 6})");
+  example("DateTime.now().minus({days: 6})");
+  example("DateTime.now().diff(DateTime.local(1982, 5, 25)).milliseconds");
+  example("DateTime.now().diff(DateTime.local(1982, 5, 25), 'days').days");
+  example("DateTime.now().diff(DateTime.local(1982, 5, 25), ['days', 'hours'])");
+  example("DateTime.now().toLocaleString()");
+  example("DateTime.now().setLocale('zh').toLocaleString()");
+  example("DateTime.now().toLocaleString(DateTime.DATE_MED)");
+  example("DateTime.now().setLocale('zh').toLocaleString(DateTime.DATE_MED)");
+  example("DateTime.now().setLocale('fr').toLocaleString(DateTime.DATE_FULL)");
   example("DateTime.fromISO('2017-05-15')");
   example("DateTime.fromISO('2017-05-15T17:36')");
   example("DateTime.fromISO('2017-W33-4')");
   example("DateTime.fromISO('2017-W33-4T04:45:32.343')");
   example("DateTime.fromFormat('12-16-2017', 'MM-dd-yyyy')");
-  example("DateTime.local().toFormat('MM-dd-yyyy')");
-  example("DateTime.local().toFormat('MMMM dd, yyyy')");
-  example("DateTime.local().setLocale('fr').toFormat('MMMM dd, yyyy')");
+  example("DateTime.now().toFormat('MM-dd-yyyy')");
+  example("DateTime.now().toFormat('MMMM dd, yyyy')");
+  example("DateTime.now().setLocale('fr').toFormat('MMMM dd, yyyy')");
   example("DateTime.fromFormat('May 25, 1982', 'MMMM dd, yyyy')");
   example("DateTime.fromFormat('mai 25, 1982', 'MMMM dd, yyyy', { locale: 'fr' })");
-  example("DateTime.local().plus({ days: 1 }).toRelativeCalendar()");
-  example("DateTime.local().plus({ days: -1 }).toRelativeCalendar()");
-  example("DateTime.local().plus({ months: 1 }).toRelativeCalendar()");
-  example("DateTime.local().setLocale('fr').plus({ days: 1 }).toRelativeCalendar()");
-  example("DateTime.local().setLocale('fr').plus({ days: -1 }).toRelativeCalendar()");
-  example("DateTime.local().setLocale('fr').plus({ months: 1 }).toRelativeCalendar()");
+  example("DateTime.now().plus({ days: 1 }).toRelativeCalendar()");
+  example("DateTime.now().plus({ days: -1 }).toRelativeCalendar()");
+  example("DateTime.now().plus({ months: 1 }).toRelativeCalendar()");
+  example("DateTime.now().setLocale('fr').plus({ days: 1 }).toRelativeCalendar()");
+  example("DateTime.now().setLocale('fr').plus({ days: -1 }).toRelativeCalendar()");
+  example("DateTime.now().setLocale('fr').plus({ months: 1 }).toRelativeCalendar()");
 
   var all = "<h1>Some Luxon examples</h1>";
   all +=

--- a/site/index.html
+++ b/site/index.html
@@ -19,7 +19,7 @@
     <script src="global/luxon.js"></script>
     <script>
       console.log(
-        "You can try Luxon right here using the `luxon` global, like `luxon.DateTime.local()`."
+        "You can try Luxon right here using the `luxon` global, like `luxon.DateTime.now()`."
       );
     </script>
     <style>
@@ -44,10 +44,10 @@
       </p>
 
       <pre>
-                <code>
-DateTime.local().setZone('America/New_York').minus({ weeks: 1 }).endOf('day').toISO();
-                </code>
-            </pre>
+        <code>
+          DateTime.now().setZone('America/New_York').minus({ weeks: 1 }).endOf('day').toISO();
+        </code>
+      </pre>
 
       <div class="section">
         <h2>Features</h2>
@@ -95,7 +95,7 @@ DateTime.local().setZone('America/New_York').minus({ weeks: 1 }).endOf('day').to
                 <p>
                   Exports a global variable called "luxon". Use it like this
                 </p>
-                <pre><code>&lt;script src=&quot;luxon.js&quot;&gt;&lt;/script&gt;<br/>&lt;script&gt;luxon.DateTime.local();&lt;/script&gt;</code></pre>
+                <pre><code>&lt;script src=&quot;luxon.js&quot;&gt;&lt;/script&gt;<br/>&lt;script&gt;luxon.DateTime.now();&lt;/script&gt;</code></pre>
                 <p>
                   See the
                   <a href="docs/manual/install.html">install instructions</a>
@@ -113,7 +113,7 @@ DateTime.local().setZone('America/New_York').minus({ weeks: 1 }).endOf('day').to
               </td>
               <td>
                 <p>Luxon as a Node.js module</p>
-                <pre><code>var { DateTime } = require('luxon');<br/>DateTime.local();</code></pre>
+                <pre><code>var { DateTime } = require('luxon');<br/>DateTime.now();</code></pre>
               </td>
               <td></td>
             </tr>
@@ -129,10 +129,9 @@ DateTime.local().setZone('America/New_York').minus({ weeks: 1 }).endOf('day').to
               </td>
               <td>
                 <p>
-                  Luxon as an AMD module. Use with Require.js, System.js, and so
-                  on.
+                  Luxon as an AMD module. Use with Require.js, System.js, and so on.
                 </p>
-                <pre><code>requirejs(['luxon'], function(luxon) {<br/>  luxon.DateTime.local();<br/>});</code></pre>
+                <pre><code>requirejs(['luxon'], function(luxon) {<br/>  luxon.DateTime.now();<br/>});</code></pre>
               </td>
               <td><a href="demo/requirejs.html">Demo</a></td>
             </tr>
@@ -146,7 +145,7 @@ DateTime.local().setZone('America/New_York').minus({ weeks: 1 }).endOf('day').to
               <td></td>
               <td>
                 <p>Luxon as an ES6 module.</p>
-                <pre><code>import { DateTime } from 'luxon';<br/>DateTime.local();</code></pre>
+                <pre><code>import { DateTime } from 'luxon';<br/>DateTime.now();</code></pre>
               </td>
               <td></td>
             </tr>

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -441,10 +441,21 @@ export default class DateTime {
   // CONSTRUCT
 
   /**
+   * Create a DateTime for the current instant, in the system's time zone.
+   *
+   * Use Settings to override these default values if needed.
+   * @example DateTime.now().toISO() //~> now in the ISO format
+   * @return {DateTime}
+   */
+  static now() {
+    return new DateTime({});
+  }
+
+  /**
    * Create a local DateTime
    * @param {number} [year] - The calendar year. If omitted (as in, call `local()` with no arguments), the current time will be used
    * @param {number} [month=1] - The month, 1-indexed
-   * @param {number} [day=1] - The day of the month
+   * @param {number} [day=1] - The day of the month, 1-indexed
    * @param {number} [hour=0] - The hour of the day, in 24-hour time
    * @param {number} [minute=0] - The minute of the hour, meaning a number between 0 and 59
    * @param {number} [second=0] - The second of the minute, meaning a number between 0 and 59
@@ -461,7 +472,7 @@ export default class DateTime {
    */
   static local(year, month, day, hour, minute, second, millisecond) {
     if (isUndefined(year)) {
-      return new DateTime({ ts: Settings.now() });
+      return new DateTime({});
     } else {
       return quickDT(
         {
@@ -1116,7 +1127,7 @@ export default class DateTime {
 
   /**
    * Get the UTC offset of this DateTime in minutes
-   * @example DateTime.local().offset //=> -240
+   * @example DateTime.now().offset //=> -240
    * @example DateTime.utc().offset //=> 0
    * @type {number}
    */
@@ -1347,12 +1358,12 @@ export default class DateTime {
    *
    * Adding hours, minutes, seconds, or milliseconds increases the timestamp by the right number of milliseconds. Adding days, months, or years shifts the calendar, accounting for DSTs and leap years along the way. Thus, `dt.plus({ hours: 24 })` may result in a different time than `dt.plus({ days: 1 })` if there's a DST shift in between.
    * @param {Duration|Object|number} duration - The amount to add. Either a Luxon Duration, a number of milliseconds, the object argument to Duration.fromObject()
-   * @example DateTime.local().plus(123) //~> in 123 milliseconds
-   * @example DateTime.local().plus({ minutes: 15 }) //~> in 15 minutes
-   * @example DateTime.local().plus({ days: 1 }) //~> this time tomorrow
-   * @example DateTime.local().plus({ days: -1 }) //~> this time yesterday
-   * @example DateTime.local().plus({ hours: 3, minutes: 13 }) //~> in 3 hr, 13 min
-   * @example DateTime.local().plus(Duration.fromObject({ hours: 3, minutes: 13 })) //~> in 3 hr, 13 min
+   * @example DateTime.now().plus(123) //~> in 123 milliseconds
+   * @example DateTime.now().plus({ minutes: 15 }) //~> in 15 minutes
+   * @example DateTime.now().plus({ days: 1 }) //~> this time tomorrow
+   * @example DateTime.now().plus({ days: -1 }) //~> this time yesterday
+   * @example DateTime.now().plus({ hours: 3, minutes: 13 }) //~> in 3 hr, 13 min
+   * @example DateTime.now().plus(Duration.fromObject({ hours: 3, minutes: 13 })) //~> in 3 hr, 13 min
    * @return {DateTime}
    */
   plus(duration) {
@@ -1450,10 +1461,10 @@ export default class DateTime {
    * @see https://moment.github.io/luxon/docs/manual/formatting.html#table-of-tokens
    * @param {string} fmt - the format string
    * @param {Object} opts - opts to override the configuration options
-   * @example DateTime.local().toFormat('yyyy LLL dd') //=> '2017 Apr 22'
-   * @example DateTime.local().setLocale('fr').toFormat('yyyy LLL dd') //=> '2017 avr. 22'
-   * @example DateTime.local().toFormat('yyyy LLL dd', { locale: "fr" }) //=> '2017 avr. 22'
-   * @example DateTime.local().toFormat("HH 'hours and' mm 'minutes'") //=> '20 hours and 55 minutes'
+   * @example DateTime.now().toFormat('yyyy LLL dd') //=> '2017 Apr 22'
+   * @example DateTime.now().setLocale('fr').toFormat('yyyy LLL dd') //=> '2017 avr. 22'
+   * @example DateTime.now().toFormat('yyyy LLL dd', { locale: "fr" }) //=> '2017 avr. 22'
+   * @example DateTime.now().toFormat("HH 'hours and' mm 'minutes'") //=> '20 hours and 55 minutes'
    * @return {string}
    */
   toFormat(fmt, opts = {}) {
@@ -1469,15 +1480,15 @@ export default class DateTime {
    * Defaults to the system's locale if no locale has been specified
    * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat
    * @param opts {Object} - Intl.DateTimeFormat constructor options and configuration options
-   * @example DateTime.local().toLocaleString(); //=> 4/20/2017
-   * @example DateTime.local().setLocale('en-gb').toLocaleString(); //=> '20/04/2017'
-   * @example DateTime.local().toLocaleString({ locale: 'en-gb' }); //=> '20/04/2017'
-   * @example DateTime.local().toLocaleString(DateTime.DATE_FULL); //=> 'April 20, 2017'
-   * @example DateTime.local().toLocaleString(DateTime.TIME_SIMPLE); //=> '11:32 AM'
-   * @example DateTime.local().toLocaleString(DateTime.DATETIME_SHORT); //=> '4/20/2017, 11:32 AM'
-   * @example DateTime.local().toLocaleString({ weekday: 'long', month: 'long', day: '2-digit' }); //=> 'Thursday, April 20'
-   * @example DateTime.local().toLocaleString({ weekday: 'short', month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit' }); //=> 'Thu, Apr 20, 11:27 AM'
-   * @example DateTime.local().toLocaleString({ hour: '2-digit', minute: '2-digit', hour12: false }); //=> '11:32'
+   * @example DateTime.now().toLocaleString(); //=> 4/20/2017
+   * @example DateTime.now().setLocale('en-gb').toLocaleString(); //=> '20/04/2017'
+   * @example DateTime.now().toLocaleString({ locale: 'en-gb' }); //=> '20/04/2017'
+   * @example DateTime.now().toLocaleString(DateTime.DATE_FULL); //=> 'April 20, 2017'
+   * @example DateTime.now().toLocaleString(DateTime.TIME_SIMPLE); //=> '11:32 AM'
+   * @example DateTime.now().toLocaleString(DateTime.DATETIME_SHORT); //=> '4/20/2017, 11:32 AM'
+   * @example DateTime.now().toLocaleString({ weekday: 'long', month: 'long', day: '2-digit' }); //=> 'Thursday, April 20'
+   * @example DateTime.now().toLocaleString({ weekday: 'short', month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit' }); //=> 'Thu, Apr 20, 11:27 AM'
+   * @example DateTime.now().toLocaleString({ hour: '2-digit', minute: '2-digit', hour12: false }); //=> '11:32'
    * @return {string}
    */
   toLocaleString(opts = Formats.DATE_SHORT) {
@@ -1491,7 +1502,7 @@ export default class DateTime {
    * Defaults to the system's locale if no locale has been specified
    * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/formatToParts
    * @param opts {Object} - Intl.DateTimeFormat constructor options, same as `toLocaleString`.
-   * @example DateTime.local().toLocaleParts(); //=> [
+   * @example DateTime.now().toLocaleParts(); //=> [
    *                                   //=>   { type: 'day', value: '25' },
    *                                   //=>   { type: 'literal', value: '/' },
    *                                   //=>   { type: 'month', value: '05' },
@@ -1513,9 +1524,9 @@ export default class DateTime {
    * @param {boolean} [opts.includeOffset=true] - include the offset, such as 'Z' or '-04:00'
    * @param {string} [opts.format='extended'] - choose between the basic and extended format
    * @example DateTime.utc(1982, 5, 25).toISO() //=> '1982-05-25T00:00:00.000Z'
-   * @example DateTime.local().toISO() //=> '2017-04-22T20:47:05.335-04:00'
-   * @example DateTime.local().toISO({ includeOffset: false }) //=> '2017-04-22T20:47:05.335'
-   * @example DateTime.local().toISO({ format: 'basic' }) //=> '20170422T204705.335-0400'
+   * @example DateTime.now().toISO() //=> '2017-04-22T20:47:05.335-04:00'
+   * @example DateTime.now().toISO({ includeOffset: false }) //=> '2017-04-22T20:47:05.335'
+   * @example DateTime.now().toISO({ format: 'basic' }) //=> '20170422T204705.335-0400'
    * @return {string}
    */
   toISO(opts = {}) {
@@ -1615,9 +1626,9 @@ export default class DateTime {
    * @param {boolean} [opts.includeZone=false] - include the zone, such as 'America/New_York'. Overrides includeOffset.
    * @param {boolean} [opts.includeOffset=true] - include the offset, such as 'Z' or '-04:00'
    * @example DateTime.utc().toSQL() //=> '05:15:16.345'
-   * @example DateTime.local().toSQL() //=> '05:15:16.345 -04:00'
-   * @example DateTime.local().toSQL({ includeOffset: false }) //=> '05:15:16.345'
-   * @example DateTime.local().toSQL({ includeZone: false }) //=> '05:15:16.345 America/New_York'
+   * @example DateTime.now().toSQL() //=> '05:15:16.345 -04:00'
+   * @example DateTime.now().toSQL({ includeOffset: false }) //=> '05:15:16.345'
+   * @example DateTime.now().toSQL({ includeZone: false }) //=> '05:15:16.345 America/New_York'
    * @return {string}
    */
   toSQLTime({ includeOffset = true, includeZone = false } = {}) {
@@ -1699,7 +1710,7 @@ export default class DateTime {
    * Returns a Javascript object with this DateTime's year, month, day, and so on.
    * @param opts - options for generating the object
    * @param {boolean} [opts.includeConfig=false] - include configuration attributes in the output
-   * @example DateTime.local().toObject() //=> { year: 2017, month: 4, day: 22, hour: 20, minute: 49, second: 42, millisecond: 268 }
+   * @example DateTime.now().toObject() //=> { year: 2017, month: 4, day: 22, hour: 20, minute: 49, second: 42, millisecond: 268 }
    * @return {Object}
    */
   toObject(opts = {}) {
@@ -1771,7 +1782,7 @@ export default class DateTime {
    * @return {Duration}
    */
   diffNow(unit = "milliseconds", opts = {}) {
-    return this.diff(DateTime.local(), unit, opts);
+    return this.diff(DateTime.now(), unit, opts);
   }
 
   /**
@@ -1787,7 +1798,7 @@ export default class DateTime {
    * Return whether this DateTime is in the same unit of time as another DateTime
    * @param {DateTime} otherDateTime - the other DateTime
    * @param {string} unit - the unit of time to check sameness on
-   * @example DateTime.local().hasSame(otherDT, 'day'); //~> true if both the same calendar day
+   * @example DateTime.now().hasSame(otherDT, 'day'); //~> true if both the same calendar day
    * @return {boolean}
    */
   hasSame(otherDateTime, unit) {
@@ -1821,19 +1832,19 @@ export default class DateTime {
    * Returns a string representation of a this time relative to now, such as "in two days". Can only internationalize if your
    * platform supports Intl.RelativeTimeFormat. Rounds down by default.
    * @param {Object} options - options that affect the output
-   * @param {DateTime} [options.base=DateTime.local()] - the DateTime to use as the basis to which this time is compared. Defaults to now.
+   * @param {DateTime} [options.base=DateTime.now()] - the DateTime to use as the basis to which this time is compared. Defaults to now.
    * @param {string} [options.style="long"] - the style of units, must be "long", "short", or "narrow"
    * @param {string} options.unit - use a specific unit; if omitted, the method will pick the unit. Use one of "years", "quarters", "months", "weeks", "days", "hours", "minutes", or "seconds"
    * @param {boolean} [options.round=true] - whether to round the numbers in the output.
    * @param {boolean} [options.padding=0] - padding in milliseconds. This allows you to round up the result if it fits inside the threshold. Don't use in combination with {round: false} because the decimal output will include the padding.
    * @param {string} options.locale - override the locale of this DateTime
    * @param {string} options.numberingSystem - override the numberingSystem of this DateTime. The Intl system may choose not to honor this
-   * @example DateTime.local().plus({ days: 1 }).toRelative() //=> "in 1 day"
-   * @example DateTime.local().setLocale("es").toRelative({ days: 1 }) //=> "dentro de 1 día"
-   * @example DateTime.local().plus({ days: 1 }).toRelative({ locale: "fr" }) //=> "dans 23 heures"
-   * @example DateTime.local().minus({ days: 2 }).toRelative() //=> "2 days ago"
-   * @example DateTime.local().minus({ days: 2 }).toRelative({ unit: "hours" }) //=> "48 hours ago"
-   * @example DateTime.local().minus({ hours: 36 }).toRelative({ round: false }) //=> "1.5 days ago"
+   * @example DateTime.now().plus({ days: 1 }).toRelative() //=> "in 1 day"
+   * @example DateTime.now().setLocale("es").toRelative({ days: 1 }) //=> "dentro de 1 día"
+   * @example DateTime.now().plus({ days: 1 }).toRelative({ locale: "fr" }) //=> "dans 23 heures"
+   * @example DateTime.now().minus({ days: 2 }).toRelative() //=> "2 days ago"
+   * @example DateTime.now().minus({ days: 2 }).toRelative({ unit: "hours" }) //=> "48 hours ago"
+   * @example DateTime.now().minus({ hours: 36 }).toRelative({ round: false }) //=> "1.5 days ago"
    */
   toRelative(options = {}) {
     if (!this.isValid) return null;
@@ -1853,14 +1864,14 @@ export default class DateTime {
    * Returns a string representation of this date relative to today, such as "yesterday" or "next month".
    * Only internationalizes on platforms that supports Intl.RelativeTimeFormat.
    * @param {Object} options - options that affect the output
-   * @param {DateTime} [options.base=DateTime.local()] - the DateTime to use as the basis to which this time is compared. Defaults to now.
+   * @param {DateTime} [options.base=DateTime.now()] - the DateTime to use as the basis to which this time is compared. Defaults to now.
    * @param {string} options.locale - override the locale of this DateTime
    * @param {string} options.unit - use a specific unit; if omitted, the method will pick the unit. Use one of "years", "quarters", "months", "weeks", or "days"
    * @param {string} options.numberingSystem - override the numberingSystem of this DateTime. The Intl system may choose not to honor this
-   * @example DateTime.local().plus({ days: 1 }).toRelativeCalendar() //=> "tomorrow"
-   * @example DateTime.local().setLocale("es").plus({ days: 1 }).toRelative() //=> ""mañana"
-   * @example DateTime.local().plus({ days: 1 }).toRelativeCalendar({ locale: "fr" }) //=> "demain"
-   * @example DateTime.local().minus({ days: 2 }).toRelativeCalendar() //=> "2 days ago"
+   * @example DateTime.now().plus({ days: 1 }).toRelativeCalendar() //=> "tomorrow"
+   * @example DateTime.now().setLocale("es").plus({ days: 1 }).toRelative() //=> ""mañana"
+   * @example DateTime.now().plus({ days: 1 }).toRelativeCalendar({ locale: "fr" }) //=> "demain"
+   * @example DateTime.now().minus({ days: 2 }).toRelativeCalendar() //=> "2 days ago"
    */
   toRelativeCalendar(options = {}) {
     if (!this.isValid) return null;

--- a/src/info.js
+++ b/src/info.js
@@ -16,7 +16,7 @@ export default class Info {
    * @return {boolean}
    */
   static hasDST(zone = Settings.defaultZone) {
-    const proto = DateTime.local()
+    const proto = DateTime.now()
       .setZone(zone)
       .set({ month: 12 });
 

--- a/test/datetime/create.test.js
+++ b/test/datetime/create.test.js
@@ -6,14 +6,45 @@ import Helpers from "../helpers";
 const withDefaultLocale = Helpers.withDefaultLocale,
   withDefaultNumberingSystem = Helpers.setUnset("defaultNumberingSystem"),
   withDefaultOutputCalendar = Helpers.setUnset("defaultOutputCalendar"),
-  withthrowOnInvalid = Helpers.setUnset("throwOnInvalid");
+  withthrowOnInvalid = Helpers.setUnset("throwOnInvalid"),
+  withDefaultZone = Helpers.withDefaultZone;
+
+//------
+// .now()
+//------
+test("DateTime.now has today's date", () => {
+  const date = new Date(),
+    now = DateTime.now();
+  expect(now.toJSDate().getDate()).toBe(date.getDate());
+  // The two instants should be a few milliseconds apart
+  expect(Math.abs(now.valueOf() - date.valueOf()) < 1000).toBe(true);
+});
+
+test("DateTime.now accepts the default locale", () => {
+  withDefaultLocale("fr", () => expect(DateTime.now().locale).toBe("fr"));
+});
+
+test("DateTime.now accepts the default numbering system", () => {
+  withDefaultNumberingSystem("beng", () => expect(DateTime.now().numberingSystem).toBe("beng"));
+});
+
+test("DateTime.now accepts the default output calendar", () => {
+  withDefaultOutputCalendar("hebrew", () => expect(DateTime.now().outputCalendar).toBe("hebrew"));
+});
+
+test("DateTime.now accepts the default time zone", () => {
+  withDefaultZone("Europe/Paris", () => expect(DateTime.now().zoneName).toBe("Europe/Paris"));
+});
 
 //------
 // .local()
 //------
 test("DateTime.local() has today's date", () => {
-  const now = DateTime.local();
-  expect(now.toJSDate().getDate()).toBe(new Date().getDate());
+  const date = new Date(),
+    now = DateTime.local();
+  expect(now.toJSDate().getDate()).toBe(date.getDate());
+  // The two instants should be a few milliseconds apart
+  expect(Math.abs(now.valueOf() - date.valueOf()) < 1000).toBe(true);
 });
 
 test("DateTime.local(2017) is the beginning of the year", () => {
@@ -110,11 +141,8 @@ test("DateTime.local does not accept non-integer values", () => {
   expect(dt.isValid).toBe(false);
 });
 
-//------
-// #toLocal()
-//-------
-test("DateTime#toLocal accepts the default locale", () => {
-  Helpers.withDefaultZone("UTC", () => expect(DateTime.local().zoneName).toBe("UTC"));
+test("DateTime.local accepts the default time zone", () => {
+  withDefaultZone("Europe/Paris", () => expect(DateTime.local().zoneName).toBe("Europe/Paris"));
 });
 
 //------
@@ -437,7 +465,7 @@ test("DateTime.fromObject() reject invalid values", () => {
 
 test("DateTime.fromObject() defaults high-order values to the current date", () => {
   const dateTime = DateTime.fromObject({}),
-    now = DateTime.local();
+    now = DateTime.now();
 
   expect(dateTime.year).toBe(now.year);
   expect(dateTime.month).toBe(now.month);
@@ -493,7 +521,7 @@ test("DateTime.fromObject() w/weekYears handles skew with Gregorian years", () =
 
 test("DateTime.fromObject() w/weeks defaults high-order values to the current date", () => {
   const dt = DateTime.fromObject({ weekday: 2 }),
-    now = DateTime.local();
+    now = DateTime.now();
 
   expect(dt.weekYear).toBe(now.weekYear);
   expect(dt.weekNumber).toBe(now.weekNumber);
@@ -529,7 +557,7 @@ test("DateTime.fromObject() w/ordinals handles fully specified dates", () => {
 
 test("DateTime.fromObject() w/ordinal defaults to the current year", () => {
   const dt = DateTime.fromObject({ ordinal: 200 }),
-    now = DateTime.local();
+    now = DateTime.now();
   expect(dt.year).toBe(now.year);
   expect(dt.ordinal).toBe(200);
 });

--- a/test/datetime/degrade.test.js
+++ b/test/datetime/degrade.test.js
@@ -79,7 +79,7 @@ Helpers.withoutIntl("DateTime#toLocaleString uses English", () => {
 });
 
 Helpers.withoutIntl("DateTime#toLocaleParts returns an empty array", () => {
-  expect(DateTime.local().toLocaleParts()).toEqual([]);
+  expect(DateTime.now().toLocaleParts()).toEqual([]);
 });
 
 Helpers.withoutIntl("DateTime.fromFormat can parse numbers in other locales", () => {
@@ -93,11 +93,11 @@ Helpers.withoutIntl("DateTime.fromFormat can't parse strings from other locales"
 });
 
 Helpers.withoutIntl("using time zones results in invalid DateTimes", () => {
-  expect(DateTime.local().setZone("America/New_York").isValid).toBe(false);
+  expect(DateTime.now().setZone("America/New_York").isValid).toBe(false);
 });
 
 Helpers.withoutIntl("DateTime#zoneName falls back to 'local'", () => {
-  expect(DateTime.local().zoneName).toBe("local");
+  expect(DateTime.now().zoneName).toBe("local");
 });
 
 Helpers.withoutIntl("DateTime#toLocaleString can use fixed-offset zones", () => {
@@ -159,7 +159,7 @@ Helpers.withoutFTP("DateTime.fromFormat can't parse strings from other locales",
 });
 
 Helpers.withoutFTP("setting the time zone still works", () => {
-  expect(DateTime.local().setZone("America/New_York").isValid).toBe(true);
+  expect(DateTime.now().setZone("America/New_York").isValid).toBe(true);
 });
 
 Helpers.withoutFTP("DateTime#offsetNameLong still works", () => {
@@ -175,7 +175,7 @@ Helpers.withoutFTP("DateTime#offsetNameLong still works", () => {
 });
 
 Helpers.withoutFTP("DateTime#toLocaleParts returns an empty array", () => {
-  expect(DateTime.local().toLocaleParts()).toEqual([]);
+  expect(DateTime.now().toLocaleParts()).toEqual([]);
 });
 
 //------
@@ -205,5 +205,5 @@ Helpers.withoutZones("DateTime#toLocaleParts is unaffected", () => {
 });
 
 Helpers.withoutZones("using time zones results in invalid DateTimes", () => {
-  expect(DateTime.local().setZone("America/New_York").isValid).toBe(false);
+  expect(DateTime.now().setZone("America/New_York").isValid).toBe(false);
 });

--- a/test/datetime/diff.test.js
+++ b/test/datetime/diff.test.js
@@ -233,8 +233,8 @@ test("DateTime#diff passes through options", () => {
 
 test("DateTime#diff returns invalid Durations if the DateTimes are invalid", () => {
   const i = DateTime.invalid("because");
-  expect(i.diff(DateTime.local()).isValid).toBe(false);
-  expect(DateTime.local().diff(i).isValid).toBe(false);
+  expect(i.diff(DateTime.now()).isValid).toBe(false);
+  expect(DateTime.now().diff(i).isValid).toBe(false);
 });
 
 test("DateTime#diff results in a duration with the same locale", () => {

--- a/test/datetime/equality.test.js
+++ b/test/datetime/equality.test.js
@@ -3,7 +3,7 @@
 import { DateTime } from "../../src/luxon";
 
 test("equals self", () => {
-  const l = DateTime.local();
+  const l = DateTime.now();
   expect(l.equals(l)).toBe(true);
 });
 

--- a/test/datetime/format.test.js
+++ b/test/datetime/format.test.js
@@ -338,7 +338,7 @@ test("DateTime#toLocaleString uses locale-appropriate time formats", () => {
 //------
 
 test("DateTime#resolvedLocaleOpts returns a thing", () => {
-  const res = DateTime.local().resolvedLocaleOpts();
+  const res = DateTime.now().resolvedLocaleOpts();
 
   expect(res.outputCalendar).toBeDefined();
   expect(res.locale).toBeDefined();
@@ -346,7 +346,7 @@ test("DateTime#resolvedLocaleOpts returns a thing", () => {
 });
 
 test("DateTime#resolvedLocaleOpts reflects changes to the locale", () => {
-  const res = DateTime.local()
+  const res = DateTime.now()
     .reconfigure({
       locale: "be",
       numberingSystem: "mong",
@@ -360,7 +360,7 @@ test("DateTime#resolvedLocaleOpts reflects changes to the locale", () => {
 });
 
 test("DateTime#resolvedLocaleOpts can override with options", () => {
-  const res = DateTime.local().resolvedLocaleOpts({
+  const res = DateTime.now().resolvedLocaleOpts({
     locale: "be",
     numberingSystem: "mong",
     outputCalendar: "coptic"

--- a/test/datetime/getters.test.js
+++ b/test/datetime/getters.test.js
@@ -164,7 +164,7 @@ test("DateTime#get returns undefined for invalid units", () => {
 // locale
 //------
 test("DateTime#locale returns the locale", () => {
-  const dt = DateTime.local().reconfigure({ locale: "be" });
+  const dt = DateTime.now().reconfigure({ locale: "be" });
   expect(dt.locale).toBe("be");
 });
 

--- a/test/datetime/invalid.test.js
+++ b/test/datetime/invalid.test.js
@@ -21,7 +21,7 @@ test("Invalid creations are invalid", () => {
 });
 
 test("invalid zones result in invalid dates", () => {
-  expect(DateTime.local().setZone("America/Lasers").isValid).toBe(false);
+  expect(DateTime.now().setZone("America/Lasers").isValid).toBe(false);
   expect(DateTime.fromObject({ zone: "America/Lasers" }).isValid).toBe(false);
   expect(DateTime.fromJSDate(new Date(), { zone: "America/Lasers" }).isValid).toBe(false);
 });
@@ -49,8 +49,8 @@ test("Invalid DateTimes return invalid Dates", () => {
 });
 
 test("Diffing invalid DateTimes creates invalid Durations", () => {
-  expect(organic1.diff(DateTime.local()).isValid).toBe(false);
-  expect(DateTime.local().diff(organic1).isValid).toBe(false);
+  expect(organic1.diff(DateTime.now()).isValid).toBe(false);
+  expect(DateTime.now().diff(organic1).isValid).toBe(false);
 });
 
 test("throwOnInvalid throws", () => {

--- a/test/datetime/misc.test.js
+++ b/test/datetime/misc.test.js
@@ -8,21 +8,21 @@ import { DateTime } from "../../src/luxon";
 //------
 
 test("DateTime#hasSame() can use milliseconds for exact comparisons", () => {
-  const dt = DateTime.local();
+  const dt = DateTime.now();
   expect(dt.hasSame(dt, "millisecond")).toBe(true);
   expect(dt.hasSame(dt.reconfigure({ locale: "fr" }), "millisecond")).toBe(true);
   expect(dt.hasSame(dt.plus({ milliseconds: 1 }), "millisecond")).toBe(false);
 });
 
 test("DateTime#hasSame() checks the unit", () => {
-  const dt = DateTime.local();
+  const dt = DateTime.now();
   expect(dt.hasSame(dt, "day")).toBe(true);
   expect(dt.hasSame(dt.startOf("day"), "day")).toBe(true);
   expect(dt.hasSame(dt.plus({ days: 1 }), "days")).toBe(false);
 });
 
 test("DateTime#hasSame() returns false for invalid DateTimes", () => {
-  const dt = DateTime.local(),
+  const dt = DateTime.now(),
     invalid = DateTime.invalid("because");
   expect(dt.hasSame(invalid, "day")).toBe(false);
   expect(invalid.hasSame(invalid, "day")).toBe(false);
@@ -34,7 +34,7 @@ test("DateTime#hasSame() returns false for invalid DateTimes", () => {
 //------
 
 test("DateTime#until() creates an Interval", () => {
-  const dt = DateTime.local(),
+  const dt = DateTime.now(),
     other = dt.plus({ days: 1 }),
     i = dt.until(other);
 
@@ -43,7 +43,7 @@ test("DateTime#until() creates an Interval", () => {
 });
 
 test("DateTime#until() creates an invalid Interval out of an invalid DateTime", () => {
-  const dt = DateTime.local(),
+  const dt = DateTime.now(),
     invalid = DateTime.invalid("because");
 
   expect(invalid.until(invalid).isValid).toBe(false);

--- a/test/datetime/proto.test.js
+++ b/test/datetime/proto.test.js
@@ -3,7 +3,7 @@
 import { DateTime } from "../../src/luxon";
 
 test("DateTime prototype properties should not throw when accessed", () => {
-  const d = DateTime.local();
+  const d = DateTime.now();
   expect(() =>
     Object.getOwnPropertyNames(d.__proto__).forEach(name => d.__proto__[name])
   ).not.toThrow();

--- a/test/datetime/regexParse.test.js
+++ b/test/datetime/regexParse.test.js
@@ -436,7 +436,7 @@ test("DateTime.fromISO() accepts year-ordinalTtime", () => {
 });
 
 test("DateTime.fromISO() accepts hour:minute:second.millisecond", () => {
-  const { year, month, day } = DateTime.local();
+  const { year, month, day } = DateTime.now();
   isSame("09:24:15.123", {
     year,
     month,
@@ -449,7 +449,7 @@ test("DateTime.fromISO() accepts hour:minute:second.millisecond", () => {
 });
 
 test("DateTime.fromISO() accepts hour:minute:second,millisecond", () => {
-  const { year, month, day } = DateTime.local();
+  const { year, month, day } = DateTime.now();
   isSame("09:24:15,123", {
     year,
     month,
@@ -462,7 +462,7 @@ test("DateTime.fromISO() accepts hour:minute:second,millisecond", () => {
 });
 
 test("DateTime.fromISO() accepts hour:minute:second", () => {
-  const { year, month, day } = DateTime.local();
+  const { year, month, day } = DateTime.now();
   isSame("09:24:15", {
     year,
     month,
@@ -475,7 +475,7 @@ test("DateTime.fromISO() accepts hour:minute:second", () => {
 });
 
 test("DateTime.fromISO() accepts hour:minute", () => {
-  const { year, month, day } = DateTime.local();
+  const { year, month, day } = DateTime.now();
   isSame("09:24", {
     year,
     month,
@@ -488,7 +488,7 @@ test("DateTime.fromISO() accepts hour:minute", () => {
 });
 
 test("DateTime.fromISO() accepts hour:minute", () => {
-  const { year, month, day } = DateTime.local();
+  const { year, month, day } = DateTime.now();
   isSame("09:24", {
     year,
     month,

--- a/test/datetime/relative.test.js
+++ b/test/datetime/relative.test.js
@@ -107,7 +107,7 @@ test("DateTime#toRelativeCalendar uses the calendar", () => {
 });
 
 test("DateTime#toRelativeCalendar picks the correct unit with no options", () => {
-  const now = DateTime.local();
+  const now = DateTime.now();
   const isLastDayOfMonth = now.endOf("month").day === now.day;
   expect(now.plus({ days: 1 }).toRelativeCalendar()).toBe(
     isLastDayOfMonth ? "next month" : "tomorrow"
@@ -161,7 +161,7 @@ Helpers.withoutRTF("DateTime#toRelativeCalendar falls back to English", () => {
 });
 
 test("DateTime#toRelativeCalendar works down through the units for different zone than local", () => {
-  const target = DateTime.local().setZone(`UTC+3`),
+  const target = DateTime.now().setZone(`UTC+3`),
     target1 = target.plus({ days: 1 }),
     target2 = target1.plus({ days: 1 }),
     target3 = target2.plus({ days: 1 }),
@@ -174,7 +174,7 @@ test("DateTime#toRelativeCalendar works down through the units for different zon
 });
 
 test("DateTime#toRelative works down through the units for diffrent zone than local", () => {
-  const base = DateTime.local().setZone(`UTC+3`);
+  const base = DateTime.now().setZone(`UTC+3`);
 
   expect(base.plus({ minutes: 65 }).toRelative()).toBe("in 1 hour");
   expect(base.plus({ minutes: 165 }).toRelative()).toBe("in 2 hours");

--- a/test/datetime/tokenParse.test.js
+++ b/test/datetime/tokenParse.test.js
@@ -332,7 +332,7 @@ test("DateTime.fromFormat() validates weekday names", () => {
 
 test("DateTime.fromFormat() defaults weekday to this week", () => {
   const d = DateTime.fromFormat("Monday", "EEEE"),
-    now = DateTime.local();
+    now = DateTime.now();
   expect(d.weekYear).toBe(now.weekYear);
   expect(d.weekNumber).toBe(now.weekNumber);
   expect(d.weekday).toBe(1);
@@ -388,7 +388,7 @@ test("DateTime.fromFormat() accepts weekYear by itself", () => {
 });
 
 test("DateTime.fromFormat() accepts weekNumber by itself", () => {
-  const now = DateTime.local();
+  const now = DateTime.now();
 
   let d = DateTime.fromFormat("17", "WW");
   expect(d.weekYear).toBe(now.weekYear);
@@ -410,7 +410,7 @@ test("DateTime.fromFormat() accepts weekYear/weekNumber/weekday", () => {
 
 test("DateTime.fromFormat() allows regex content", () => {
   const d = DateTime.fromFormat("Monday", "EEEE"),
-    now = DateTime.local();
+    now = DateTime.now();
   expect(d.weekYear).toBe(now.weekYear);
   expect(d.weekNumber).toBe(now.weekNumber);
   expect(d.weekday).toBe(1);

--- a/test/datetime/typecheck.test.js
+++ b/test/datetime/typecheck.test.js
@@ -5,7 +5,7 @@ import { DateTime } from "../../src/luxon";
 // #isDateTime()
 //------
 test("DateTime#isDateTime return true for valid DateTime", () => {
-  const dt = DateTime.local();
+  const dt = DateTime.now();
   expect(DateTime.isDateTime(dt)).toBe(true);
 });
 

--- a/test/duration/invalid.test.js
+++ b/test/duration/invalid.test.js
@@ -24,8 +24,8 @@ test("Duration.invalid throws if you don't provide a reason", () => {
 
 test("Diffing invalid DateTimes creates invalid Durations", () => {
   const invalidDT = DateTime.invalid("so?");
-  expect(invalidDT.diff(DateTime.local()).isValid).toBe(false);
-  expect(DateTime.local().diff(invalidDT).isValid).toBe(false);
+  expect(invalidDT.diff(DateTime.now()).isValid).toBe(false);
+  expect(DateTime.now().diff(invalidDT).isValid).toBe(false);
 });
 
 test("Duration.invalid produces invalid Intervals", () => {

--- a/test/interval/create.test.js
+++ b/test/interval/create.test.js
@@ -55,7 +55,7 @@ test("Interval.fromDateTimes results in an invalid Interval if the endpoints are
 });
 
 test("Interval.fromDateTimes throws with invalid input", () => {
-  expect(() => Interval.fromDateTimes(DateTime.local(), true)).toThrow();
+  expect(() => Interval.fromDateTimes(DateTime.now(), true)).toThrow();
 });
 
 test("Interval.fromDateTimes throws with start date coming after end date", () => {

--- a/test/interval/info.test.js
+++ b/test/interval/info.test.js
@@ -9,7 +9,7 @@ const fromISOs = (s, e) => DateTime.fromISO(s).until(DateTime.fromISO(e));
 // #length()
 //-------
 test("Interval#length defaults to milliseconds", () => {
-  const n = DateTime.local(),
+  const n = DateTime.now(),
     d = n.until(n.plus({ minutes: 1 }));
   expect(d.length()).toBe(60 * 1000);
 });

--- a/test/interval/typecheck.test.js
+++ b/test/interval/typecheck.test.js
@@ -6,7 +6,7 @@ import { Interval, DateTime } from "../../src/luxon";
 // #isInterval
 //-------
 test("Interval.isInterval return true for valid duration", () => {
-  const int = Interval.fromDateTimes(DateTime.local(), DateTime.local());
+  const int = Interval.fromDateTimes(DateTime.now(), DateTime.now());
   expect(Interval.isInterval(int)).toBe(true);
 });
 


### PR DESCRIPTION
This was scheduled for 2.0, but since it is not a breaking change, I try the main branch.

This may be a pain to rebase in the 2.0 branch however.