### PR TITLE
Set required node version to 12+

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "jsdelivr": "build/global/luxon.min.js",
   "unpkg": "build/global/luxon.min.js",
   "engines": {
-    "node": "*"
+    "node": ">=12"
   },
   "files": [
     "build/node/luxon.js",


### PR DESCRIPTION
Since Luxon only supports node v12+ (https://moment.github.io/luxon/#/upgrading?id=environment-support), this PR changes `engines.node` from `*` to `>=12`.