### PR TITLE
Fixed DRY principle violation in DateTime.local()

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -479,7 +479,7 @@ export default class DateTime {
    */
   static local(year, month, day, hour, minute, second, millisecond) {
     if (isUndefined(year)) {
-      return new DateTime({});
+      return DateTime.now();
     } else {
       return quickDT(
         {


### PR DESCRIPTION
`DateTime.local()` violated the DRY principle by using `return new DateTime({})` which is already defined in `DateTime.now()`.

So, I have fixed it by reusing the `DateTime.now()`.