### PR TITLE
Add luxon to console in /api-docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build-global": "babel-node tasks/buildGlobal.js",
     "jest": "jest",
     "test": "jest --coverage",
-    "api-docs": "mkdir -p build && documentation build src/luxon.js -f html -o build/api-docs",
+    "api-docs": "mkdir -p build && documentation build src/luxon.js -f html -o build/api-docs && sed -i.bak 's/<\\/body>/<script src=\"\\/global\\/luxon.js\"><\\/script><script>console.log(\"You can try Luxon right here using the `luxon` global, like `luxon.DateTime.now()`\");<\\/script><\\/body>/g' build/api-docs/index.html && rm build/api-docs/index.html.bak",
     "copy-site": "mkdir -p build && rsync -a docs/ build/docs && rsync -a site/ build",
     "site": "npm run api-docs && npm run copy-site",
     "format": "prettier --write 'src/**/*.js' 'test/**/*.js' 'benchmarks/*.js'",


### PR DESCRIPTION
Having `luxon` accessible in the console of https://moment.github.io/luxon/ is super useful to me -- however, it isn't available on /api-docs, where it is arguably even more useful. Many times, I've opened the console to try something in the API docs out, just to find that `luxon` isn't there. (Most of the time, I end up switching tabs back to the homepage to run it in the homepage console.) This PR injects `luxon.js` into /api-docs so it's accessible there.