### PR TITLE
Add iso8601 for "Generally supported calendars"

### DIFF
--- a/docs/calendars.md
+++ b/docs/calendars.md
@@ -47,6 +47,7 @@ DateTime.fromObject({ outputCalendar: c }).toLocaleString(DateTime.DATE_FULL);
 | indian   | Asvina 2, 1939 Saka      |
 | islamic  | Muharram 4, 1439 AH      |
 | islamicc | Muharram 3, 1439 AH      |
+| iso8601  | September 24, 2017       |
 | japanese | September 24, 29 Heisei  |
 | persian  | Mehr 2, 1396 AP          |
 | roc      | September 24, 106 Minguo |


### PR DESCRIPTION
Sorry for my English and I'm Thai. 

It would be great since I try using locale `th` but do not need `buddhist` so I can use `iso8601` but [the document](https://moment.github.io/luxon/#/calendars?id=generally-supported-calendars) doesn't tell me about it. And I found for myself at [mdn](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#parameters) that I can use this to change Buddhist year into Christian year for my locale.

Sample of code below.

```ts
import { Settings } from 'luxon'

Settings.defaultLocale = 'th'
Settings.defaultZone = 'Asia/Bangkok'
Settings.defaultOutputCalendar = 'iso8601'
```

The purpose is sometimes in Thai would confuse between ISO year (Christian) and official year (Buddhist). So I decide to use ISO year instead like sample birthday of "10 ตุลาคม 2540" into "10 ตุลาคม 1997". And only this way to config this.