### PR TITLE
Fixed small typo

### DIFF
--- a/src/duration.js
+++ b/src/duration.js
@@ -216,7 +216,7 @@ export default class Duration {
   }
 
   /**
-   * Create a Duration from a JavaScript object with keys like 'years' and 'hours.
+   * Create a Duration from a JavaScript object with keys like 'years' and 'hours'.
    * If this object is empty then a zero milliseconds duration is returned.
    * @param {Object} obj - the object to create the DateTime from
    * @param {number} obj.years


### PR DESCRIPTION
Fixed small typo where the closing quotation was missing inside the `fromObject` documentation inside `src/duration`