### PR TITLE
.toSeconds() returns seconds.milliseconds

### DIFF
--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -36,7 +36,7 @@ DateTime objects can also be converted to numerical [Unix timestamps](https://en
 
 ```js
 dt.toMillis(); //=> 1492702320000
-dt.toSeconds(); //=> 1492702320
+dt.toSeconds(); //=> 1492702320.000
 dt.valueOf(); //=> 1492702320000, same as .toMillis()
 ```
 


### PR DESCRIPTION
As explained on https://github.com/moment/luxon/issues/565 .toSeconds() returns seconds.milliseconds to mimic UNIX system behaviour.