### PR TITLE
Add whole second unix timestamp function

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1749,6 +1749,14 @@ export default class DateTime {
   toSeconds() {
     return this.isValid ? this.ts / 1000 : NaN;
   }
+  
+  /**
+   * Returns the epoch seconds (as a whole number) of this DateTime.
+   * @return {number}
+   */
+  toUnixInteger() {
+    return this.isValid ? Math.floor(this.ts / 1000) : NaN;
+  }
 
   /**
    * Returns an ISO 8601 representation of this DateTime appropriate for use in JSON.


### PR DESCRIPTION
fixes #1109

@icambron I used the function name toUnixInteger, but toUnix I guess works too. Just let me know and I'll tweak