### PR TITLE
Test in Node 16 instead of 15

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [15.x]
+        node-version: [16.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Node 15 is no longer supported and 16 is now the "Current" version.