### PR TITLE
feat: multiple units support in toRelative

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -360,7 +360,7 @@ function diffRelative(start, end, opts) {
       return format(count, unit);
     }
   }
-  return format(0, opts.units[opts.units.length - 1]);
+  return format(start > end ? -0 : 0, opts.units[opts.units.length - 1]);
 }
 
 /**
@@ -1847,7 +1847,7 @@ export default class DateTime {
    * @param {Object} options - options that affect the output
    * @param {DateTime} [options.base=DateTime.now()] - the DateTime to use as the basis to which this time is compared. Defaults to now.
    * @param {string} [options.style="long"] - the style of units, must be "long", "short", or "narrow"
-   * @param {string} options.unit - use a specific unit; if omitted, the method will pick the unit. Use one of "years", "quarters", "months", "weeks", "days", "hours", "minutes", or "seconds"
+   * @param {string|string[]} options.unit - use a specific unit or array of units; if omitted, or an array, the method will pick the best unit. Use an array or one of "years", "quarters", "months", "weeks", "days", "hours", "minutes", or "seconds"
    * @param {boolean} [options.round=true] - whether to round the numbers in the output.
    * @param {number} [options.padding=0] - padding in milliseconds. This allows you to round up the result if it fits inside the threshold. Don't use in combination with {round: false} because the decimal output will include the padding.
    * @param {string} options.locale - override the locale of this DateTime
@@ -1863,12 +1863,19 @@ export default class DateTime {
     if (!this.isValid) return null;
     const base = options.base || DateTime.fromObject({ zone: this.zone }),
       padding = options.padding ? (this < base ? -options.padding : options.padding) : 0;
+    let units = ["years", "months", "days", "hours", "minutes", "seconds"];
+    let unit = options.unit;
+    if (Array.isArray(options.unit)) {
+      units = options.unit;
+      unit = undefined;
+    }
     return diffRelative(
       base,
       this.plus(padding),
       Object.assign(options, {
         numeric: "always",
-        units: ["years", "months", "days", "hours", "minutes", "seconds"]
+        units,
+        unit
       })
     );
   }

--- a/test/datetime/relative.test.js
+++ b/test/datetime/relative.test.js
@@ -56,6 +56,8 @@ test("DateTime#toRelative takes a unit argument", () => {
   expect(base.minus({ seconds: 30 }).toRelative({ base, unit: ["days", "hours", "minutes"] })).toBe(
     "0 minutes ago"
   );
+  expect(base.minus({ seconds: 1 }).toRelative({ base, unit: "minutes" })).toBe("0 minutes ago");
+  expect(base.plus({ seconds: 1 }).toRelative({ base, unit: "minutes" })).toBe("in 0 minutes");
   expect(
     base.plus({ seconds: 30 }).toRelative({
       base,

--- a/test/datetime/relative.test.js
+++ b/test/datetime/relative.test.js
@@ -53,6 +53,21 @@ test("DateTime#toRelative takes a unit argument", () => {
   expect(base.minus({ months: 3 }).toRelative({ base, unit: "years", round: false })).toBe(
     "0.25 years ago"
   );
+  expect(base.minus({ seconds: 30 }).toRelative({ base, unit: ["days", "hours", "minutes"] })).toBe(
+    "0 minutes ago"
+  );
+  expect(
+    base.plus({ seconds: 30 }).toRelative({
+      base,
+      unit: ["days", "hours", "minutes"]
+    })
+  ).toBe("in 0 minutes");
+  expect(
+    base.plus({ years: 2 }).toRelative({
+      base,
+      unit: ["days", "hours", "minutes"]
+    })
+  ).toBe("in 731 days");
 });
 
 test("DateTime#toRelative always rounds toward 0", () => {


### PR DESCRIPTION
This has been requested before in #579, see discussion there for more details.

My use case is that during the first minute, `.toRelative()` will print something like `1 second ago`. I'd like to avoid updating it every second (for performance purposes), and instead I'd like it to print out `0 minutes ago`. This way I can schedule updates once every minute instead of every second.

This PR adds a way to override which units are considered when formatting a relative date.

See the tests I added as well.

Fixes #579.