### PR TITLE
Duration support for fractional duration

### DIFF
--- a/src/duration.js
+++ b/src/duration.js
@@ -162,7 +162,7 @@ export function flattenValues(matrix, obj) {
     const currentValue = flattened[prop] || 0;
 
     if (!hasOwnProperty(obj, prop)) {
-      flattened[prop] = currentValue;
+      if (currentValue !== 0) flattened[prop] = currentValue;
       continue;
     }
 

--- a/src/duration.js
+++ b/src/duration.js
@@ -271,12 +271,14 @@ export default class Duration {
           obj === null ? "null" : typeof obj
         }`
       );
-      const normalizedObject = normalizeObject(obj, Duration.normalizeUnit);
-      const flattenedValues = flattenValues(
-        opts.conversionAccuracy === "casual" ? casualMatrix : accurateMatrix,
-        normalizedObject
-      );
     }
+
+    const normalizedObject = normalizeObject(obj, Duration.normalizeUnit);
+    const flattenedValues = flattenValues(
+      opts.conversionAccuracy === "casual" ? casualMatrix : accurateMatrix,
+      normalizedObject
+    );
+
     return new Duration({
       values: flattenedValues,
       loc: Locale.fromObject(opts),

--- a/src/duration.js
+++ b/src/duration.js
@@ -155,37 +155,6 @@ function normalizeValues(matrix, vals) {
   }, null);
 }
 
-export function flattenValues(matrix, obj) {
-  const flattened = {};
-  for (let i = 0; i < orderedUnits.length; i++) {
-    const prop = orderedUnits[i];
-    const inputValue = obj[prop];
-    const currentValue = flattened[prop] || 0;
-    const sum = (inputValue || 0) + currentValue;
-
-    if (isInteger(sum)) {
-      if (sum === 0) continue;
-      flattened[prop] = sum;
-      continue;
-    }
-
-    const integerPart = ~~sum;
-    const decimalPart = sum - integerPart;
-    flattened[prop] = integerPart;
-
-    if (i + 1 < orderedUnits.length) {
-      flattened[orderedUnits[i + 1]] = matrix[prop][orderedUnits[i + 1]] * decimalPart;
-      continue;
-    }
-
-    // truncate milliseconds
-    flattened[prop] = antiTrunc(sum);
-    continue;
-  }
-
-  return flattened;
-}
-
 /**
  * A Duration object represents a period of time, like "2 months" or "1 day, 1 hour". Conceptually, it's just a map of units to their quantities, accompanied by some additional configuration and methods for creating, parsing, interrogating, transforming, and formatting them. They can be used on their own or in conjunction with other Luxon types; for example, you can use {@link DateTime#plus} to add a Duration object to a DateTime, producing another DateTime.
  *
@@ -272,14 +241,8 @@ export default class Duration {
       );
     }
 
-    const normalizedObject = normalizeObject(obj, Duration.normalizeUnit);
-    const flattenedValues = flattenValues(
-      opts.conversionAccuracy === "casual" ? casualMatrix : accurateMatrix,
-      normalizedObject
-    );
-
     return new Duration({
-      values: flattenedValues,
+      values: normalizeObject(obj, Duration.normalizeUnit),
       loc: Locale.fromObject(opts),
       conversionAccuracy: opts.conversionAccuracy,
     });

--- a/src/duration.js
+++ b/src/duration.js
@@ -159,29 +159,28 @@ export function flattenValues(matrix, obj) {
   const flattened = {};
   for (let i = 0; i < orderedUnits.length; i++) {
     const prop = orderedUnits[i];
+    const inputValue = obj[prop];
     const currentValue = flattened[prop] || 0;
+    const sum = (inputValue || 0) + currentValue;
 
-    if (!hasOwnProperty(obj, prop)) {
-      if (currentValue !== 0) flattened[prop] = currentValue;
+    if (isInteger(sum)) {
+      if (sum === 0) continue;
+      flattened[prop] = sum;
       continue;
     }
 
-    if (!isInteger(obj[prop])) {
-      const integerPart = ~~obj[prop];
-      const decimalPart = obj[prop] - integerPart;
-      flattened[prop] = currentValue + integerPart;
+    const integerPart = ~~sum;
+    const decimalPart = sum - integerPart;
+    flattened[prop] = integerPart;
 
-      if (i + 1 < orderedUnits.length) {
-        flattened[orderedUnits[i + 1]] = matrix[prop][orderedUnits[i + 1]] * decimalPart;
-        continue;
-      }
-
-      // truncate milliseconds
-      flattened[prop] = currentValue + antiTrunc(obj[prop]);
+    if (i + 1 < orderedUnits.length) {
+      flattened[orderedUnits[i + 1]] = matrix[prop][orderedUnits[i + 1]] * decimalPart;
       continue;
     }
 
-    flattened[prop] = currentValue + obj[prop];
+    // truncate milliseconds
+    flattened[prop] = antiTrunc(sum);
+    continue;
   }
 
   return flattened;

--- a/src/duration.js
+++ b/src/duration.js
@@ -6,6 +6,7 @@ import { parseISODuration, parseISOTimeOnly } from "./impl/regexParser.js";
 import {
   asNumber,
   hasOwnProperty,
+  isInteger,
   isNumber,
   isUndefined,
   normalizeObject,
@@ -152,6 +153,38 @@ function normalizeValues(matrix, vals) {
       return previous;
     }
   }, null);
+}
+
+export function flattenValues(matrix, obj) {
+  const flattened = {};
+  for (let i = 0; i < orderedUnits.length; i++) {
+    const prop = orderedUnits[i];
+    const currentValue = flattened[prop] || 0;
+
+    if (!hasOwnProperty(obj, prop)) {
+      flattened[prop] = currentValue;
+      continue;
+    }
+
+    if (!isInteger(obj[prop])) {
+      const integerPart = ~~obj[prop];
+      const decimalPart = obj[prop] - integerPart;
+      flattened[prop] = currentValue + integerPart;
+
+      if (i + 1 < orderedUnits.length) {
+        flattened[orderedUnits[i + 1]] = matrix[prop][orderedUnits[i + 1]] * decimalPart;
+        continue;
+      }
+
+      // truncate milliseconds
+      flattened[prop] = currentValue + antiTrunc(obj[prop]);
+      continue;
+    }
+
+    flattened[prop] = currentValue + obj[prop];
+  }
+
+  return flattened;
 }
 
 /**

--- a/src/duration.js
+++ b/src/duration.js
@@ -17,7 +17,7 @@ import Settings from "./settings.js";
 const INVALID = "Invalid Duration";
 
 // unit conversion constants
-const lowOrderMatrix = {
+export const lowOrderMatrix = {
     weeks: {
       days: 7,
       hours: 7 * 24,
@@ -271,9 +271,14 @@ export default class Duration {
           obj === null ? "null" : typeof obj
         }`
       );
+      const normalizedObject = normalizeObject(obj, Duration.normalizeUnit);
+      const flattenedValues = flattenValues(
+        opts.conversionAccuracy === "casual" ? casualMatrix : accurateMatrix,
+        normalizedObject
+      );
     }
     return new Duration({
-      values: normalizeObject(obj, Duration.normalizeUnit),
+      values: flattenedValues,
       loc: Locale.fromObject(opts),
       conversionAccuracy: opts.conversionAccuracy,
     });

--- a/src/impl/regexParser.js
+++ b/src/impl/regexParser.js
@@ -5,6 +5,7 @@ import {
   parseMillis,
   ianaRegex,
   isUndefined,
+  parseFloating,
 } from "./util.js";
 import * as English from "./english.js";
 import FixedOffsetZone from "../zones/fixedOffsetZone.js";
@@ -125,7 +126,7 @@ const isoTimeOnly = RegExp(`^T?${isoTimeBaseRegex.source}$`);
 // ISO duration parsing
 
 const isoDuration =
-  /^-?P(?:(?:(-?\d{1,9})Y)?(?:(-?\d{1,9})M)?(?:(-?\d{1,9})W)?(?:(-?\d{1,9})D)?(?:T(?:(-?\d{1,9})H)?(?:(-?\d{1,9})M)?(?:(-?\d{1,20})(?:[.,](-?\d{1,9}))?S)?)?)$/;
+  /^-?P(?:(?:(-?\d{1,9}(?:\.\d{1,9})?)Y)?(?:(-?\d{1,9}(?:\.\d{1,9})?)M)?(?:(-?\d{1,9}(?:\.\d{1,9})?)W)?(?:(-?\d{1,9}(?:\.\d{1,9})?)D)?(?:T(?:(-?\d{1,9}(?:\.\d{1,9})?)H)?(?:(-?\d{1,9}(?:\.\d{1,9})?)M)?(?:(-?\d{1,20})(?:[.,](-?\d{1,9}))?S)?)?)$/;
 
 function extractISODuration(match) {
   const [s, yearStr, monthStr, weekStr, dayStr, hourStr, minuteStr, secondStr, millisecondsStr] =
@@ -139,13 +140,13 @@ function extractISODuration(match) {
 
   return [
     {
-      years: maybeNegate(parseInteger(yearStr)),
-      months: maybeNegate(parseInteger(monthStr)),
-      weeks: maybeNegate(parseInteger(weekStr)),
-      days: maybeNegate(parseInteger(dayStr)),
-      hours: maybeNegate(parseInteger(hourStr)),
-      minutes: maybeNegate(parseInteger(minuteStr)),
-      seconds: maybeNegate(parseInteger(secondStr), secondStr === "-0"),
+      years: maybeNegate(parseFloating(yearStr)),
+      months: maybeNegate(parseFloating(monthStr)),
+      weeks: maybeNegate(parseFloating(weekStr)),
+      days: maybeNegate(parseFloating(dayStr)),
+      hours: maybeNegate(parseFloating(hourStr)),
+      minutes: maybeNegate(parseFloating(minuteStr)),
+      seconds: maybeNegate(parseFloating(secondStr), secondStr === "-0"),
       milliseconds: maybeNegate(parseMillis(millisecondsStr), negativeSeconds),
     },
   ];

--- a/src/impl/util.js
+++ b/src/impl/util.js
@@ -108,6 +108,14 @@ export function parseInteger(string) {
   }
 }
 
+export function parseFloating(string) {
+  if (isUndefined(string) || string === null || string === "") {
+    return undefined;
+  } else {
+    return parseFloat(string);
+  }
+}
+
 export function parseMillis(fraction) {
   // Return undefined (instead of 0) in these cases, where fraction is not set
   if (isUndefined(fraction) || fraction === null || fraction === "") {

--- a/test/duration/create.test.js
+++ b/test/duration/create.test.js
@@ -34,8 +34,8 @@ test("Duration.fromObject sets all the fractional values", () => {
   expect(dur.years).toBe(1);
   expect(dur.months).toBe(2);
   expect(dur.days).toBe(3);
-  expect(dur.hours).toBe(4);
-  expect(dur.minutes).toBe(30);
+  expect(dur.hours).toBe(4.5);
+  expect(dur.minutes).toBe(0);
   expect(dur.seconds).toBe(0);
   expect(dur.milliseconds).toBe(0);
 });

--- a/test/duration/create.test.js
+++ b/test/duration/create.test.js
@@ -24,6 +24,22 @@ test("Duration.fromObject sets all the values", () => {
   expect(dur.milliseconds).toBe(7);
 });
 
+test("Duration.fromObject sets all the fractional values", () => {
+  const dur = Duration.fromObject({
+    years: 1,
+    months: 2,
+    days: 3,
+    hours: 4.5,
+  });
+  expect(dur.years).toBe(1);
+  expect(dur.months).toBe(2);
+  expect(dur.days).toBe(3);
+  expect(dur.hours).toBe(4);
+  expect(dur.minutes).toBe(30);
+  expect(dur.seconds).toBe(0);
+  expect(dur.milliseconds).toBe(0);
+});
+
 test("Duration.fromObject sets all the values from the object having string type values", () => {
   const dur = Duration.fromObject({
     years: "1",

--- a/test/duration/equality.test.js
+++ b/test/duration/equality.test.js
@@ -12,9 +12,21 @@ test("equals identically constructed", () => {
   expect(l1.equals(l2)).toBe(true);
 });
 
-test("equals identically constructed but one has sting type values", () => {
+test("equals identically constructed with fractional values", () => {
+  const l1 = Duration.fromObject({ years: 5.5, days: 6 }),
+    l2 = Duration.fromObject({ years: 5.5, days: 6 });
+  expect(l1.equals(l2)).toBe(true);
+});
+
+test("equals identically constructed but one has string type values", () => {
   const l1 = Duration.fromObject({ years: 5, days: 6 }),
     l2 = Duration.fromObject({ years: "5", days: "6" });
+  expect(l1.equals(l2)).toBe(true);
+});
+
+test("equals identically constructed but one has fractional string type values", () => {
+  const l1 = Duration.fromObject({ years: 5.5, days: 6 }),
+    l2 = Duration.fromObject({ years: "5.5", days: "6" });
   expect(l1.equals(l2)).toBe(true);
 });
 

--- a/test/duration/flattenValues.test.js
+++ b/test/duration/flattenValues.test.js
@@ -1,4 +1,4 @@
-import { flattenValues, casualMatrix } from "../../src/duration";
+import { flattenValues, casualMatrix, accurateMatrix } from "../../src/duration";
 
 test("flattenValues converts decimal days to hours", () => {
   const dur = flattenValues(casualMatrix, {
@@ -17,6 +17,23 @@ test("flattenValues converts in cascade", () => {
   expect(dur.days).toBe(1);
   expect(dur.hours).toBe(16);
   expect(dur.minutes).toBe(30);
+
+  const dur2 = flattenValues(casualMatrix, {
+    months: 1.5,
+  });
+  expect(dur2.months).toBe(1);
+  expect(dur2.weeks).toBe(2);
+
+  const dur3 = flattenValues(accurateMatrix, {
+    months: 1.5,
+  });
+  expect(dur3.months).toBe(1);
+  expect(dur3.weeks).toBe(2);
+  expect(dur3.days).toBe(1);
+  expect(dur3.hours).toBe(5);
+  expect(dur3.minutes).toBe(14);
+  expect(dur3.seconds).toBe(33);
+  expect(dur3.milliseconds).toBe(1);
 });
 
 test("flattenValues rounds milliseconds", () => {

--- a/test/duration/flattenValues.test.js
+++ b/test/duration/flattenValues.test.js
@@ -5,13 +5,8 @@ test("flattenValues converts decimal days to hours", () => {
     days: 1.5,
     hours: 4,
   });
-  expect(dur.years).toBe(0);
-  expect(dur.months).toBe(0);
   expect(dur.days).toBe(1);
   expect(dur.hours).toBe(16);
-  expect(dur.minutes).toBe(0);
-  expect(dur.seconds).toBe(0);
-  expect(dur.milliseconds).toBe(0);
 });
 
 test("flattenValues converts in cascade", () => {
@@ -19,13 +14,9 @@ test("flattenValues converts in cascade", () => {
     days: 1.5,
     hours: 4.5,
   });
-  expect(dur.years).toBe(0);
-  expect(dur.months).toBe(0);
   expect(dur.days).toBe(1);
   expect(dur.hours).toBe(16);
   expect(dur.minutes).toBe(30);
-  expect(dur.seconds).toBe(0);
-  expect(dur.milliseconds).toBe(0);
 });
 
 test("flattenValues rounds milliseconds", () => {
@@ -33,11 +24,6 @@ test("flattenValues rounds milliseconds", () => {
     seconds: 1.5,
     milliseconds: 100.5,
   });
-  expect(dur.years).toBe(0);
-  expect(dur.months).toBe(0);
-  expect(dur.days).toBe(0);
-  expect(dur.hours).toBe(0);
-  expect(dur.minutes).toBe(0);
   expect(dur.seconds).toBe(1);
   expect(dur.milliseconds).toBe(601);
 });

--- a/test/duration/flattenValues.test.js
+++ b/test/duration/flattenValues.test.js
@@ -1,0 +1,43 @@
+import { flattenValues, casualMatrix } from "../../src/duration";
+
+test("flattenValues converts decimal days to hours", () => {
+  const dur = flattenValues(casualMatrix, {
+    days: 1.5,
+    hours: 4,
+  });
+  expect(dur.years).toBe(0);
+  expect(dur.months).toBe(0);
+  expect(dur.days).toBe(1);
+  expect(dur.hours).toBe(16);
+  expect(dur.minutes).toBe(0);
+  expect(dur.seconds).toBe(0);
+  expect(dur.milliseconds).toBe(0);
+});
+
+test("flattenValues converts in cascade", () => {
+  const dur = flattenValues(casualMatrix, {
+    days: 1.5,
+    hours: 4.5,
+  });
+  expect(dur.years).toBe(0);
+  expect(dur.months).toBe(0);
+  expect(dur.days).toBe(1);
+  expect(dur.hours).toBe(16);
+  expect(dur.minutes).toBe(30);
+  expect(dur.seconds).toBe(0);
+  expect(dur.milliseconds).toBe(0);
+});
+
+test("flattenValues rounds milliseconds", () => {
+  const dur = flattenValues(casualMatrix, {
+    seconds: 1.5,
+    milliseconds: 100.5,
+  });
+  expect(dur.years).toBe(0);
+  expect(dur.months).toBe(0);
+  expect(dur.days).toBe(0);
+  expect(dur.hours).toBe(0);
+  expect(dur.minutes).toBe(0);
+  expect(dur.seconds).toBe(1);
+  expect(dur.milliseconds).toBe(601);
+});

--- a/test/duration/format.test.js
+++ b/test/duration/format.test.js
@@ -21,6 +21,20 @@ test("Duration#toISO fills out every field", () => {
   expect(dur().toISO()).toBe("P1Y2M1W3DT4H5M6.007S");
 });
 
+test("Duration#toISO fills out every field with fractional", () => {
+  const dur = Duration.fromObject({
+    years: 1.1,
+    months: 2.2,
+    weeks: 1.1,
+    days: 3.3,
+    hours: 4.4,
+    minutes: 5.5,
+    seconds: 6.6,
+    milliseconds: 7,
+  });
+  expect(dur.toISO()).toBe("P1.1Y2.2M1.1W3.3DT4.4H5.5M6.607S");
+});
+
 test("Duration#toISO creates a minimal string", () => {
   expect(Duration.fromObject({ years: 3, seconds: 45 }).toISO()).toBe("P3YT45S");
   expect(Duration.fromObject({ months: 4, seconds: 45 }).toISO()).toBe("P4MT45S");

--- a/test/duration/getters.test.js
+++ b/test/duration/getters.test.js
@@ -44,6 +44,24 @@ test("Duration#hours returns the hours", () => {
   expect(inv.hours).toBeFalsy();
 });
 
+test("Duration#hours returns the fractional hours", () => {
+  const localDur = Duration.fromObject({
+      years: 1,
+      quarters: 2,
+      months: 2,
+      days: 3,
+      hours: 4.5,
+      minutes: 5,
+      seconds: 6,
+      milliseconds: 7,
+      weeks: 8,
+    }),
+    localInv = Duration.invalid("because i say so");
+
+  expect(localDur.hours).toBe(4.5);
+  expect(localInv.hours).toBeFalsy();
+});
+
 test("Duration#minutes returns the minutes", () => {
   expect(dur.minutes).toBe(5);
   expect(inv.minutes).toBeFalsy();

--- a/test/duration/info.test.js
+++ b/test/duration/info.test.js
@@ -6,7 +6,7 @@ const dur = Duration.fromObject(
   {
     years: 1,
     months: 2,
-    days: 3,
+    days: 3.3,
   },
   {
     locale: "fr",
@@ -22,7 +22,7 @@ test("Duration#toObject returns the object", () => {
   expect(dur.toObject()).toEqual({
     years: 1,
     months: 2,
-    days: 3,
+    days: 3.3,
   });
 });
 
@@ -31,7 +31,7 @@ test("Duration#toObject accepts a flag to return config", () => {
     {
       years: 1,
       months: 2,
-      days: 3,
+      days: 3.3,
     },
     {
       locale: "fr",

--- a/test/duration/math.test.js
+++ b/test/duration/math.test.js
@@ -16,6 +16,17 @@ test("Duration#plus add straightforward durations", () => {
   expect(result.milliseconds).toBe(14);
 });
 
+test("Duration#plus add fractional durations", () => {
+  const first = Duration.fromObject({ hours: 4.2, minutes: 12, seconds: 2 }),
+    second = Duration.fromObject({ hours: 1, seconds: 6.8, milliseconds: 14 }),
+    result = first.plus(second);
+
+  expect(result.hours).toBeCloseTo(5.2, 8);
+  expect(result.minutes).toBe(12);
+  expect(result.seconds).toBeCloseTo(8.8, 8);
+  expect(result.milliseconds).toBe(14);
+});
+
 test("Duration#plus noops empty druations", () => {
   const first = Duration.fromObject({ hours: 4, minutes: 12, seconds: 2 }),
     second = Duration.fromObject({}),
@@ -82,6 +93,17 @@ test("Duration#minus subtracts durations", () => {
     result = first.minus(second);
 
   expect(result.hours).toBe(3);
+  expect(result.minutes).toBe(12);
+  expect(result.seconds).toBe(-4);
+  expect(result.milliseconds).toBe(-14);
+});
+
+test("Duration#minus subtracts fractional durations", () => {
+  const first = Duration.fromObject({ hours: 4.2, minutes: 12, seconds: 2 }),
+    second = Duration.fromObject({ hours: 1, seconds: 6, milliseconds: 14 }),
+    result = first.minus(second);
+
+  expect(result.hours).toBeCloseTo(3.2, 8);
   expect(result.minutes).toBe(12);
   expect(result.seconds).toBe(-4);
   expect(result.milliseconds).toBe(-14);

--- a/test/duration/parse.test.js
+++ b/test/duration/parse.test.js
@@ -65,6 +65,35 @@ test("Duration.fromISO can parse fractions of seconds", () => {
   });
 });
 
+test("Duration.fromISO can parse fractions", () => {
+  expect(Duration.fromISO("P1.5Y").toObject()).toEqual({
+    years: 1,
+    quarters: 2,
+  });
+  expect(Duration.fromISO("P1.5M").toObject()).toEqual({
+    months: 1,
+    weeks: 2,
+    days: 1,
+    hours: 5,
+    minutes: 14,
+    seconds: 33,
+    milliseconds: 1,
+  });
+  expect(Duration.fromISO("P1.5W").toObject()).toEqual({
+    weeks: 1,
+    days: 3,
+    hours: 12,
+  });
+  expect(Duration.fromISO("P1.5D").toObject()).toEqual({
+    days: 1,
+    hours: 12,
+  });
+  expect(Duration.fromISO("PT9.5H").toObject()).toEqual({
+    hours: 9,
+    minutes: 30,
+  });
+});
+
 const rejects = (s) => {
   expect(Duration.fromISO(s).isValid).toBe(false);
 };

--- a/test/duration/parse.test.js
+++ b/test/duration/parse.test.js
@@ -67,30 +67,19 @@ test("Duration.fromISO can parse fractions of seconds", () => {
 
 test("Duration.fromISO can parse fractions", () => {
   expect(Duration.fromISO("P1.5Y").toObject()).toEqual({
-    years: 1,
-    quarters: 2,
+    years: 1.5,
   });
   expect(Duration.fromISO("P1.5M").toObject()).toEqual({
-    months: 1,
-    weeks: 2,
-    days: 1,
-    hours: 5,
-    minutes: 14,
-    seconds: 33,
-    milliseconds: 1,
+    months: 1.5,
   });
   expect(Duration.fromISO("P1.5W").toObject()).toEqual({
-    weeks: 1,
-    days: 3,
-    hours: 12,
+    weeks: 1.5,
   });
   expect(Duration.fromISO("P1.5D").toObject()).toEqual({
-    days: 1,
-    hours: 12,
+    days: 1.5,
   });
   expect(Duration.fromISO("PT9.5H").toObject()).toEqual({
-    hours: 9,
-    minutes: 30,
+    hours: 9.5,
   });
 });
 

--- a/test/duration/set.test.js
+++ b/test/duration/set.test.js
@@ -20,6 +20,7 @@ test("Duration#set() sets the values", () => {
   expect(dur().set({ months: 2 }).months).toBe(2);
   expect(dur().set({ days: 2 }).days).toBe(2);
   expect(dur().set({ hours: 4 }).hours).toBe(4);
+  expect(dur().set({ hours: 4.5 }).hours).toBe(4.5);
   expect(dur().set({ minutes: 16 }).minutes).toBe(16);
   expect(dur().set({ seconds: 45 }).seconds).toBe(45);
   expect(dur().set({ milliseconds: 86 }).milliseconds).toBe(86);

--- a/test/duration/typecheck.test.js
+++ b/test/duration/typecheck.test.js
@@ -6,7 +6,7 @@ import { Duration } from "../../src/luxon";
 // #isDuration
 //-------
 test("Duration#isDuration return true for valid duration", () => {
-  const dur = Duration.fromObject({ hours: 1 });
+  const dur = Duration.fromObject({ hours: 1, minutes: 4.5 });
   expect(Duration.isDuration(dur)).toBe(true);
 });
 
@@ -19,6 +19,7 @@ test("Duration#isDuration return false for primitives", () => {
   expect(Duration.isDuration({})).toBe(false);
   expect(Duration.isDuration({ hours: 60 })).toBe(false);
   expect(Duration.isDuration(1)).toBe(false);
+  expect(Duration.isDuration(1.1)).toBe(false);
   expect(Duration.isDuration("")).toBe(false);
   expect(Duration.isDuration(null)).toBe(false);
   expect(Duration.isDuration()).toBe(false);

--- a/test/duration/units.test.js
+++ b/test/duration/units.test.js
@@ -46,6 +46,14 @@ test("Duration#shiftTo deconstructs decimal inputs", () => {
   expect(dur.minutes).toBeCloseTo(18, 8);
 });
 
+test("Duration#shiftTo deconstructs in cascade and tacks decimal onto the end", () => {
+  const dur = Duration.fromObject({ hours: 1.17 }).shiftTo("hours", "minutes", "seconds");
+  expect(dur.isValid).toBe(true);
+  expect(dur.hours).toBe(1);
+  expect(dur.minutes).toBe(10);
+  expect(dur.seconds).toBeCloseTo(12, 8);
+});
+
 test("Duration#shiftTo maintains invalidity", () => {
   const dur = Duration.invalid("because").shiftTo("years");
   expect(dur.isValid).toBe(false);


### PR DESCRIPTION
Improve duration with fractional support :
`Duration.fromObject({ days: 1.5 }) => { days: 1.5 }`
`Duration.fromISO("PT9.5H").toObject() => { hours: 9.5 }`

Closes #1058
Edit : I have updated this section to reflect the final result. 