### PR TITLE
Add fromDurationLike method

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1,4 +1,4 @@
-import Duration, { friendlyDuration } from "./duration.js";
+import Duration from "./duration.js";
 import Interval from "./interval.js";
 import Settings from "./settings.js";
 import Info from "./info.js";
@@ -1382,7 +1382,7 @@ export default class DateTime {
    */
   plus(duration) {
     if (!this.isValid) return this;
-    const dur = friendlyDuration(duration);
+    const dur = Duration.fromDurationLike(duration);
     return clone(this, adjustTime(this, dur));
   }
 
@@ -1394,7 +1394,7 @@ export default class DateTime {
   */
   minus(duration) {
     if (!this.isValid) return this;
-    const dur = friendlyDuration(duration).negate();
+    const dur = Duration.fromDurationLike(duration).negate();
     return clone(this, adjustTime(this, dur));
   }
 

--- a/src/duration.js
+++ b/src/duration.js
@@ -247,6 +247,30 @@ export default class Duration {
   }
 
   /**
+   * Create a Duration from DurationLike.
+   *
+   * @param {Object | number | Duration} durationLike
+   * One of:
+   * - object with keys like 'years' and 'hours'.
+   * - number representing milliseconds
+   * - Duration instance
+   * @return {Duration}
+   */
+  static fromDurationLike(durationLike) {
+    if (isNumber(durationLike)) {
+      return Duration.fromMillis(durationLike);
+    } else if (Duration.isDuration(durationLike)) {
+      return durationLike;
+    } else if (typeof durationLike === "object") {
+      return Duration.fromObject(durationLike);
+    } else {
+      throw new InvalidArgumentError(
+        `Unknown duration argument ${durationLike} of type ${typeof durationLike}`
+      );
+    }
+  }
+
+  /**
    * Create a Duration from an ISO 8601 duration string.
    * @param {string} text - text to parse
    * @param {Object} opts - options for parsing
@@ -530,7 +554,7 @@ export default class Duration {
   plus(duration) {
     if (!this.isValid) return this;
 
-    const dur = friendlyDuration(duration),
+    const dur = Duration.fromDurationLike(duration),
       result = {};
 
     for (const k of orderedUnits) {
@@ -550,7 +574,7 @@ export default class Duration {
   minus(duration) {
     if (!this.isValid) return this;
 
-    const dur = friendlyDuration(duration);
+    const dur = Duration.fromDurationLike(duration);
     return this.plus(dur.negate());
   }
 
@@ -839,22 +863,5 @@ export default class Duration {
       }
     }
     return true;
-  }
-}
-
-/**
- * @private
- */
-export function friendlyDuration(durationish) {
-  if (isNumber(durationish)) {
-    return Duration.fromMillis(durationish);
-  } else if (Duration.isDuration(durationish)) {
-    return durationish;
-  } else if (typeof durationish === "object") {
-    return Duration.fromObject(durationish);
-  } else {
-    throw new InvalidArgumentError(
-      `Unknown duration argument ${durationish} of type ${typeof durationish}`
-    );
   }
 }

--- a/src/interval.js
+++ b/src/interval.js
@@ -1,5 +1,5 @@
 import DateTime, { friendlyDateTime } from "./datetime.js";
-import Duration, { friendlyDuration } from "./duration.js";
+import Duration from "./duration.js";
 import Settings from "./settings.js";
 import { InvalidArgumentError, InvalidIntervalError } from "./errors.js";
 import Invalid from "./impl/invalid.js";
@@ -106,7 +106,7 @@ export default class Interval {
    * @return {Interval}
    */
   static after(start, duration) {
-    const dur = friendlyDuration(duration),
+    const dur = Duration.fromDurationLike(duration),
       dt = friendlyDateTime(start);
     return Interval.fromDateTimes(dt, dt.plus(dur));
   }
@@ -118,7 +118,7 @@ export default class Interval {
    * @return {Interval}
    */
   static before(end, duration) {
-    const dur = friendlyDuration(duration),
+    const dur = Duration.fromDurationLike(duration),
       dt = friendlyDateTime(end);
     return Interval.fromDateTimes(dt.minus(dur), dt);
   }
@@ -333,7 +333,7 @@ export default class Interval {
    * @return {Array}
    */
   splitBy(duration) {
-    const dur = friendlyDuration(duration);
+    const dur = Duration.fromDurationLike(duration);
 
     if (!this.isValid || !dur.isValid || dur.as("milliseconds") === 0) {
       return [];

--- a/test/duration/create.test.js
+++ b/test/duration/create.test.js
@@ -90,3 +90,41 @@ test("Duration.fromObject is valid if providing options only", () => {
   expect(dur.milliseconds).toBe(0);
   expect(dur.isValid).toBe(true);
 });
+
+//------
+// .fromDurationLike()
+//-------
+
+it("Duration.fromDurationLike returns a Duration from millis", () => {
+  expect.assertions(2);
+
+  const result = Duration.fromDurationLike(1000);
+
+  expect(result).toBeInstanceOf(Duration);
+  expect(result).toMatchInlineSnapshot(`"PT1S"`);
+});
+
+it("Duration.fromDurationLike returns a Duration from object", () => {
+  expect.assertions(2);
+
+  const result = Duration.fromDurationLike({ hours: 1 });
+
+  expect(result).toBeInstanceOf(Duration);
+  expect(result.toObject()).toStrictEqual({ hours: 1 });
+});
+
+it("Duration.fromDurationLike returns passed Duration", () => {
+  expect.assertions(1);
+
+  const duration = Duration.fromObject({ hours: 1 });
+  const result = Duration.fromDurationLike(duration);
+
+  expect(result).toStrictEqual(duration);
+});
+
+it("Duration.fromDurationLike returns passed Duration", () => {
+  expect.assertions(1);
+
+  expect(() => Duration.fromDurationLike("foo")).toThrow();
+  expect(() => Duration.fromDurationLike(null)).toThrow();
+});

--- a/test/duration/create.test.js
+++ b/test/duration/create.test.js
@@ -96,35 +96,24 @@ test("Duration.fromObject is valid if providing options only", () => {
 //-------
 
 it("Duration.fromDurationLike returns a Duration from millis", () => {
-  expect.assertions(2);
-
-  const result = Duration.fromDurationLike(1000);
-
-  expect(result).toBeInstanceOf(Duration);
-  expect(result).toMatchInlineSnapshot(`"PT1S"`);
+  const dur = Duration.fromDurationLike(1000);
+  expect(dur).toBeInstanceOf(Duration);
+  expect(dur).toMatchInlineSnapshot(`"PT1S"`);
 });
 
 it("Duration.fromDurationLike returns a Duration from object", () => {
-  expect.assertions(2);
-
-  const result = Duration.fromDurationLike({ hours: 1 });
-
-  expect(result).toBeInstanceOf(Duration);
-  expect(result.toObject()).toStrictEqual({ hours: 1 });
+  const dur = Duration.fromDurationLike({ hours: 1 });
+  expect(dur).toBeInstanceOf(Duration);
+  expect(dur.toObject()).toStrictEqual({ hours: 1 });
 });
 
 it("Duration.fromDurationLike returns passed Duration", () => {
-  expect.assertions(1);
-
-  const duration = Duration.fromObject({ hours: 1 });
-  const result = Duration.fromDurationLike(duration);
-
-  expect(result).toStrictEqual(duration);
+  const durFromObject = Duration.fromObject({ hours: 1 });
+  const dur = Duration.fromDurationLike(durFromObject);
+  expect(dur).toStrictEqual(durFromObject);
 });
 
 it("Duration.fromDurationLike returns passed Duration", () => {
-  expect.assertions(1);
-
   expect(() => Duration.fromDurationLike("foo")).toThrow();
   expect(() => Duration.fromDurationLike(null)).toThrow();
 });


### PR DESCRIPTION
This PR moves the private `friendlyDuration` function to `Duration.fromDurationLike`.
`DurationLike` is a TS interface defined [here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/22d5e137fff20a3da5ba2c4937f10731a100a530/types/luxon/src/duration.d.ts#L60)

This change was suggested in #1057

Basically, no code was added, so bundle size remains the same.

## Why this is useful
This change allows to do things like this:
```ts
type Example = {
  durationProp: Duration
}

const createExample = (duration: DurationLike): Example => {
  return {
    durationProp: Duration.fromDurationLike(duration)
  }
}

const a = createExample(1000)
const b = createExample({ seconds: 5 })

// now we can compare a.durationProp and b.durationProp
```
