### PR TITLE
Continuation of #1097

### DIFF
--- a/benchmarks/datetime.js
+++ b/benchmarks/datetime.js
@@ -24,11 +24,11 @@ function runDateTimeSuite() {
       .add("DateTime.fromSQL", () => {
         DateTime.fromSQL("2016-05-14 10:23:54.2346");
       })
-      .add("DateTime.fromString", () => {
-        DateTime.fromString("1982/05/25 09:10:11.445", "yyyy/MM/dd HH:mm:ss.SSS");
+      .add("DateTime.fromFormat", () => {
+        DateTime.fromFormat("1982/05/25 09:10:11.445", "yyyy/MM/dd HH:mm:ss.SSS");
       })
-      .add("DateTime.fromString with zone", () => {
-        DateTime.fromString("1982/05/25 09:10:11.445", "yyyy/MM/dd HH:mm:ss.SSS", {
+      .add("DateTime.fromFormat with zone", () => {
+        DateTime.fromFormat("1982/05/25 09:10:11.445", "yyyy/MM/dd HH:mm:ss.SSS", {
           zone: "America/Los_Angeles",
         });
       })

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -18,6 +18,7 @@ import {
   normalizeObject,
   roundTo,
   objToLocalTS,
+  padStart,
 } from "./impl/util.js";
 import { normalizeZone } from "./impl/zoneUtil.js";
 import diff from "./impl/diff.js";
@@ -1394,7 +1395,7 @@ export default class DateTime {
    * See {@link DateTime#plus}
    * @param {Duration|Object|number} duration - The amount to subtract. Either a Luxon Duration, a number of milliseconds, the object argument to Duration.fromObject()
    @return {DateTime}
-  */
+   */
   minus(duration) {
     if (!this.isValid) return this;
     const dur = Duration.fromDurationLike(duration).negate();
@@ -1548,12 +1549,87 @@ export default class DateTime {
    * @example DateTime.now().toISO({ format: 'basic' }) //=> '20170422T204705.335-0400'
    * @return {string}
    */
-  toISO(opts = {}) {
+  toISO({
+    format = "extended",
+    suppressSeconds = false,
+    suppressMilliseconds = false,
+    includeOffset = true,
+    allowZ = true,
+  } = {}) {
     if (!this.isValid) {
       return null;
     }
 
-    return `${this.toISODate(opts)}T${this.toISOTime(opts)}`;
+    const o = this;
+    const longFormat = Math.abs(o.c.year) > 9999;
+    if (format === "extended") {
+      let c = "";
+      if (longFormat && o.c.year >= 0) c += "+";
+      c += padStart(o.c.year, longFormat ? 6 : 4);
+      c += "-";
+      c += padStart(o.c.month);
+      c += "-";
+      c += padStart(o.c.day);
+      c += "T";
+      c += padStart(o.c.hour);
+      c += ":";
+      c += padStart(o.c.minute);
+      if (o.c.second !== 0 || !suppressSeconds) {
+        c += ":";
+        c += padStart(o.c.second);
+        if (o.c.millisecond !== 0 || !suppressMilliseconds) {
+          c += ".";
+          c += padStart(o.c.millisecond, 3);
+        }
+      }
+
+      if (includeOffset) {
+        if (o.isOffsetFixed && o.offset === 0 && allowZ) {
+          c += "Z";
+        } else if (o.o < 0) {
+          c += "-";
+          c += padStart(Math.trunc(-o.o / 60));
+          c += ":";
+          c += padStart(Math.trunc(-o.o % 60));
+        } else {
+          c += "+";
+          c += padStart(Math.trunc(o.o / 60));
+          c += ":";
+          c += padStart(Math.trunc(o.o % 60));
+        }
+      }
+      return c;
+    } else {
+      let c = "";
+      if (longFormat && o.c.year >= 0) c += "+";
+      c += padStart(o.c.year, longFormat ? 6 : 4);
+      c += padStart(o.c.month);
+      c += padStart(o.c.day);
+      c += "T";
+      c += padStart(o.c.hour);
+      c += padStart(o.c.minute);
+      if (o.c.second !== 0 || !suppressSeconds) {
+        c += padStart(o.c.second);
+        if (o.c.millisecond !== 0 || !suppressMilliseconds) {
+          c += ".";
+          c += padStart(o.c.millisecond, 3);
+        }
+      }
+      if (includeOffset) {
+        if (o.isOffsetFixed && o.offset === 0 && allowZ) {
+          c += "Z";
+        } else if (o.o < 0) {
+          c += "-";
+          c += padStart(Math.trunc(-o.o / 60));
+          c += padStart(Math.trunc(-o.o % 60));
+        } else {
+          c += "+";
+          c += padStart(Math.trunc(o.o / 60));
+          c += padStart(Math.trunc(o.o % 60));
+        }
+      }
+      return c;
+    }
   }
 
   /**

--- a/src/impl/util.js
+++ b/src/impl/util.js
@@ -87,17 +87,14 @@ export function floorMod(x, n) {
 }
 
 export function padStart(input, n = 2) {
-  const minus = input < 0 ? "-" : "";
-  const target = minus ? input * -1 : input;
-  let result;
-
-  if (target.toString().length < n) {
-    result = ("0".repeat(n) + target).slice(-n);
+  const isNeg = input < 0;
+  let padded;
+  if (isNeg) {
+    padded = "-" + ("" + -input).padStart(n, "0");
   } else {
-    result = target.toString();
+    padded = ("" + input).padStart(n, "0");
   }
-
-  return `${minus}${result}`;
+  return padded;
 }
 
 export function parseInteger(string) {

--- a/test/datetime/format.test.js
+++ b/test/datetime/format.test.js
@@ -65,6 +65,31 @@ test("DateTime#toISO() rounds fractional timezone minute offsets", () => {
   );
 });
 
+test("DateTime#toISO() handles long gregorian format", () => {
+  const negativeYear = dt.set({ year: 12345 });
+  expect(negativeYear.toISO()).toBe("+012345-05-25T09:23:54.123Z");
+});
+
+test("DateTime#toISO() handles negative years", () => {
+  const negativeYear = dt.set({ year: -12345 });
+  expect(negativeYear.toISO()).toBe("-012345-05-25T09:23:54.123Z");
+});
+
+test("DateTime#toISO() default to Z when timezone is 00:00", () => {
+  const negativeYear = dt.setZone("utc");
+  expect(negativeYear.toISO()).toBe("1982-05-25T09:23:54.123Z");
+});
+
+test("DateTime#toISO() renders 00:00 for non-offset but non utc datetimes", () => {
+  const negativeYear = dt.setZone("Africa/Abidjan");
+  expect(negativeYear.toISO()).toBe("1982-05-25T09:23:54.123+00:00");
+});
+
+test("DateTime#toISO() renders 00:00 when timezone is 00:00 and does not allowZ", () => {
+  const negativeYear = dt.setZone("utc");
+  expect(negativeYear.toISO({ allowZ: false })).toBe("1982-05-25T09:23:54.123+00:00");
+});
+
 //------
 // #toISODate()
 //------

--- a/test/datetime/format.test.js
+++ b/test/datetime/format.test.js
@@ -85,11 +85,6 @@ test("DateTime#toISO() renders 00:00 for non-offset but non utc datetimes", () =
   expect(negativeYear.toISO()).toBe("1982-05-25T09:23:54.123+00:00");
 });
 
-test("DateTime#toISO() renders 00:00 when timezone is 00:00 and does not allowZ", () => {
-  const negativeYear = dt.setZone("utc");
-  expect(negativeYear.toISO({ allowZ: false })).toBe("1982-05-25T09:23:54.123+00:00");
-});
-
 //------
 // #toISODate()
 //------
@@ -120,10 +115,10 @@ test("DateTime#toISODate() returns ISO 8601 date in format [±YYYYY]", () => {
 
 test("DateTime#toISODate() correctly pads negative years", () => {
   expect(DateTime.fromObject({ year: -1, month: 1, day: 1 }, { zone: "utc" }).toISODate()).toBe(
-    "-0001-01-01"
+    "-000001-01-01"
   );
   expect(DateTime.fromObject({ year: -10, month: 1, day: 1 }, { zone: "utc" }).toISODate()).toBe(
-    "-0010-01-01"
+    "-000010-01-01"
   );
 });
 


### PR DESCRIPTION
@gpaucot Added some commits:

 1. I really wanted to push the work into `toSQLDate` and `toSQLTime`. So I set up both your fully-inlined one and my refactor and benchmarked them against each other, then tweaked mine until it was within the benchmark's noise level.
 2. Admittedly, my code benefited from some tweaks to the logic, and once I backported those into the inlined code, that code got faster again. But only by a little, so I'm going to live with it.
 3. I also removed some no-longer-needed code and did some other cleanup

These were the logic changes relative to your PR:

 1. Turns out, we're supposed to always use 6-digit years for negative years. That's actually #951. That has a small perf advantage because it's quicker to compare `o.c.year > 9999 || o.c.year < 0` than it is to do `Math.abs(o.c.year) > 9999`. So we'll squash that bug by-the-by.
 2. You had logic for `allowZ`, but that's not actually an option on `toISO`. You always get Z for the UTC zone; the old code hardcoded into the call to the formatter. No real perf difference either way