### PR TITLE
#829: Made English Info lists immutable

### DIFF
--- a/src/impl/english.js
+++ b/src/impl/english.js
@@ -44,11 +44,11 @@ export const monthsNarrow = ["J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "
 export function months(length) {
   switch (length) {
     case "narrow":
-      return monthsNarrow;
+      return [...monthsNarrow];
     case "short":
-      return monthsShort;
+      return [...monthsShort];
     case "long":
-      return monthsLong;
+      return [...monthsLong];
     case "numeric":
       return ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"];
     case "2-digit":
@@ -75,11 +75,11 @@ export const weekdaysNarrow = ["M", "T", "W", "T", "F", "S", "S"];
 export function weekdays(length) {
   switch (length) {
     case "narrow":
-      return weekdaysNarrow;
+      return [...weekdaysNarrow];
     case "short":
-      return weekdaysShort;
+      return [...weekdaysShort];
     case "long":
-      return weekdaysLong;
+      return [...weekdaysLong];
     case "numeric":
       return ["1", "2", "3", "4", "5", "6", "7"];
     default:
@@ -98,11 +98,11 @@ export const erasNarrow = ["B", "A"];
 export function eras(length) {
   switch (length) {
     case "narrow":
-      return erasNarrow;
+      return [...erasNarrow];
     case "short":
-      return erasShort;
+      return [...erasShort];
     case "long":
-      return erasLong;
+      return [...erasLong];
     default:
       return null;
   }

--- a/test/info/listers.test.js
+++ b/test/info/listers.test.js
@@ -2,6 +2,9 @@
 
 import { Info } from "../../src/luxon";
 
+import Helpers from "../helpers";
+const withDefaultLocale = Helpers.withDefaultLocale;
+
 //------
 // .months()
 //------
@@ -373,4 +376,34 @@ test("Info.eras lists both eras", () => {
   expect(Info.eras("long")).toEqual(["Before Christ", "Anno Domini"]);
   expect(Info.eras("short", { locale: "fr" })).toEqual(["av. J.-C.", "ap. J.-C."]);
   expect(Info.eras("long", { locale: "fr" })).toEqual(["avant Jésus-Christ", "après Jésus-Christ"]);
+});
+
+//------
+// general
+//------
+test("Info English lists are not mutable", () => {
+  withDefaultLocale("en-US", () => {
+    const cachingMethods = [
+      ["weekdays", "short"],
+      ["weekdays", "long"],
+      ["weekdays", "narrow"],
+      ["weekdays", "numeric"],
+      ["months", "short"],
+      ["months", "long"],
+      ["months", "narrow"],
+      ["months", "numeric"],
+      ["months", "2-digit"],
+      ["eras", "narrow"],
+      ["eras", "short"],
+      ["eras", "long"]
+    ];
+
+    for (const [method, arg] of cachingMethods) {
+      const fn = Info[method];
+      const original = [...fn(arg)];
+      fn(arg).pop();
+      const expected = fn(arg);
+      expect(expected).toEqual(original);
+    }
+  });
 });


### PR DESCRIPTION
Fix for [#829](https://github.com/moment/luxon/issues/829).

Bug only appears when the English lists are used, hence setting the default locale in the test.