### PR TITLE
Add opt to use existing loc obj in weekdays/months

### DIFF
--- a/benchmarks/datetime.js
+++ b/benchmarks/datetime.js
@@ -4,64 +4,76 @@ import Benchmark from "benchmark";
 import DateTime from "../src/datetime";
 import Settings from "../src/settings";
 
-const suite = new Benchmark.Suite();
+function runDateTimeSuite() {
+  return new Promise((resolve, reject) => {
+    const suite = new Benchmark.Suite();
 
-const dt = DateTime.now();
+    const dt = DateTime.now();
 
-suite
-  .add("DateTime.local", () => {
-    DateTime.now();
-  })
-  .add("DateTime.fromObject with locale", () => {
-    DateTime.fromObject({ locale: "fr" });
-  })
-  .add("DateTime.local with numbers", () => {
-    DateTime.local(2017, 5, 15);
-  })
-  .add("DateTime.fromISO", () => {
-    DateTime.fromISO("1982-05-25T09:10:11.445Z");
-  })
-  .add("DateTime.fromSQL", () => {
-    DateTime.fromSQL("2016-05-14 10:23:54.2346");
-  })
-  .add("DateTime.fromString", () => {
-    DateTime.fromString("1982/05/25 09:10:11.445", "yyyy/MM/dd HH:mm:ss.SSS");
-  })
-  .add("DateTime.fromString with zone", () => {
-    DateTime.fromString("1982/05/25 09:10:11.445", "yyyy/MM/dd HH:mm:ss.SSS", {
-      zone: "America/Los_Angeles"
-    });
-  })
-  .add("DateTime#setZone", () => {
-    dt.setZone("America/Los_Angeles");
-  })
-  .add("DateTime#toFormat", () => {
-    dt.toFormat("yyyy-MM-dd");
-  })
-  .add("DateTime#toFormat with macro", () => {
-    dt.toFormat("T");
-  })
-  .add("DateTime#toFormat with macro no cache", () => {
-    dt.toFormat("T");
-    Settings.resetCaches();
-  })
-  .add("DateTime#add", () => {
-    dt.plus({ milliseconds: 3434 });
-  })
-  .add("DateTime#toISO", () => {
-    dt.toISO();
-  })
-  .add("DateTime#toLocaleString", () => {
-    dt.toLocaleString();
-  })
-  .add("DateTime#toRelativeCalendar", () => {
-    dt.toRelativeCalendar({ base: DateTime.now(), locale: "fi" });
-  })
-  .on("cycle", event => {
-    console.log(String(event.target));
-  })
-  // eslint-disable-next-line func-names
-  .on("complete", function() {
-    console.log("Fastest is " + this.filter("fastest").map("name"));
-  })
-  .run();
+    suite
+      .add("DateTime.local", () => {
+        DateTime.now();
+      })
+      .add("DateTime.fromObject with locale", () => {
+        DateTime.fromObject({ locale: "fr" });
+      })
+      .add("DateTime.local with numbers", () => {
+        DateTime.local(2017, 5, 15);
+      })
+      .add("DateTime.fromISO", () => {
+        DateTime.fromISO("1982-05-25T09:10:11.445Z");
+      })
+      .add("DateTime.fromSQL", () => {
+        DateTime.fromSQL("2016-05-14 10:23:54.2346");
+      })
+      .add("DateTime.fromString", () => {
+        DateTime.fromString("1982/05/25 09:10:11.445", "yyyy/MM/dd HH:mm:ss.SSS");
+      })
+      .add("DateTime.fromString with zone", () => {
+        DateTime.fromString("1982/05/25 09:10:11.445", "yyyy/MM/dd HH:mm:ss.SSS", {
+          zone: "America/Los_Angeles"
+        });
+      })
+      .add("DateTime#setZone", () => {
+        dt.setZone("America/Los_Angeles");
+      })
+      .add("DateTime#toFormat", () => {
+        dt.toFormat("yyyy-MM-dd");
+      })
+      .add("DateTime#toFormat with macro", () => {
+        dt.toFormat("T");
+      })
+      .add("DateTime#toFormat with macro no cache", () => {
+        dt.toFormat("T");
+        Settings.resetCaches();
+      })
+      .add("DateTime#add", () => {
+        dt.plus({ milliseconds: 3434 });
+      })
+      .add("DateTime#toISO", () => {
+        dt.toISO();
+      })
+      .add("DateTime#toLocaleString", () => {
+        dt.toLocaleString();
+      })
+      .add("DateTime#toRelativeCalendar", () => {
+        dt.toRelativeCalendar({ base: DateTime.now(), locale: "fi" });
+      })
+      .on("cycle", event => {
+        console.log(String(event.target));
+      })
+      // eslint-disable-next-line func-names
+      .on("complete", function() {
+        console.log("Fastest is " + this.filter("fastest").map("name"));
+        resolve();
+      })
+      .on("error", function() {
+        reject(this.error);
+      })
+      .run();
+  });
+}
+
+const allSuites = [runDateTimeSuite];
+
+export default allSuites;

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -1,0 +1,12 @@
+import dateTimeSuites from "./datetime";
+import infoSuites from "./info";
+
+const allSuites = [...dateTimeSuites, ...infoSuites];
+
+async function runAllSuites() {
+  for (const runSuite of allSuites) {
+    await runSuite();
+  }
+}
+
+runAllSuites();

--- a/benchmarks/info.js
+++ b/benchmarks/info.js
@@ -1,0 +1,112 @@
+/* eslint import/no-extraneous-dependencies: off */
+/* eslint no-console: off */
+import Benchmark from "benchmark";
+import Info from "../src/info";
+import Locale from "../src/impl/locale.js";
+
+function runWeekdaysSuite() {
+  return new Promise((resolve, reject) => {
+    const locale = Locale.create(null, null, null);
+
+    new Benchmark.Suite()
+      .add("Info.weekdays with existing locale", () => {
+        Info.weekdays("long", { locObj: locale });
+      })
+      .add("Info.weekdays", () => {
+        Info.weekdays("long");
+      })
+      .on("cycle", event => {
+        console.log(String(event.target));
+      })
+      // eslint-disable-next-line func-names
+      .on("complete", function() {
+        console.log("Fastest is " + this.filter("fastest").map("name"));
+        resolve();
+      })
+      .on("error", function() {
+        reject(this.error);
+      })
+      .run();
+  });
+}
+
+function runWeekdaysFormatSuite() {
+  return new Promise((resolve, reject) => {
+    const locale = Locale.create(null, null, null);
+
+    new Benchmark.Suite()
+      .add("Info.weekdaysFormat with existing locale", () => {
+        Info.weekdaysFormat("long", { locObj: locale });
+      })
+      .add("Info.weekdaysFormat", () => {
+        Info.weekdaysFormat("long");
+      })
+      .on("cycle", event => {
+        console.log(String(event.target));
+      })
+      // eslint-disable-next-line func-names
+      .on("complete", function() {
+        console.log("Fastest is " + this.filter("fastest").map("name"));
+        resolve();
+      })
+      .on("error", function() {
+        reject(this.error);
+      })
+      .run();
+  });
+}
+
+function runMonthsSuite() {
+  return new Promise((resolve, reject) => {
+    const locale = Locale.create(null, null, null);
+    new Benchmark.Suite()
+      .add("Info.months with existing locale", () => {
+        Info.months("long", { locObj: locale });
+      })
+      .add("Info.months", () => {
+        Info.months("long");
+      })
+      .on("cycle", event => {
+        console.log(String(event.target));
+      })
+      // eslint-disable-next-line func-names
+      .on("complete", function() {
+        console.log("Fastest is " + this.filter("fastest").map("name"));
+        resolve();
+      })
+      .on("error", function() {
+        reject(this.error);
+      })
+      .run();
+  });
+}
+
+function runMonthsFormatSuite() {
+  return new Promise((resolve, reject) => {
+    const locale = Locale.create(null, null, null);
+
+    new Benchmark.Suite()
+      .add("Info.monthsFormat with existing locale", () => {
+        Info.monthsFormat("long", { locObj: locale });
+      })
+      .add("Info.monthsFormat", () => {
+        Info.monthsFormat("long");
+      })
+      .on("cycle", event => {
+        console.log(String(event.target));
+      })
+      // eslint-disable-next-line func-names
+      .on("complete", function() {
+        console.log("Fastest is " + this.filter("fastest").map("name"));
+        resolve();
+      })
+      .on("error", function() {
+        reject(this.error);
+      })
+      .run();
+  });
+}
+
+const allSuites = [runMonthsSuite, runMonthsFormatSuite, runWeekdaysSuite, runWeekdaysFormatSuite];
+
+export default allSuites;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint --quiet src test benchmarks",
     "lint!": "npm run format && npm run lint",
     "format": "prettier --write 'src/**/*.js' 'test/**/*.js' 'benchmarks/*.js'",
-    "benchmark": "babel-node benchmarks/datetime.js",
+    "benchmark": "babel-node benchmarks/index.js",
     "codecov": "codecov",
     "check-doc-coverage": "babel-node tasks/docCoverage"
   },

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1092,7 +1092,7 @@ export default class DateTime {
    * @type {string}
    */
   get monthShort() {
-    return this.isValid ? Info.months("short", { locale: this.locale })[this.month - 1] : null;
+    return this.isValid ? Info.months("short", { locObj: this.loc })[this.month - 1] : null;
   }
 
   /**
@@ -1102,7 +1102,7 @@ export default class DateTime {
    * @type {string}
    */
   get monthLong() {
-    return this.isValid ? Info.months("long", { locale: this.locale })[this.month - 1] : null;
+    return this.isValid ? Info.months("long", { locObj: this.loc })[this.month - 1] : null;
   }
 
   /**
@@ -1112,7 +1112,7 @@ export default class DateTime {
    * @type {string}
    */
   get weekdayShort() {
-    return this.isValid ? Info.weekdays("short", { locale: this.locale })[this.weekday - 1] : null;
+    return this.isValid ? Info.weekdays("short", { locObj: this.loc })[this.weekday - 1] : null;
   }
 
   /**
@@ -1122,7 +1122,7 @@ export default class DateTime {
    * @type {string}
    */
   get weekdayLong() {
-    return this.isValid ? Info.weekdays("long", { locale: this.locale })[this.weekday - 1] : null;
+    return this.isValid ? Info.weekdays("long", { locObj: this.loc })[this.weekday - 1] : null;
   }
 
   /**

--- a/src/info.js
+++ b/src/info.js
@@ -57,6 +57,7 @@ export default class Info {
    * @param {Object} opts - options
    * @param {string} [opts.locale] - the locale code
    * @param {string} [opts.numberingSystem=null] - the numbering system
+   * @param {string} [opts.locObj=null] - an existing locale object to use
    * @param {string} [opts.outputCalendar='gregory'] - the calendar
    * @example Info.months()[0] //=> 'January'
    * @example Info.months('short')[0] //=> 'Jan'
@@ -68,9 +69,9 @@ export default class Info {
    */
   static months(
     length = "long",
-    { locale = null, numberingSystem = null, outputCalendar = "gregory" } = {}
+    { locale = null, numberingSystem = null, locObj = null, outputCalendar = "gregory" } = {}
   ) {
-    return Locale.create(locale, numberingSystem, outputCalendar).months(length);
+    return (locObj || Locale.create(locale, numberingSystem, outputCalendar)).months(length);
   }
 
   /**
@@ -82,14 +83,15 @@ export default class Info {
    * @param {Object} opts - options
    * @param {string} [opts.locale] - the locale code
    * @param {string} [opts.numberingSystem=null] - the numbering system
+   * @param {string} [opts.locObj=null] - an existing locale object to use
    * @param {string} [opts.outputCalendar='gregory'] - the calendar
    * @return {[string]}
    */
   static monthsFormat(
     length = "long",
-    { locale = null, numberingSystem = null, outputCalendar = "gregory" } = {}
+    { locale = null, numberingSystem = null, locObj = null, outputCalendar = "gregory" } = {}
   ) {
-    return Locale.create(locale, numberingSystem, outputCalendar).months(length, true);
+    return (locObj || Locale.create(locale, numberingSystem, outputCalendar)).months(length, true);
   }
 
   /**
@@ -99,14 +101,15 @@ export default class Info {
    * @param {Object} opts - options
    * @param {string} [opts.locale] - the locale code
    * @param {string} [opts.numberingSystem=null] - the numbering system
+   * @param {string} [opts.locObj=null] - an existing locale object to use
    * @example Info.weekdays()[0] //=> 'Monday'
    * @example Info.weekdays('short')[0] //=> 'Mon'
    * @example Info.weekdays('short', { locale: 'fr-CA' })[0] //=> 'lun.'
    * @example Info.weekdays('short', { locale: 'ar' })[0] //=> 'الاثنين'
    * @return {[string]}
    */
-  static weekdays(length = "long", { locale = null, numberingSystem = null } = {}) {
-    return Locale.create(locale, numberingSystem, null).weekdays(length);
+  static weekdays(length = "long", { locale = null, numberingSystem = null, locObj = null } = {}) {
+    return (locObj || Locale.create(locale, numberingSystem, null)).weekdays(length);
   }
 
   /**
@@ -118,10 +121,14 @@ export default class Info {
    * @param {Object} opts - options
    * @param {string} [opts.locale=null] - the locale code
    * @param {string} [opts.numberingSystem=null] - the numbering system
+   * @param {string} [opts.locObj=null] - an existing locale object to use
    * @return {[string]}
    */
-  static weekdaysFormat(length = "long", { locale = null, numberingSystem = null } = {}) {
-    return Locale.create(locale, numberingSystem, null).weekdays(length, true);
+  static weekdaysFormat(
+    length = "long",
+    { locale = null, numberingSystem = null, locObj = null } = {}
+  ) {
+    return (locObj || Locale.create(locale, numberingSystem, null)).weekdays(length, true);
   }
 
   /**


### PR DESCRIPTION
Potential fix for https://github.com/moment/luxon/issues/775 .

This allows an existing loc object to be passed into Info `months` and `weekdays` functions, to be used instead of creating a new one. The use of these in DateTime has been modified to use this option.

In a loop of 100000 uses of `DateTime.weekdayLong` this appears to be roughly twice as fast as creating a Locale each time.