### PR TITLE
Add check for etc zone support before using for formatting

### DIFF
--- a/test/datetime/format.test.js
+++ b/test/datetime/format.test.js
@@ -333,6 +333,12 @@ test("DateTime#toLocaleString() shows things in the right fixed-offset zone when
   );
 });
 
+test("DateTime#toLocaleString() shows things with UTC if fixed-offset zone with 0 offset is used", () => {
+  expect(dt.setZone("UTC").toLocaleString(DateTime.DATETIME_FULL)).toBe(
+    "May 25, 1982, 9:23 AM UTC"
+  );
+});
+
 test("DateTime#toLocaleString() does the best it can with unsupported fixed-offset zone when showing the zone", () => {
   expect(dt.setZone("UTC+4:30").toLocaleString(DateTime.DATETIME_FULL)).toBe(
     "May 25, 1982, 9:23 AM UTC"


### PR DESCRIPTION
This fixes issues like #912 and #883.

- Instead of checking only if the range is likely supported, the zone is really tested before it is used. While this will have likely some performance impact, I cannot think of some other reliable way to do this.
- TZ used for formatting when the offset is 0 is UTC. This will fix issues like #878 because it'll revert things to the previous behaviour. It is not ideal, because if somebody uses explicit GMT it still becomes UTC, but AFAIK FixedOffsetZone doesn't hold the original name so this is the best that can be done.
