### PR TITLE
Fix padding of negative years in IsoDate

### DIFF
--- a/src/impl/util.js
+++ b/src/impl/util.js
@@ -99,11 +99,17 @@ export function floorMod(x, n) {
 }
 
 export function padStart(input, n = 2) {
-  if (input.toString().length < n) {
-    return ("0".repeat(n) + input).slice(-n);
+  const minus = input < 0 ? "-" : "";
+  const target = minus ? input * -1 : input;
+  let result;
+
+  if (target.toString().length < n) {
+    result = ("0".repeat(n) + target).slice(-n);
   } else {
-    return input.toString();
+    result = target.toString();
   }
+
+  return `${minus}${result}`;
 }
 
 export function parseInteger(string) {

--- a/test/datetime/format.test.js
+++ b/test/datetime/format.test.js
@@ -91,6 +91,15 @@ test("DateTime#toISODate() returns ISO 8601 date in format [±YYYYY]", () => {
   );
 });
 
+test("DateTime#toISODate() correctly pads negative years", () => {
+  expect(DateTime.fromObject({ year: -1, month: 1, day: 1, zone: "utc" }).toISODate()).toBe(
+    "-0001-01-01"
+  );
+  expect(DateTime.fromObject({ year: -10, month: 1, day: 1, zone: "utc" }).toISODate()).toBe(
+    "-0010-01-01"
+  );
+});
+
 //------
 // #toISOWeekDate()
 //------


### PR DESCRIPTION
Fixes [868](https://github.com/moment/luxon/issues/868)