### PR TITLE
Update Duration.negate() to not negate zeros

### DIFF
--- a/src/duration.js
+++ b/src/duration.js
@@ -766,7 +766,7 @@ export default class Duration {
     if (!this.isValid) return this;
     const negated = {};
     for (const k of Object.keys(this.values)) {
-      negated[k] = -this.values[k];
+      negated[k] = this.values[k] === 0 ? 0 : -this.values[k];
     }
     return clone(this, { values: negated }, true);
   }

--- a/test/datetime/diff.test.js
+++ b/test/datetime/diff.test.js
@@ -146,6 +146,25 @@ test("DateTime#diff sets all its units to 0 if the duration is empty", () => {
   expect(t.diff(t, "days").toObject()).toEqual({ days: 0 });
 });
 
+test("DateTime#diff sets units to 0 if second object is slightly larger", () => {
+  expect(
+    diffObjs(
+      { year: 2017, month: 6, day: 26, hour: 21, minute: 1, second: 2, millisecond: 1 },
+      { year: 2017, month: 6, day: 26, hour: 21, minute: 1, second: 2, millisecond: 2 },
+      ["years", "months", "weeks", "days", "hours", "minutes", "seconds", "milliseconds"]
+    )
+  ).toEqual({
+    years: 0,
+    months: 0,
+    weeks: 0,
+    days: 0,
+    hours: 0,
+    minutes: 0,
+    seconds: 0,
+    milliseconds: -1,
+  });
+});
+
 test("DateTime#diff puts fractional parts in the lowest order unit", () => {
   expect(
     diffObjs({ year: 2017, month: 7, day: 14 }, { year: 2016, month: 6, day: 16 }, [


### PR DESCRIPTION
Fixes https://github.com/moment/luxon/issues/1050

Appears when diffing two dates and the second date is larger. We negate all units, leading to confusing values such as `-0` for units with no difference.