### PR TITLE
UnitFormat was folded into Unified NumberFormat

### DIFF
--- a/docs/moment.md
+++ b/docs/moment.md
@@ -164,7 +164,7 @@ Luxon has `toRelative` and `toRelativeCalendar`. For internationalization, they 
 Moment Durations and Luxon Durations are broadly similar in purpose and capabilities. The main differences are:
 
 1.  Luxon durations have more sophisticated conversion capabilities. They can convert from one set of units to another using `shiftTo`. They can also be configured to use different unit conversions. See [Duration Math](math.html#duration-math) for more.
-1.  Luxon does not (yet) have an equivalent of Moment's Duration `humanize` method. Luxon will add that when [Intl.UnitFormat](https://github.com/tc39/proposal-intl-unit-format) is supported by browsers.
+1.  Luxon does not (yet) have an equivalent of Moment's Duration `humanize` method. Luxon will add that when [Unified Intl.NumberFormat](https://github.com/tc39/proposal-unified-intl-numberformat) is supported by browsers.
 1.  Like DateTimes, Luxon Durations have separate methods for creating objects from different sources.
 
 See the [Duration API docs](../class/src/duration.js~Duration.html) for more.


### PR DESCRIPTION
Hiya, was looking into proper internationalisation of durations and encountered this note in the luxon docs.

As per https://github.com/tc39/ecma402/issues/32#issuecomment-516588266, UnitFormat was merged into Unified NumberFormat, which was merged into ECMA-402 last March (2020).

Now I haven't investigated how widely it's already supported by browsers but I think this update of the documentation is at least warranted.

Should I create an issue to start preparing for a `Duration.humanize`-like method?