### PR TITLE
Stick to ES5 functions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,5 +13,28 @@ module.exports = {
   },
   env: {
     es6: true
-  }
+  },
+  overrides: [
+    {
+      files: ["src/**/*.js"],
+      plugins: ["es5"],
+      extends: ["plugin:es5/no-es2015", "plugin:es5/no-es2016"],
+      rules: {
+        "es5/no-arrow-functions": "off",
+        "es5/no-block-scoping": "off",
+        "es5/no-block-scoping": "off",
+        "es5/no-classes": "off",
+        "es5/no-computed-properties": "off",
+        "es5/no-default-parameters": "off",
+        "es5/no-destructuring": "off",
+        "es5/no-for-of": "off",
+        "es5/no-modules": "off",
+        "es5/no-object-super": "off",
+        "es5/no-rest-parameters": "off",
+        "es5/no-shorthand-properties": "off",
+        "es5/no-spread": "off",
+        "es5/no-template-literals": "off"
+      }
+    }
+  ]
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,8 @@ module.exports = {
       plugins: ["es5"],
       extends: ["plugin:es5/no-es2015", "plugin:es5/no-es2016"],
       rules: {
+        // allow things that can be rewritten from static analysis to ES5
+        // E.g. TypeScript with ES5 target https://www.typescriptlang.org/play?target=1&jsx=0
         "es5/no-arrow-functions": "off",
         "es5/no-block-scoping": "off",
         "es5/no-block-scoping": "off",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4322,6 +4322,12 @@
         }
       }
     },
+    "eslint-plugin-es5": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es5/-/eslint-plugin-es5-1.5.0.tgz",
+      "integrity": "sha512-Qxmfo7v2B7SGAEURJo0dpBweFf+JU15kSyALfiB2rXWcBuJ96r6X9kFHXFnhdopPHCaHjoQs1xQPUJVbGMb1AA==",
+      "dev": true
+    },
     "eslint-plugin-import": {
       "version": "2.20.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.20.2.tgz",
@@ -4938,7 +4944,10 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.1.tgz",
       "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "icu4c-data": "^0.67.2"
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -5453,6 +5462,12 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "icu4c-data": {
+      "version": "0.67.2",
+      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.67.2.tgz",
+      "integrity": "sha512-OIRiop+k1IVf4TBLEOj910duoO9NKwtJLwp++qWT6KT5gRziHNt+5gwhcGuTqRy++RTK2gLoAIbk8KYCNxW++g==",
+      "dev": true
     },
     "ignore": {
       "version": "4.0.6",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "eslint-config-prettier": "6.3.0",
     "eslint-config-standard": "^14.1.1",
     "eslint-plugin-babel": "latest",
+    "eslint-plugin-es5": "^1.5.0",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-node": "10.0.0",
     "eslint-plugin-prettier": "3.1.1",

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -402,7 +402,7 @@ export default class DateTime {
       } else {
         const ot = zone.offset(this.ts);
         c = tsToObj(this.ts, ot);
-        invalid = Number.isNaN(c.year) ? new Invalid("invalid input") : null;
+        invalid = isNaN(c.year) ? new Invalid("invalid input") : null;
         c = invalid ? null : c;
         o = invalid ? null : ot;
       }

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -17,7 +17,8 @@ import {
   weeksInWeekYear,
   normalizeObject,
   roundTo,
-  objToLocalTS
+  objToLocalTS,
+  trunc
 } from "./impl/util.js";
 import { normalizeZone } from "./impl/zoneUtil.js";
 import diff from "./impl/diff.js";
@@ -123,22 +124,19 @@ function objToTS(obj, offset, zone) {
 // create a new DT instance by adding a duration, adjusting for DSTs
 function adjustTime(inst, dur) {
   const oPre = inst.o,
-    year = inst.c.year + Math.trunc(dur.years),
-    month = inst.c.month + Math.trunc(dur.months) + Math.trunc(dur.quarters) * 3,
+    year = inst.c.year + trunc(dur.years),
+    month = inst.c.month + trunc(dur.months) + trunc(dur.quarters) * 3,
     c = Object.assign({}, inst.c, {
       year,
       month,
-      day:
-        Math.min(inst.c.day, daysInMonth(year, month)) +
-        Math.trunc(dur.days) +
-        Math.trunc(dur.weeks) * 7
+      day: Math.min(inst.c.day, daysInMonth(year, month)) + trunc(dur.days) + trunc(dur.weeks) * 7
     }),
     millisToAdd = Duration.fromObject({
-      years: dur.years - Math.trunc(dur.years),
-      quarters: dur.quarters - Math.trunc(dur.quarters),
-      months: dur.months - Math.trunc(dur.months),
-      weeks: dur.weeks - Math.trunc(dur.weeks),
-      days: dur.days - Math.trunc(dur.days),
+      years: dur.years - trunc(dur.years),
+      quarters: dur.quarters - trunc(dur.quarters),
+      months: dur.months - trunc(dur.months),
+      weeks: dur.weeks - trunc(dur.weeks),
+      days: dur.days - trunc(dur.days),
       hours: dur.hours,
       minutes: dur.minutes,
       seconds: dur.seconds,

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -19,7 +19,8 @@ import {
   roundTo,
   objToLocalTS,
   trunc,
-  assign
+  assign,
+  isNaN
 } from "./impl/util.js";
 import { normalizeZone } from "./impl/zoneUtil.js";
 import diff from "./impl/diff.js";
@@ -384,7 +385,7 @@ export default class DateTime {
 
     let invalid =
       config.invalid ||
-      (Number.isNaN(config.ts) ? new Invalid("invalid input") : null) ||
+      (isNaN(config.ts) ? new Invalid("invalid input") : null) ||
       (!zone.isValid ? unsupportedZone(zone) : null);
     /**
      * @access private
@@ -538,7 +539,7 @@ export default class DateTime {
    */
   static fromJSDate(date, options = {}) {
     const ts = isDate(date) ? date.valueOf() : NaN;
-    if (Number.isNaN(ts)) {
+    if (isNaN(ts)) {
       return DateTime.invalid("invalid input");
     }
 

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -18,7 +18,8 @@ import {
   normalizeObject,
   roundTo,
   objToLocalTS,
-  trunc
+  trunc,
+  assign
 } from "./impl/util.js";
 import { normalizeZone } from "./impl/zoneUtil.js";
 import diff from "./impl/diff.js";
@@ -69,7 +70,7 @@ function clone(inst, alts) {
     loc: inst.loc,
     invalid: inst.invalid
   };
-  return new DateTime(Object.assign({}, current, alts, { old: current }));
+  return new DateTime(assign({}, current, alts, { old: current }));
 }
 
 // find the right offset a given local time. The o input is our guess, which determines which
@@ -126,7 +127,7 @@ function adjustTime(inst, dur) {
   const oPre = inst.o,
     year = inst.c.year + trunc(dur.years),
     month = inst.c.month + trunc(dur.months) + trunc(dur.quarters) * 3,
-    c = Object.assign({}, inst.c, {
+    c = assign({}, inst.c, {
       year,
       month,
       day: Math.min(inst.c.day, daysInMonth(year, month)) + trunc(dur.days) + trunc(dur.weeks) * 7
@@ -162,7 +163,7 @@ function parseDataToDateTime(parsed, parsedZone, opts, format, text) {
   if (parsed && Object.keys(parsed).length !== 0) {
     const interpretationZone = parsedZone || zone,
       inst = DateTime.fromObject(
-        Object.assign(parsed, opts, {
+        assign(parsed, opts, {
           zone: interpretationZone,
           // setZone is a valid option in the calling methods, but not in fromObject
           setZone: undefined
@@ -1334,11 +1335,11 @@ export default class DateTime {
 
     let mixed;
     if (settingWeekStuff) {
-      mixed = weekToGregorian(Object.assign(gregorianToWeek(this.c), normalized));
+      mixed = weekToGregorian(assign(gregorianToWeek(this.c), normalized));
     } else if (!isUndefined(normalized.ordinal)) {
-      mixed = ordinalToGregorian(Object.assign(gregorianToOrdinal(this.c), normalized));
+      mixed = ordinalToGregorian(assign(gregorianToOrdinal(this.c), normalized));
     } else {
-      mixed = Object.assign(this.toObject(), normalized);
+      mixed = assign(this.toObject(), normalized);
 
       // if we didn't set the day but we ended up on an overflow date,
       // use the last day of the right month
@@ -1716,7 +1717,7 @@ export default class DateTime {
   toObject(opts = {}) {
     if (!this.isValid) return {};
 
-    const base = Object.assign({}, this.c);
+    const base = assign({}, this.c);
 
     if (opts.includeConfig) {
       base.outputCalendar = this.outputCalendar;
@@ -1759,10 +1760,7 @@ export default class DateTime {
       );
     }
 
-    const durOpts = Object.assign(
-      { locale: this.locale, numberingSystem: this.numberingSystem },
-      opts
-    );
+    const durOpts = assign({ locale: this.locale, numberingSystem: this.numberingSystem }, opts);
 
     const units = maybeArray(unit).map(Duration.normalizeUnit),
       otherIsLater = otherDateTime.valueOf() > this.valueOf(),
@@ -1853,7 +1851,7 @@ export default class DateTime {
     return diffRelative(
       base,
       this.plus(padding),
-      Object.assign(options, {
+      assign(options, {
         numeric: "always",
         units: ["years", "months", "days", "hours", "minutes", "seconds"]
       })
@@ -1879,7 +1877,7 @@ export default class DateTime {
     return diffRelative(
       options.base || DateTime.fromObject({ zone: this.zone }),
       this,
-      Object.assign(options, {
+      assign(options, {
         numeric: "auto",
         units: ["years", "months", "days"],
         calendary: true

--- a/src/duration.js
+++ b/src/duration.js
@@ -11,7 +11,8 @@ import {
   normalizeObject,
   roundTo,
   trunc,
-  assign
+  assign,
+  sign
 } from "./impl/util.js";
 import Settings from "./settings.js";
 
@@ -137,7 +138,7 @@ function antiTrunc(n) {
 function convert(matrix, fromMap, fromUnit, toMap, toUnit) {
   const conv = matrix[toUnit][fromUnit],
     raw = fromMap[fromUnit] / conv,
-    sameSign = Math.sign(raw) === Math.sign(toMap[toUnit]),
+    sameSign = sign(raw) === sign(toMap[toUnit]),
     // ok, so this is wild, but see the matrix in the tests
     added = !sameSign && toMap[toUnit] !== 0 && Math.abs(raw) <= 1 ? antiTrunc(raw) : trunc(raw);
   toMap[toUnit] += added;

--- a/src/duration.js
+++ b/src/duration.js
@@ -9,7 +9,8 @@ import {
   isNumber,
   isUndefined,
   normalizeObject,
-  roundTo
+  roundTo,
+  trunc
 } from "./impl/util.js";
 import Settings from "./settings.js";
 
@@ -137,8 +138,7 @@ function convert(matrix, fromMap, fromUnit, toMap, toUnit) {
     raw = fromMap[fromUnit] / conv,
     sameSign = Math.sign(raw) === Math.sign(toMap[toUnit]),
     // ok, so this is wild, but see the matrix in the tests
-    added =
-      !sameSign && toMap[toUnit] !== 0 && Math.abs(raw) <= 1 ? antiTrunc(raw) : Math.trunc(raw);
+    added = !sameSign && toMap[toUnit] !== 0 && Math.abs(raw) <= 1 ? antiTrunc(raw) : trunc(raw);
   toMap[toUnit] += added;
   fromMap[fromUnit] -= added * conv;
 }
@@ -608,7 +608,7 @@ export default class Duration {
           own += vals[k];
         }
 
-        const i = Math.trunc(own);
+        const i = trunc(own);
         built[k] = i;
         accumulated[k] = own - i; // we'd like to absorb these fractions in another unit
 

--- a/src/duration.js
+++ b/src/duration.js
@@ -10,7 +10,8 @@ import {
   isUndefined,
   normalizeObject,
   roundTo,
-  trunc
+  trunc,
+  assign
 } from "./impl/util.js";
 import Settings from "./settings.js";
 
@@ -35,7 +36,7 @@ const lowOrderMatrix = {
     minutes: { seconds: 60, milliseconds: 60 * 1000 },
     seconds: { milliseconds: 1000 }
   },
-  casualMatrix = Object.assign(
+  casualMatrix = assign(
     {
       years: {
         quarters: 4,
@@ -69,7 +70,7 @@ const lowOrderMatrix = {
   ),
   daysInYearAccurate = 146097.0 / 400,
   daysInMonthAccurate = 146097.0 / 4800,
-  accurateMatrix = Object.assign(
+  accurateMatrix = assign(
     {
       years: {
         quarters: 4,
@@ -121,7 +122,7 @@ const reverseUnits = orderedUnits.slice(0).reverse();
 function clone(dur, alts, clear = false) {
   // deep merge for vals
   const conf = {
-    values: clear ? alts.values : Object.assign({}, dur.values, alts.values || {}),
+    values: clear ? alts.values : assign({}, dur.values, alts.values || {}),
     loc: dur.loc.clone(alts.loc),
     conversionAccuracy: alts.conversionAccuracy || dur.conversionAccuracy
   };
@@ -212,7 +213,7 @@ export default class Duration {
    * @return {Duration}
    */
   static fromMillis(count, opts) {
-    return Duration.fromObject(Object.assign({ milliseconds: count }, opts));
+    return Duration.fromObject(assign({ milliseconds: count }, opts));
   }
 
   /**
@@ -269,7 +270,7 @@ export default class Duration {
   static fromISO(text, opts) {
     const [parsed] = parseISODuration(text);
     if (parsed) {
-      const obj = Object.assign(parsed, opts);
+      const obj = assign(parsed, opts);
       return Duration.fromObject(obj);
     } else {
       return Duration.invalid("unparsable", `the input "${text}" can't be parsed as ISO 8601`);
@@ -374,7 +375,7 @@ export default class Duration {
    */
   toFormat(fmt, opts = {}) {
     // reverse-compat since 1.2; we always round down now, never up, and we do it by default
-    const fmtOpts = Object.assign({}, opts, {
+    const fmtOpts = assign({}, opts, {
       floor: opts.round !== false && opts.floor !== false
     });
     return this.isValid
@@ -392,7 +393,7 @@ export default class Duration {
   toObject(opts = {}) {
     if (!this.isValid) return {};
 
-    const base = Object.assign({}, this.values);
+    const base = assign({}, this.values);
 
     if (opts.includeConfig) {
       base.conversionAccuracy = this.conversionAccuracy;
@@ -527,7 +528,7 @@ export default class Duration {
   set(values) {
     if (!this.isValid) return this;
 
-    const mixed = Object.assign(this.values, normalizeObject(values, Duration.normalizeUnit, []));
+    const mixed = assign(this.values, normalizeObject(values, Duration.normalizeUnit, []));
     return clone(this, { values: mixed });
   }
 

--- a/src/impl/conversions.js
+++ b/src/impl/conversions.js
@@ -5,7 +5,8 @@ import {
   daysInYear,
   daysInMonth,
   weeksInWeekYear,
-  isInteger
+  isInteger,
+  assign
 } from "./util.js";
 import Invalid from "./invalid.js";
 
@@ -57,7 +58,7 @@ export function gregorianToWeek(gregObj) {
     weekYear = year;
   }
 
-  return Object.assign({ weekYear, weekNumber, weekday }, timeObject(gregObj));
+  return assign({ weekYear, weekNumber, weekday }, timeObject(gregObj));
 }
 
 export function weekToGregorian(weekData) {
@@ -80,21 +81,21 @@ export function weekToGregorian(weekData) {
 
   const { month, day } = uncomputeOrdinal(year, ordinal);
 
-  return Object.assign({ year, month, day }, timeObject(weekData));
+  return assign({ year, month, day }, timeObject(weekData));
 }
 
 export function gregorianToOrdinal(gregData) {
   const { year, month, day } = gregData,
     ordinal = computeOrdinal(year, month, day);
 
-  return Object.assign({ year, ordinal }, timeObject(gregData));
+  return assign({ year, ordinal }, timeObject(gregData));
 }
 
 export function ordinalToGregorian(ordinalData) {
   const { year, ordinal } = ordinalData,
     { month, day } = uncomputeOrdinal(year, ordinal);
 
-  return Object.assign({ year, month, day }, timeObject(ordinalData));
+  return assign({ year, month, day }, timeObject(ordinalData));
 }
 
 export function hasInvalidWeekData(obj) {

--- a/src/impl/conversions.js
+++ b/src/impl/conversions.js
@@ -6,7 +6,8 @@ import {
   daysInMonth,
   weeksInWeekYear,
   isInteger,
-  assign
+  assign,
+  findIndex
 } from "./util.js";
 import Invalid from "./invalid.js";
 
@@ -31,7 +32,7 @@ function computeOrdinal(year, month, day) {
 
 function uncomputeOrdinal(year, ordinal) {
   const table = isLeapYear(year) ? leapLadder : nonLeapLadder,
-    month0 = table.findIndex(i => i < ordinal),
+    month0 = findIndex(table, i => i < ordinal),
     day = ordinal - table[month0];
   return { month: month0 + 1, day };
 }

--- a/src/impl/diff.js
+++ b/src/impl/diff.js
@@ -1,4 +1,5 @@
 import Duration from "../duration.js";
+import { assign } from "./util.js";
 
 function dayDiff(earlier, later) {
   const utcDayStart = dt =>
@@ -67,7 +68,7 @@ export default function(earlier, later, units, opts) {
     }
   }
 
-  const duration = Duration.fromObject(Object.assign(results, opts));
+  const duration = Duration.fromObject(assign(results, opts));
 
   if (lowerOrderUnits.length > 0) {
     return Duration.fromMillis(remainingMillis, opts)

--- a/src/impl/english.js
+++ b/src/impl/english.js
@@ -1,5 +1,5 @@
 import * as Formats from "./formats.js";
-import { pick } from "./util.js";
+import { pick, is } from "./util.js";
 
 function stringify(obj) {
   return JSON.stringify(obj, Object.keys(obj).sort());
@@ -151,7 +151,7 @@ export function formatRelativeTime(unit, count, numeric = "always", narrow = fal
     }
   }
 
-  const isInPast = Object.is(count, -0) || count < 0,
+  const isInPast = is(count, -0) || count < 0,
     fmtValue = Math.abs(count),
     singular = fmtValue === 1,
     lilUnits = units[unit],

--- a/src/impl/formatter.js
+++ b/src/impl/formatter.js
@@ -1,6 +1,6 @@
 import * as English from "./english.js";
 import * as Formats from "./formats.js";
-import { hasFormatToParts, padStart } from "./util.js";
+import { hasFormatToParts, padStart, assign } from "./util.js";
 
 function stringifyTokens(splits, tokenToString) {
   let s = "";
@@ -94,22 +94,22 @@ export default class Formatter {
     if (this.systemLoc === null) {
       this.systemLoc = this.loc.redefaultToSystem();
     }
-    const df = this.systemLoc.dtFormatter(dt, Object.assign({}, this.opts, opts));
+    const df = this.systemLoc.dtFormatter(dt, assign({}, this.opts, opts));
     return df.format();
   }
 
   formatDateTime(dt, opts = {}) {
-    const df = this.loc.dtFormatter(dt, Object.assign({}, this.opts, opts));
+    const df = this.loc.dtFormatter(dt, assign({}, this.opts, opts));
     return df.format();
   }
 
   formatDateTimeParts(dt, opts = {}) {
-    const df = this.loc.dtFormatter(dt, Object.assign({}, this.opts, opts));
+    const df = this.loc.dtFormatter(dt, assign({}, this.opts, opts));
     return df.formatToParts();
   }
 
   resolvedOptions(dt, opts = {}) {
-    const df = this.loc.dtFormatter(dt, Object.assign({}, this.opts, opts));
+    const df = this.loc.dtFormatter(dt, assign({}, this.opts, opts));
     return df.resolvedOptions();
   }
 
@@ -119,7 +119,7 @@ export default class Formatter {
       return padStart(n, p);
     }
 
-    const opts = Object.assign({}, this.opts);
+    const opts = assign({}, this.opts);
 
     if (p > 0) {
       opts.padTo = p;

--- a/src/impl/locale.js
+++ b/src/impl/locale.js
@@ -1,4 +1,12 @@
-import { hasFormatToParts, hasIntl, padStart, roundTo, hasRelative, assign } from "./util.js";
+import {
+  hasFormatToParts,
+  hasIntl,
+  padStart,
+  roundTo,
+  hasRelative,
+  assign,
+  startsWith
+} from "./util.js";
 import * as English from "./english.js";
 import Settings from "../settings.js";
 import DateTime from "../datetime.js";
@@ -138,7 +146,7 @@ function supportsFastNumbers(loc) {
     return (
       loc.numberingSystem === "latn" ||
       !loc.locale ||
-      loc.locale.startsWith("en") ||
+      startsWith(loc.locale, "en") ||
       (hasIntl() && new Intl.DateTimeFormat(loc.intl).resolvedOptions().numberingSystem === "latn")
     );
   }
@@ -455,7 +463,8 @@ export default class Locale {
     return (
       this.locale === "en" ||
       this.locale.toLowerCase() === "en-us" ||
-      (hasIntl() && new Intl.DateTimeFormat(this.intl).resolvedOptions().locale.startsWith("en-us"))
+      (hasIntl() &&
+        startsWith(new Intl.DateTimeFormat(this.intl).resolvedOptions().locale, "en-us"))
     );
   }
 

--- a/src/impl/locale.js
+++ b/src/impl/locale.js
@@ -1,4 +1,4 @@
-import { hasFormatToParts, hasIntl, padStart, roundTo, hasRelative } from "./util.js";
+import { hasFormatToParts, hasIntl, padStart, roundTo, hasRelative, assign } from "./util.js";
 import * as English from "./english.js";
 import Settings from "../settings.js";
 import DateTime from "../datetime.js";
@@ -206,7 +206,7 @@ class PolyDateFormatter {
     }
 
     if (this.hasIntl) {
-      const intlOpts = Object.assign({}, this.opts);
+      const intlOpts = assign({}, this.opts);
       if (z) {
         intlOpts.timeZone = z;
       }
@@ -252,7 +252,7 @@ class PolyDateFormatter {
  */
 class PolyRelFormatter {
   constructor(intl, isEnglish, opts) {
-    this.opts = Object.assign({ style: "long" }, opts);
+    this.opts = assign({ style: "long" }, opts);
     if (!isEnglish && hasRelative()) {
       this.rtf = getCachedRTF(intl, opts);
     }
@@ -360,11 +360,11 @@ export default class Locale {
   }
 
   redefaultToEN(alts = {}) {
-    return this.clone(Object.assign({}, alts, { defaultToEN: true }));
+    return this.clone(assign({}, alts, { defaultToEN: true }));
   }
 
   redefaultToSystem(alts = {}) {
-    return this.clone(Object.assign({}, alts, { defaultToEN: false }));
+    return this.clone(assign({}, alts, { defaultToEN: false }));
   }
 
   months(length, format = false, defaultOK = true) {

--- a/src/impl/locale.js
+++ b/src/impl/locale.js
@@ -5,7 +5,8 @@ import {
   roundTo,
   hasRelative,
   assign,
-  startsWith
+  startsWith,
+  find
 } from "./util.js";
 import * as English from "./english.js";
 import Settings from "../settings.js";
@@ -441,7 +442,7 @@ export default class Locale {
   extract(dt, intlOpts, field) {
     const df = this.dtFormatter(dt, intlOpts),
       results = df.formatToParts(),
-      matching = results.find(m => m.type.toLowerCase() === field);
+      matching = find(results, m => m.type.toLowerCase() === field);
     return matching ? matching.value : null;
   }
 

--- a/src/impl/regexParser.js
+++ b/src/impl/regexParser.js
@@ -4,7 +4,8 @@ import {
   parseInteger,
   parseMillis,
   ianaRegex,
-  isUndefined
+  isUndefined,
+  assign
 } from "./util.js";
 import * as English from "./english.js";
 import FixedOffsetZone from "../zones/fixedOffsetZone.js";
@@ -31,7 +32,7 @@ function combineExtractors(...extractors) {
       .reduce(
         ([mergedVals, mergedZone, cursor], ex) => {
           const [val, zone, next] = ex(m, cursor);
-          return [Object.assign(mergedVals, val), mergedZone || zone, next];
+          return [assign(mergedVals, val), mergedZone || zone, next];
         },
         [{}, null, 1]
       )

--- a/src/impl/tokenParser.js
+++ b/src/impl/tokenParser.js
@@ -390,7 +390,7 @@ function maybeExpandMacroToken(token, locale) {
 
   const tokens = parts.map(p => tokenForPart(p, locale, formatOpts));
 
-  if (tokens.includes(undefined)) {
+  if (tokens.indexOf(undefined) >= 0) {
     return token;
   }
 

--- a/src/impl/tokenParser.js
+++ b/src/impl/tokenParser.js
@@ -4,7 +4,8 @@ import {
   untruncateYear,
   signedOffset,
   hasOwnProperty,
-  find
+  find,
+  findIndex
 } from "./util.js";
 import Formatter from "./formatter.js";
 import FixedOffsetZone from "../zones/fixedOffsetZone.js";
@@ -43,7 +44,7 @@ function oneOf(strings, startIndex) {
     return {
       regex: RegExp(strings.map(fixListRegex).join("|")),
       deser: ([s]) =>
-        strings.findIndex(i => stripInsensitivities(s) === stripInsensitivities(i)) + startIndex
+        findIndex(strings, i => stripInsensitivities(s) === stripInsensitivities(i)) + startIndex
     };
   }
 }

--- a/src/impl/tokenParser.js
+++ b/src/impl/tokenParser.js
@@ -1,4 +1,11 @@
-import { parseMillis, isUndefined, untruncateYear, signedOffset, hasOwnProperty } from "./util.js";
+import {
+  parseMillis,
+  isUndefined,
+  untruncateYear,
+  signedOffset,
+  hasOwnProperty,
+  find
+} from "./util.js";
 import Formatter from "./formatter.js";
 import FixedOffsetZone from "../zones/fixedOffsetZone.js";
 import IANAZone from "../zones/IANAZone.js";
@@ -400,7 +407,7 @@ function expandMacroTokens(tokens, locale) {
 export function explainFromTokens(locale, input, format) {
   const tokens = expandMacroTokens(Formatter.parseFormat(format), locale),
     units = tokens.map(t => unitForToken(t, locale)),
-    disqualifyingUnit = units.find(t => t.invalidReason);
+    disqualifyingUnit = find(units, t => t.invalidReason);
 
   if (disqualifyingUnit) {
     return { input, tokens, invalidReason: disqualifyingUnit.invalidReason };

--- a/src/impl/util.js
+++ b/src/impl/util.js
@@ -201,6 +201,22 @@ export function findIndex(array, predicate) {
   return -1;
 }
 
+export function is(x, y) {
+  if (typeof Object.is === "function") {
+    return Object.is(x, y);
+  }
+  // SameValue algorithm
+  if (x === y) {
+    // Steps 1-5, 7-10
+    // Steps 6.b-6.e: +0 != -0
+    return x !== 0 || 1 / x === 1 / y;
+  } else {
+    // Step 6.a: NaN == NaN
+    // eslint-disable-next-line no-self-compare
+    return x !== x && y !== y;
+  }
+}
+
 // NUMBERS AND STRINGS
 
 export function integerBetween(thing, bottom, top) {
@@ -388,7 +404,7 @@ export function signedOffset(offHourStr, offMinuteStr) {
   }
 
   const offMin = parseInt(offMinuteStr, 10) || 0,
-    offMinSigned = offHour < 0 || Object.is(offHour, -0) ? -offMin : offMin;
+    offMinSigned = offHour < 0 || is(offHour, -0) ? -offMin : offMin;
   return offHour * 60 + offMinSigned;
 }
 

--- a/src/impl/util.js
+++ b/src/impl/util.js
@@ -126,8 +126,12 @@ export function parseMillis(fraction) {
 
 export function roundTo(number, digits, towardZero = false) {
   const factor = 10 ** digits,
-    rounder = towardZero ? Math.trunc : Math.round;
+    rounder = towardZero ? trunc : Math.round;
   return rounder(number * factor) / factor;
+}
+
+export function trunc(v) {
+  return v < 0 ? Math.ceil(v) : Math.floor(v);
 }
 
 // DATE BASICS
@@ -263,8 +267,8 @@ export function normalizeObject(obj, normalizer, nonUnitKeys) {
 }
 
 export function formatOffset(offset, format) {
-  const hours = Math.trunc(Math.abs(offset / 60)),
-    minutes = Math.trunc(Math.abs(offset % 60)),
+  const hours = trunc(Math.abs(offset / 60)),
+    minutes = trunc(Math.abs(offset % 60)),
     sign = offset >= 0 ? "+" : "-";
 
   switch (format) {

--- a/src/impl/util.js
+++ b/src/impl/util.js
@@ -161,6 +161,10 @@ export function trunc(v) {
   return v < 0 ? Math.ceil(v) : Math.floor(v);
 }
 
+export function sign(x) {
+  return (x > 0) - (x < 0) || +x;
+}
+
 // DATE BASICS
 
 export function isLeapYear(year) {

--- a/src/impl/util.js
+++ b/src/impl/util.js
@@ -87,6 +87,28 @@ export function hasOwnProperty(obj, prop) {
   return Object.prototype.hasOwnProperty.call(obj, prop);
 }
 
+export function assign(target /*, ...sources*/) {
+  if (target === null || target === undefined) {
+    throw new TypeError("Cannot convert undefined or null to object");
+  }
+
+  var to = Object(target);
+
+  for (var index = 1; index < arguments.length; index++) {
+    var nextSource = arguments[index];
+
+    if (nextSource !== null && nextSource !== undefined) {
+      for (var nextKey in nextSource) {
+        // Avoid bugs when hasOwnProperty is shadowed
+        if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+          to[nextKey] = nextSource[nextKey];
+        }
+      }
+    }
+  }
+  return to;
+}
+
 // NUMBERS AND STRINGS
 
 export function integerBetween(thing, bottom, top) {
@@ -210,7 +232,7 @@ export function parseZoneInfo(ts, offsetFormat, locale, timeZone = null) {
     intlOpts.timeZone = timeZone;
   }
 
-  const modified = Object.assign({ timeZoneName: offsetFormat }, intlOpts),
+  const modified = assign({ timeZoneName: offsetFormat }, intlOpts),
     intl = hasIntl();
 
   if (intl && hasFormatToParts()) {

--- a/src/impl/util.js
+++ b/src/impl/util.js
@@ -87,15 +87,19 @@ export function hasOwnProperty(obj, prop) {
   return Object.prototype.hasOwnProperty.call(obj, prop);
 }
 
-export function assign(target /* , ...sources */) {
+export function assign(target, ...sources) {
+  if (typeof Object.assign === "function") {
+    return Object.assign(target, ...sources);
+  }
+
   if (target === null || target === undefined) {
     throw new TypeError("Cannot convert undefined or null to object");
   }
 
   var to = Object(target);
 
-  for (var index = 1; index < arguments.length; index++) {
-    var nextSource = arguments[index];
+  for (var index = 0; index < sources.length; index++) {
+    var nextSource = sources[index];
 
     if (nextSource !== null && nextSource !== undefined) {
       for (var nextKey in nextSource) {
@@ -110,6 +114,10 @@ export function assign(target /* , ...sources */) {
 }
 
 export function find(array, predicate) {
+  if (typeof Array.prototype.find === "function") {
+    return Array.prototype.find.call(array, predicate);
+  }
+
   // 1. Let O be ? ToObject(this value).
   if (array == null) {
     throw TypeError('"this" is null or not defined');
@@ -150,6 +158,10 @@ export function find(array, predicate) {
 }
 
 export function findIndex(array, predicate) {
+  if (typeof Array.prototype.findIndex === "function") {
+    return Array.prototype.findIndex.call(array, predicate);
+  }
+
   // 1. Let O be ? ToObject(this value).
   if (array == null) {
     throw new TypeError('"this" is null or not defined');
@@ -201,6 +213,10 @@ export function floorMod(x, n) {
 }
 
 export function padStart(input, n = 2) {
+  if (typeof String.prototype.padStart === "function") {
+    return String.prototype.padStart.call(input, n);
+  }
+
   if (input.toString().length < n) {
     let res = "";
     for (let i = 0; i < n; i++) {
@@ -214,6 +230,10 @@ export function padStart(input, n = 2) {
 }
 
 export function startsWith(str, search, rawPos) {
+  if (typeof String.prototype.startsWith === "function") {
+    return String.prototype.startsWith.call(str, search, rawPos);
+  }
+
   var pos = rawPos > 0 ? rawPos | 0 : 0;
   return str.substring(pos, pos + search.length) === search;
 }
@@ -243,6 +263,9 @@ export function roundTo(number, digits, towardZero = false) {
 }
 
 export function trunc(v) {
+  if (typeof Math.trunc === "function") {
+    return Math.trunc(v);
+  }
   return v < 0 ? Math.ceil(v) : Math.floor(v);
 }
 
@@ -348,6 +371,9 @@ export function parseZoneInfo(ts, offsetFormat, locale, timeZone = null) {
 }
 
 export function isNaN(input) {
+  if (typeof Number.isNaN === "function") {
+    return Number.isNaN(input);
+  }
   // eslint-disable-next-line no-self-compare
   return typeof input === "number" && input !== input;
 }

--- a/src/impl/util.js
+++ b/src/impl/util.js
@@ -87,7 +87,7 @@ export function hasOwnProperty(obj, prop) {
   return Object.prototype.hasOwnProperty.call(obj, prop);
 }
 
-export function assign(target /*, ...sources*/) {
+export function assign(target /* , ...sources */) {
   if (target === null || target === undefined) {
     throw new TypeError("Cannot convert undefined or null to object");
   }
@@ -252,12 +252,17 @@ export function parseZoneInfo(ts, offsetFormat, locale, timeZone = null) {
   }
 }
 
+export function isNaN(input) {
+  // eslint-disable-next-line no-self-compare
+  return typeof input === "number" && input !== input;
+}
+
 // signedOffset('-5', '30') -> -330
 export function signedOffset(offHourStr, offMinuteStr) {
   let offHour = parseInt(offHourStr, 10);
 
   // don't || this because we want to preserve -0
-  if (Number.isNaN(offHour)) {
+  if (isNaN(offHour)) {
     offHour = 0;
   }
 
@@ -270,7 +275,7 @@ export function signedOffset(offHourStr, offMinuteStr) {
 
 export function asNumber(value) {
   const numericValue = Number(value);
-  if (typeof value === "boolean" || value === "" || Number.isNaN(numericValue))
+  if (typeof value === "boolean" || value === "" || isNaN(numericValue))
     throw new InvalidArgumentError(`Invalid unit value ${value}`);
   return numericValue;
 }

--- a/src/impl/util.js
+++ b/src/impl/util.js
@@ -149,6 +149,46 @@ export function find(array, predicate) {
   return undefined;
 }
 
+export function findIndex(array, predicate) {
+  // 1. Let O be ? ToObject(this value).
+  if (array == null) {
+    throw new TypeError('"this" is null or not defined');
+  }
+
+  var o = Object(array);
+
+  // 2. Let len be ? ToLength(? Get(O, "length")).
+  var len = o.length >>> 0;
+
+  // 3. If IsCallable(predicate) is false, throw a TypeError exception.
+  if (typeof predicate !== "function") {
+    throw new TypeError("predicate must be a function");
+  }
+
+  // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
+  var thisArg = arguments[2];
+
+  // 5. Let k be 0.
+  var k = 0;
+
+  // 6. Repeat, while k < len
+  while (k < len) {
+    // a. Let Pk be ! ToString(k).
+    // b. Let kValue be ? Get(O, Pk).
+    // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
+    // d. If testResult is true, return k.
+    var kValue = o[k];
+    if (predicate.call(thisArg, kValue, k, o)) {
+      return k;
+    }
+    // e. Increase k by 1.
+    k++;
+  }
+
+  // 7. Return -1.
+  return -1;
+}
+
 // NUMBERS AND STRINGS
 
 export function integerBetween(thing, bottom, top) {

--- a/src/impl/util.js
+++ b/src/impl/util.js
@@ -5,6 +5,7 @@
 */
 
 import { InvalidArgumentError } from "../errors.js";
+import * as Ponyfills from "../ponyfills.js";
 
 /**
  * @private
@@ -88,135 +89,19 @@ export function hasOwnProperty(obj, prop) {
 }
 
 export function assign(target, ...sources) {
-  if (typeof Object.assign === "function") {
-    // eslint-disable-next-line es5/no-es6-static-methods
-    return Object.assign(target, ...sources);
-  }
-
-  if (target === null || target === undefined) {
-    throw new TypeError("Cannot convert undefined or null to object");
-  }
-
-  var to = Object(target);
-
-  for (var index = 0; index < sources.length; index++) {
-    var nextSource = sources[index];
-
-    if (nextSource !== null && nextSource !== undefined) {
-      for (var nextKey in nextSource) {
-        // Avoid bugs when hasOwnProperty is shadowed
-        if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
-          to[nextKey] = nextSource[nextKey];
-        }
-      }
-    }
-  }
-  return to;
+  return Ponyfills.assign(target, ...sources);
 }
 
 export function find(array, predicate) {
-  if (typeof Array.prototype.find === "function") {
-    return Array.prototype.find.call(array, predicate);
-  }
-
-  // 1. Let O be ? ToObject(this value).
-  if (array == null) {
-    throw TypeError('"this" is null or not defined');
-  }
-
-  var o = Object(array);
-
-  // 2. Let len be ? ToLength(? Get(O, "length")).
-  var len = o.length >>> 0;
-
-  // 3. If IsCallable(predicate) is false, throw a TypeError exception.
-  if (typeof predicate !== "function") {
-    throw TypeError("predicate must be a function");
-  }
-
-  // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
-  var thisArg = arguments[2];
-
-  // 5. Let k be 0.
-  var k = 0;
-
-  // 6. Repeat, while k < len
-  while (k < len) {
-    // a. Let Pk be ! ToString(k).
-    // b. Let kValue be ? Get(O, Pk).
-    // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
-    // d. If testResult is true, return kValue.
-    var kValue = o[k];
-    if (predicate.call(thisArg, kValue, k, o)) {
-      return kValue;
-    }
-    // e. Increase k by 1.
-    k++;
-  }
-
-  // 7. Return undefined.
-  return undefined;
+  return Ponyfills.find.call(array, predicate);
 }
 
 export function findIndex(array, predicate) {
-  if (typeof Array.prototype.findIndex === "function") {
-    return Array.prototype.findIndex.call(array, predicate);
-  }
-
-  // 1. Let O be ? ToObject(this value).
-  if (array == null) {
-    throw new TypeError('"this" is null or not defined');
-  }
-
-  var o = Object(array);
-
-  // 2. Let len be ? ToLength(? Get(O, "length")).
-  var len = o.length >>> 0;
-
-  // 3. If IsCallable(predicate) is false, throw a TypeError exception.
-  if (typeof predicate !== "function") {
-    throw new TypeError("predicate must be a function");
-  }
-
-  // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
-  var thisArg = arguments[2];
-
-  // 5. Let k be 0.
-  var k = 0;
-
-  // 6. Repeat, while k < len
-  while (k < len) {
-    // a. Let Pk be ! ToString(k).
-    // b. Let kValue be ? Get(O, Pk).
-    // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
-    // d. If testResult is true, return k.
-    var kValue = o[k];
-    if (predicate.call(thisArg, kValue, k, o)) {
-      return k;
-    }
-    // e. Increase k by 1.
-    k++;
-  }
-
-  // 7. Return -1.
-  return -1;
+  return Ponyfills.findIndex.call(array, predicate);
 }
 
 export function is(x, y) {
-  if (typeof Object.is === "function") {
-    // eslint-disable-next-line es5/no-es6-static-methods
-    return Object.is(x, y);
-  }
-  // SameValue algorithm
-  if (x === y) {
-    // Steps 1-5, 7-10
-    // Steps 6.b-6.e: +0 != -0
-    return x !== 0 || 1 / x === 1 / y;
-  } else {
-    // Step 6.a: NaN == NaN
-    // eslint-disable-next-line no-self-compare
-    return x !== x && y !== y;
-  }
+  return Ponyfills.is(x, y);
 }
 
 // NUMBERS AND STRINGS
@@ -231,29 +116,11 @@ export function floorMod(x, n) {
 }
 
 export function padStart(input, n = 2) {
-  if (typeof String.prototype.padStart === "function") {
-    return String.prototype.padStart.call(input, n);
-  }
-
-  if (input.toString().length < n) {
-    let res = "";
-    for (let i = 0; i < n; i++) {
-      res += "0";
-    }
-    res += input;
-    return res.slice(-n);
-  } else {
-    return input.toString();
-  }
+  return Ponyfills.padStart.call(input, n);
 }
 
 export function startsWith(str, search, rawPos) {
-  if (typeof String.prototype.startsWith === "function") {
-    return String.prototype.startsWith.call(str, search, rawPos);
-  }
-
-  var pos = rawPos > 0 ? rawPos | 0 : 0;
-  return str.substring(pos, pos + search.length) === search;
+  return Ponyfills.startsWith.call(str, search, rawPos);
 }
 
 export function parseInteger(string) {
@@ -281,11 +148,7 @@ export function roundTo(number, digits, towardZero = false) {
 }
 
 export function trunc(v) {
-  if (typeof Math.trunc === "function") {
-    // eslint-disable-next-line es5/no-es6-static-methods
-    return Math.trunc(v);
-  }
-  return v < 0 ? Math.ceil(v) : Math.floor(v);
+  return Ponyfills.trunc(v);
 }
 
 export function sign(x) {
@@ -390,12 +253,7 @@ export function parseZoneInfo(ts, offsetFormat, locale, timeZone = null) {
 }
 
 export function isNaN(input) {
-  if (typeof Number.isNaN === "function") {
-    // eslint-disable-next-line es5/no-es6-static-methods
-    return Number.isNaN(input);
-  }
-  // eslint-disable-next-line no-self-compare
-  return typeof input === "number" && input !== input;
+  return Ponyfills.isNaN(input);
 }
 
 // signedOffset('-5', '30') -> -330

--- a/src/impl/util.js
+++ b/src/impl/util.js
@@ -147,7 +147,7 @@ export function parseMillis(fraction) {
 }
 
 export function roundTo(number, digits, towardZero = false) {
-  const factor = 10 ** digits,
+  const factor = Math.pow(10, digits),
     rounder = towardZero ? trunc : Math.round;
   return rounder(number * factor) / factor;
 }

--- a/src/impl/util.js
+++ b/src/impl/util.js
@@ -122,7 +122,12 @@ export function floorMod(x, n) {
 
 export function padStart(input, n = 2) {
   if (input.toString().length < n) {
-    return ("0".repeat(n) + input).slice(-n);
+    let res = "";
+    for (let i = 0; i < n; i++) {
+      res += "0";
+    }
+    res += input;
+    return res.slice(-n);
   } else {
     return input.toString();
   }

--- a/src/impl/util.js
+++ b/src/impl/util.js
@@ -109,6 +109,46 @@ export function assign(target /* , ...sources */) {
   return to;
 }
 
+export function find(array, predicate) {
+  // 1. Let O be ? ToObject(this value).
+  if (array == null) {
+    throw TypeError('"this" is null or not defined');
+  }
+
+  var o = Object(array);
+
+  // 2. Let len be ? ToLength(? Get(O, "length")).
+  var len = o.length >>> 0;
+
+  // 3. If IsCallable(predicate) is false, throw a TypeError exception.
+  if (typeof predicate !== "function") {
+    throw TypeError("predicate must be a function");
+  }
+
+  // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
+  var thisArg = arguments[2];
+
+  // 5. Let k be 0.
+  var k = 0;
+
+  // 6. Repeat, while k < len
+  while (k < len) {
+    // a. Let Pk be ! ToString(k).
+    // b. Let kValue be ? Get(O, Pk).
+    // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
+    // d. If testResult is true, return kValue.
+    var kValue = o[k];
+    if (predicate.call(thisArg, kValue, k, o)) {
+      return kValue;
+    }
+    // e. Increase k by 1.
+    k++;
+  }
+
+  // 7. Return undefined.
+  return undefined;
+}
+
 // NUMBERS AND STRINGS
 
 export function integerBetween(thing, bottom, top) {
@@ -250,9 +290,10 @@ export function parseZoneInfo(ts, offsetFormat, locale, timeZone = null) {
     intl = hasIntl();
 
   if (intl && hasFormatToParts()) {
-    const parsed = new Intl.DateTimeFormat(locale, modified)
-      .formatToParts(date)
-      .find(m => m.type.toLowerCase() === "timezonename");
+    const parsed = find(
+      new Intl.DateTimeFormat(locale, modified).formatToParts(date),
+      m => m.type.toLowerCase() === "timezonename"
+    );
     return parsed ? parsed.value : null;
   } else if (intl) {
     // this probably doesn't work for all locales

--- a/src/impl/util.js
+++ b/src/impl/util.js
@@ -133,6 +133,11 @@ export function padStart(input, n = 2) {
   }
 }
 
+export function startsWith(str, search, rawPos) {
+  var pos = rawPos > 0 ? rawPos | 0 : 0;
+  return str.substring(pos, pos + search.length) === search;
+}
+
 export function parseInteger(string) {
   if (isUndefined(string) || string === null || string === "") {
     return undefined;

--- a/src/impl/util.js
+++ b/src/impl/util.js
@@ -5,7 +5,7 @@
 */
 
 import { InvalidArgumentError } from "../errors.js";
-import * as Ponyfills from "../ponyfills.js";
+import Ponyfills from "../ponyfills.js";
 
 /**
  * @private

--- a/src/impl/util.js
+++ b/src/impl/util.js
@@ -89,6 +89,7 @@ export function hasOwnProperty(obj, prop) {
 
 export function assign(target, ...sources) {
   if (typeof Object.assign === "function") {
+    // eslint-disable-next-line es5/no-es6-static-methods
     return Object.assign(target, ...sources);
   }
 
@@ -203,6 +204,7 @@ export function findIndex(array, predicate) {
 
 export function is(x, y) {
   if (typeof Object.is === "function") {
+    // eslint-disable-next-line es5/no-es6-static-methods
     return Object.is(x, y);
   }
   // SameValue algorithm
@@ -280,6 +282,7 @@ export function roundTo(number, digits, towardZero = false) {
 
 export function trunc(v) {
   if (typeof Math.trunc === "function") {
+    // eslint-disable-next-line es5/no-es6-static-methods
     return Math.trunc(v);
   }
   return v < 0 ? Math.ceil(v) : Math.floor(v);
@@ -388,6 +391,7 @@ export function parseZoneInfo(ts, offsetFormat, locale, timeZone = null) {
 
 export function isNaN(input) {
   if (typeof Number.isNaN === "function") {
+    // eslint-disable-next-line es5/no-es6-static-methods
     return Number.isNaN(input);
   }
   // eslint-disable-next-line no-self-compare

--- a/src/luxon.js
+++ b/src/luxon.js
@@ -8,7 +8,7 @@ import IANAZone from "./zones/IANAZone.js";
 import InvalidZone from "./zones/invalidZone.js";
 import LocalZone from "./zones/localZone.js";
 import Settings from "./settings.js";
-import * as Ponyfills from "./ponyfills.js";
+import Ponyfills from "./ponyfills.js";
 
 export {
   DateTime,

--- a/src/luxon.js
+++ b/src/luxon.js
@@ -8,6 +8,7 @@ import IANAZone from "./zones/IANAZone.js";
 import InvalidZone from "./zones/invalidZone.js";
 import LocalZone from "./zones/localZone.js";
 import Settings from "./settings.js";
+import * as Ponyfills from "./ponyfills.js";
 
 export {
   DateTime,
@@ -19,5 +20,6 @@ export {
   IANAZone,
   InvalidZone,
   LocalZone,
-  Settings
+  Settings,
+  Ponyfills
 };

--- a/src/ponyfills.js
+++ b/src/ponyfills.js
@@ -1,0 +1,9 @@
+// Note these are intentionally `var` so that consumers can replace them
+export var assign = Object.assign;
+export var find = Array.prototype.find;
+export var findIndex = Array.prototype.findIndex;
+export var is = Object.is;
+export var isNaN = Number.isNaN;
+export var padStart = String.prototype.padStart;
+export var startsWith = String.prototype.startsWith;
+export var trunc = Math.trunc;

--- a/src/ponyfills.js
+++ b/src/ponyfills.js
@@ -1,9 +1,10 @@
-// Note these are intentionally `var` so that consumers can replace them
-export var assign = Object.assign;
-export var find = Array.prototype.find;
-export var findIndex = Array.prototype.findIndex;
-export var is = Object.is;
-export var isNaN = Number.isNaN;
-export var padStart = String.prototype.padStart;
-export var startsWith = String.prototype.startsWith;
-export var trunc = Math.trunc;
+export default {
+  assign: Object.assign,
+  find: Array.prototype.find,
+  findIndex: Array.prototype.findIndex,
+  is: Object.is,
+  isNaN: Number.isNaN,
+  padStart: String.prototype.padStart,
+  startsWith: String.prototype.startsWith,
+  trunc: Math.trunc
+};


### PR DESCRIPTION
This adds a few more helpers so that the build is not using ES6 functions (which are undetectable from static analysis).

We would like to use Luxon on a platform where we have only polyfilled up to ES5, and it's risky for us to add more polyfills. We can run the output through the typescript compiler with a target of ES5 though, so things like `const`, `let`, `[...something]` etc are ok.

I noticed there are already helpers for other ES6 things like `padStart` and `padEnd`, so I'm hoping this is ok?

Thanks!