### PR TITLE
Prevent error from being thrown in IANAZone.offset

### DIFF
--- a/src/zones/IANAZone.js
+++ b/src/zones/IANAZone.js
@@ -152,8 +152,11 @@ export default class IANAZone extends Zone {
 
   /** @override **/
   offset(ts) {
-    const date = new Date(ts),
-      dtf = makeDTF(this.name),
+    const date = new Date(ts);
+
+    if (isNaN(date)) return NaN;
+
+    const dtf = makeDTF(this.name),
       [year, month, day, hour, minute, second] = dtf.formatToParts
         ? partsOffset(dtf, date)
         : hackyOffset(dtf, date),

--- a/test/datetime/math.test.js
+++ b/test/datetime/math.test.js
@@ -116,6 +116,13 @@ test("DateTime#plus renders invalid when out of max. datetime range using second
   expect(d.isValid).toBe(false);
 });
 
+test("DateTime#plus renders invalid when out of max. datetime range using IANAZone", () => {
+  const d = DateTime.utc(1970, 1, 1, 0, 0, 0, 0)
+    .setZone("America/Los_Angeles")
+    .plus({ second: 1e8 * 24 * 60 * 60 + 1 });
+  expect(d.isValid).toBe(false);
+});
+
 test("DateTime#plus handles fractional days", () => {
   const d = DateTime.fromISO("2016-01-31T10:00");
   expect(d.plus({ days: 0.8 })).toEqual(d.plus({ hours: (24 * 4) / 5 }));
@@ -202,6 +209,13 @@ test("DateTime#minus renders invalid when out of max. datetime range using days"
 
 test("DateTime#minus renders invalid when out of max. datetime range using seconds", () => {
   const d = DateTime.utc(1970, 1, 1, 0, 0, 0, 0).minus({ second: 1e8 * 24 * 60 * 60 + 1 });
+  expect(d.isValid).toBe(false);
+});
+
+test("DateTime#plus renders invalid when out of max. datetime range using IANAZone", () => {
+  const d = DateTime.utc(1970, 1, 1, 0, 0, 0, 0)
+    .setZone("America/Los_Angeles")
+    .minus({ second: 1e8 * 24 * 60 * 60 + 1 });
   expect(d.isValid).toBe(false);
 });
 


### PR DESCRIPTION
To fix bug #905.

I confirmed the fix in the browser (local build):
```js
let d = luxon.DateTime.local();
let dz = d.setZone("America/Vancouver");

d.plus({seconds: 12345678901234567890});
DateTime {ts: 1.2345678902851053e+22, _zone: LocalZone, loc: Locale, invalid: Invalid, weekData: null, …}

dz.plus({seconds: 12345678901234567890});
DateTime {ts: 1.2345678902851053e+22, _zone: IANAZone, loc: Locale, invalid: Invalid, weekData: null, …}
```