### PR TITLE
Added a missing differ for quarters. Fixing #776

### DIFF
--- a/src/impl/diff.js
+++ b/src/impl/diff.js
@@ -13,6 +13,7 @@ function dayDiff(earlier, later) {
 function highOrderDiffs(cursor, later, units) {
   const differs = [
     ["years", (a, b) => b.year - a.year],
+    ["quarters", (a, b) => b.quarter - a.quarter],
     ["months", (a, b) => b.month - a.month + (b.year - a.year) * 12],
     [
       "weeks",

--- a/test/datetime/diff.test.js
+++ b/test/datetime/diff.test.js
@@ -295,7 +295,7 @@ test("DateTime#diffNow returns invalid Durations if the DateTime is invalid", ()
   expect(i.diffNow().isValid).toBe(false);
 });
 
-test("DateTime#diff can handle 'quarters' as a unit", ()=>{
-  const t = () => DateTime.local().diff(DateTime.fromMillis(0), 'quarters')
-  expect(t).not.toThrow()
-})
+test("DateTime#diff can handle 'quarters' as a unit", () => {
+  const t = () => DateTime.local().diff(DateTime.fromMillis(0), "quarters");
+  expect(t).not.toThrow();
+});

--- a/test/datetime/diff.test.js
+++ b/test/datetime/diff.test.js
@@ -295,7 +295,7 @@ test("DateTime#diffNow returns invalid Durations if the DateTime is invalid", ()
   expect(i.diffNow().isValid).toBe(false);
 });
 
-test.only("DateTime#diff can handle 'quarters' as a unit", ()=>{
+test("DateTime#diff can handle 'quarters' as a unit", ()=>{
   const t = () => DateTime.local().diff(DateTime.fromMillis(0), 'quarters')
   expect(t).not.toThrow()
 })

--- a/test/datetime/diff.test.js
+++ b/test/datetime/diff.test.js
@@ -294,3 +294,8 @@ test("DateTime#diffNow returns invalid Durations if the DateTime is invalid", ()
   const i = DateTime.invalid("because");
   expect(i.diffNow().isValid).toBe(false);
 });
+
+test.only("DateTime#diff can handle 'quarters' as a unit", ()=>{
+  const t = () => DateTime.local().diff(DateTime.fromMillis(0), 'quarters')
+  expect(t).not.toThrow()
+})


### PR DESCRIPTION
Attempted to fix #776 
There seemed to be missing a "quarters" case in the highOrderDiffs function of diff.js. I added my take on such a differ, fixed the issue.