### PR TITLE
Fixed broken link to cldr.unicode.org

### DIFF
--- a/src/impl/formatter.js
+++ b/src/impl/formatter.js
@@ -166,7 +166,7 @@ export default class Formatter {
       era = length =>
         knownEnglish ? English.eraForDateTime(dt, length) : string({ era: length }, "era"),
       tokenToString = token => {
-        // Where possible: http://cldr.unicode.org/translation/date-time#TOC-Stand-Alone-vs.-Format-Styles
+        // Where possible: http://cldr.unicode.org/translation/date-time-1/date-time#TOC-Standalone-vs.-Format-Styles
         switch (token) {
           // ms
           case "S":


### PR DESCRIPTION
I noticed that the link to http://cldr.unicode.org/translation/date-time was broken (404).

I believe the new URL is http://cldr.unicode.org/translation/date-time-1/date-time.

Seeing as I didn't change any code (only a comment) I didn't run the tests but I did run the linter.