### PR TITLE
Protect IANAZone.isValidZone from undefined

### DIFF
--- a/src/zones/IANAZone.js
+++ b/src/zones/IANAZone.js
@@ -97,6 +97,9 @@ export default class IANAZone extends Zone {
    * @return {boolean}
    */
   static isValidZone(zone) {
+    if (typeof zone !== "string") {
+      return false;
+    }
     try {
       new Intl.DateTimeFormat("en-US", { timeZone: zone }).format();
       return true;

--- a/src/zones/IANAZone.js
+++ b/src/zones/IANAZone.js
@@ -97,7 +97,7 @@ export default class IANAZone extends Zone {
    * @return {boolean}
    */
   static isValidZone(zone) {
-    if (typeof zone !== "string") {
+    if (!zone) {
       return false;
     }
     try {

--- a/test/zones/IANA.test.js
+++ b/test/zones/IANA.test.js
@@ -30,6 +30,8 @@ test("IANAZone.isValidZone", () => {
   expect(IANAZone.isValidZone("Sport~~blorp")).toBe(false);
   expect(IANAZone.isValidZone("")).toBe(false);
   expect(IANAZone.isValidZone(undefined)).toBe(false);
+  expect(IANAZone.isValidZone(null)).toBe(false);
+  expect(IANAZone.isValidZone(4)).toBe(false);
 });
 
 test("IANAZone.parseGMTOffset returns a number for a valid input", () => {

--- a/test/zones/IANA.test.js
+++ b/test/zones/IANA.test.js
@@ -29,6 +29,7 @@ test("IANAZone.isValidZone", () => {
   expect(IANAZone.isValidZone("Fantasia/Castle")).toBe(false);
   expect(IANAZone.isValidZone("Sport~~blorp")).toBe(false);
   expect(IANAZone.isValidZone("")).toBe(false);
+  expect(IANAZone.isValidZone(undefined)).toBe(false);
 });
 
 test("IANAZone.parseGMTOffset returns a number for a valid input", () => {


### PR DESCRIPTION
This addresses #973 (IANAZone.isValidZone(undefined) returns true).

`Intl.DateTimeFormat("en-US", { timeZone: zone }).format()` will succeed if `zone` is `undefined`.  `null`, and other non-`string` values for timeZone fail.

This adds a check to make sure `zone` is not undefined, as well as a few additional test cases for non-string values.