### PR TITLE
Correct example in documentation for weekYear (fixes #885).

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1055,7 +1055,7 @@ export default class DateTime {
   /**
    * Get the week year
    * @see https://en.wikipedia.org/wiki/ISO_week_date
-   * @example DateTime.local(2014, 11, 31).weekYear //=> 2015
+   * @example DateTime.local(2014, 12, 31).weekYear //=> 2015
    * @type {number}
    */
   get weekYear() {


### PR DESCRIPTION
Fixes documentation mishap for weekYear function (fixes #885).