### PR TITLE
perf: Use memoized zone for universal zone validation

### DIFF
--- a/benchmarks/datetime.js
+++ b/benchmarks/datetime.js
@@ -54,6 +54,9 @@ function runDateTimeSuite() {
       .add("DateTime#toLocaleString", () => {
         dt.toLocaleString();
       })
+      .add("DateTime#toLocaleString in utc", () => {
+        dt.toUTC().toLocaleString();
+      })
       .add("DateTime#toRelativeCalendar", () => {
         dt.toRelativeCalendar({ base: DateTime.now(), locale: "fi" });
       })

--- a/src/impl/locale.js
+++ b/src/impl/locale.js
@@ -181,8 +181,7 @@ class PolyDateFormatter {
       //    - < Etc/GMT-14, > Etc/GMT+12, and 30-minute or 45-minute offsets are not part of tzdata
       const gmtOffset = -1 * (dt.offset / 60);
       const offsetZ = gmtOffset >= 0 ? `Etc/GMT+${gmtOffset}` : `Etc/GMT${gmtOffset}`;
-      const isOffsetZoneSupported = IANAZone.isValidZone(offsetZ);
-      if (dt.offset !== 0 && isOffsetZoneSupported) {
+      if (dt.offset !== 0 && IANAZone.create(offsetZ).valid) {
         z = offsetZ;
         this.dt = dt;
       } else {


### PR DESCRIPTION
When formatting to UTC IANAZone.isValidZone will construct a new Intl.DateTimeFormat for each call.

![luxon-isvalidzone](https://user-images.githubusercontent.com/51433/139398058-67a8cd87-2e84-4a06-8b31-630338593899.png)
