### PR TITLE
Remove outdated parsing tokens note

### DIFF
--- a/docs/parsing.md
+++ b/docs/parsing.md
@@ -177,7 +177,7 @@ Because Luxon was able to parse the string without difficulty, the output is a l
 
 ### Table of tokens
 
-(Examples below given for `2014-08-06T13:07:04.054` considered as a local time in America/New_York). Note that many tokens supported by the [formatter](formatting.md) are **not** supported by the parser. That includes all the "macro" formats like "D" for "localized numeric date".
+(Examples below given for `2014-08-06T13:07:04.054` considered as a local time in America/New_York). Note that many tokens supported by the [formatter](formatting.md) are **not** supported by the parser.
 
 | Standalone token | Format token | Description                                                    | Example                     |
 | ---------------- | ------------ | -------------------------------------------------------------- | --------------------------- |


### PR DESCRIPTION
Removed:
> That includes all the "macro" formats like "D" for "localized numeric date".

`D` is in the [table](https://moment.github.io/luxon/#/parsing?id=table-of-tokens) and is working, so I assume this is outdated.

`luxon.DateTime.fromFormat("22/07/2021", "D", { locale: "en-GB" }).toISO()` -> "2021-07-22T00:00:00.000-07:00"