### PR TITLE
[docs] Update Duration#get docs to show `get` method use

### DIFF
--- a/src/duration.js
+++ b/src/duration.js
@@ -593,9 +593,9 @@ export default class Duration {
   /**
    * Get the value of unit.
    * @param {string} unit - a unit such as 'minute' or 'day'
-   * @example Duration.fromObject({years: 2, days: 3}).years //=> 2
-   * @example Duration.fromObject({years: 2, days: 3}).months //=> 0
-   * @example Duration.fromObject({years: 2, days: 3}).days //=> 3
+   * @example Duration.fromObject({years: 2, days: 3}).get('years') //=> 2
+   * @example Duration.fromObject({years: 2, days: 3}).get('months') //=> 0
+   * @example Duration.fromObject({years: 2, days: 3}).get('days') //=> 3
    * @return {number}
    */
   get(unit) {


### PR DESCRIPTION
The docs for `Duration#get` are showing the use of the named getters `like Duration#years` instead of the `get` method itself. This PR fixes that.