### PR TITLE
issue 1046 remove useless test in info.test.js

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1568,6 +1568,8 @@ export default class DateTime {
     let fmt = format === "basic" ? "yyyyMMdd" : "yyyy-MM-dd";
     if (this.year > 9999) {
       fmt = "+" + fmt;
+    } else if (this.year < 0) {
+      fmt = "yy" + fmt;
     }
 
     return toTechFormat(this, fmt);

--- a/test/datetime/format.test.js
+++ b/test/datetime/format.test.js
@@ -65,6 +65,15 @@ test("DateTime#toISO() rounds fractional timezone minute offsets", () => {
   );
 });
 
+test("DateTime#toISO() displays 6 digits year for a negative year", () => {
+  expect(
+    DateTime.fromObject(
+      { year: -1, month: 1, day: 1, hour: 0, minute: 0, second: 0, millisecond: 53 },
+      { zone: "utc" }
+    ).toISO()
+  ).toBe("-000001-01-01T00:00:00.053Z");
+});
+
 //------
 // #toISODate()
 //------
@@ -93,12 +102,12 @@ test("DateTime#toISODate() returns ISO 8601 date in format [±YYYYY]", () => {
   ).toBe("-118040-05-25");
 });
 
-test("DateTime#toISODate() correctly pads negative years", () => {
+test("DateTime#toISODate() correctly pads negative years to 6 characters", () => {
   expect(DateTime.fromObject({ year: -1, month: 1, day: 1 }, { zone: "utc" }).toISODate()).toBe(
-    "-0001-01-01"
+    "-000001-01-01"
   );
   expect(DateTime.fromObject({ year: -10, month: 1, day: 1 }, { zone: "utc" }).toISODate()).toBe(
-    "-0010-01-01"
+    "-000010-01-01"
   );
 });
 

--- a/test/duration/info.test.js
+++ b/test/duration/info.test.js
@@ -2,18 +2,11 @@
 
 import { Duration } from "../../src/luxon";
 
-const dur = Duration.fromObject(
-  {
-    years: 1,
-    months: 2,
-    days: 3.3,
-  },
-  {
-    locale: "fr",
-    numberingSystem: "beng",
-    conversionAccuracy: "longterm",
-  }
-);
+const dur = Duration.fromObject({
+  years: 1,
+  months: 2,
+  days: 3.3,
+});
 
 //------
 // #toObject
@@ -24,21 +17,6 @@ test("Duration#toObject returns the object", () => {
     months: 2,
     days: 3.3,
   });
-});
-
-test("Duration#toObject accepts a flag to return config", () => {
-  expect(dur.toObject({ includeConfig: true })).toEqual(
-    {
-      years: 1,
-      months: 2,
-      days: 3.3,
-    },
-    {
-      locale: "fr",
-      numberingSystem: "beng",
-      conversionAccuracy: "longterm",
-    }
-  );
 });
 
 test("Duration#toObject returns an empty object for invalid durations", () => {


### PR DESCRIPTION
removed testing Duration.toObject() providing a configure flag set at true
Duration.toObject() does not take any argument IN

I've removed configuration values as well (locale, etc.) since they don't get tested anymore