### PR TITLE
Updated JSDoc on `DateTime.fromISO`

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -751,8 +751,8 @@ export default class DateTime {
    * @param {string|Zone} [opts.zone='local'] - use this zone if no offset is specified in the input string itself. Will also convert the time to this zone
    * @param {boolean} [opts.setZone=false] - override the zone with a fixed-offset zone specified in the string itself, if it specifies one
    * @param {string} [opts.locale='system's locale'] - a locale to set on the resulting DateTime instance
-   * @param {string} opts.outputCalendar - the output calendar to set on the resulting DateTime instance
-   * @param {string} opts.numberingSystem - the numbering system to set on the resulting DateTime instance
+   * @param {string} [opts.outputCalendar] - the output calendar to set on the resulting DateTime instance
+   * @param {string} [opts.numberingSystem] - the numbering system to set on the resulting DateTime instance
    * @example DateTime.fromISO('2016-05-25T09:08:34.123')
    * @example DateTime.fromISO('2016-05-25T09:08:34.123+06:00')
    * @example DateTime.fromISO('2016-05-25T09:08:34.123+06:00', {setZone: true})


### PR DESCRIPTION
Tiny cleanup to prevent warnings in ide's when not using all opts

![qra0dx](https://user-images.githubusercontent.com/8171714/114122494-33bd4580-98a5-11eb-9429-9e0b38d40dd3.png)
