### PR TITLE
#927: Return null when calling intersection() on abutting Intervals

### DIFF
--- a/src/interval.js
+++ b/src/interval.js
@@ -429,7 +429,7 @@ export default class Interval {
     const s = this.s > other.s ? this.s : other.s,
       e = this.e < other.e ? this.e : other.e;
 
-    if (s > e) {
+    if (s >= e) {
       return null;
     } else {
       return Interval.fromDateTimes(s, e);

--- a/test/interval/many.test.js
+++ b/test/interval/many.test.js
@@ -111,12 +111,8 @@ test("Interval#intersection returns the intersection for overlapping intervals",
   ).toBeTruthy();
 });
 
-test("Interval#intersection returns empty for adjacent intervals", () => {
-  expect(
-    todayFrom(5, 8)
-      .intersection(todayFrom(8, 10))
-      .isEmpty()
-  ).toBeTruthy();
+test("Interval#intersection returns null for adjacent intervals", () => {
+  expect(todayFrom(5, 8).intersection(todayFrom(8, 10))).toBeNull();
 });
 
 test("Interval#intersection returns invalid for invalid intervals", () => {


### PR DESCRIPTION
See #927 for the justification.

### Tested
Updated test to intended behavior without updating code and it failed (as intended):
```
 FAIL  test/interval/many.test.js
  ● Interval#intersection returns null for adjacent intervals

    expect(received).toBeNull()

    Received: {"e": "2017-05-25T08:00:00.000-04:00", "invalid": null, "isLuxonInterval": true, "s": "2017-05-25T08:00:00.000-04:00"}

      113 |
      114 | test("Interval#intersection returns null for adjacent intervals", () => {
    > 115 |   expect(todayFrom(5, 8).intersection(todayFrom(8, 10))).toBeNull();
          |                                                          ^
      116 | });
      117 |
      118 | test("Interval#intersection returns invalid for invalid intervals", () => {

      at Object.<anonymous> (test/interval/many.test.js:115:58)
```

Updating interval.js caused the test to begin passing and did not cause any other failures:
```
 PASS  test/interval/many.test.js
```