### PR TITLE
Clarify the isDateTime docs

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -901,7 +901,7 @@ export default class DateTime {
   }
 
   /**
-   * Check if an object is a DateTime. Works across context boundaries
+   * Check if an object is an instance of DateTime. Works across context boundaries
    * @param {object} o
    * @return {boolean}
    */


### PR DESCRIPTION
Since the argument is an object, and `DateTime` is a generic term in addition to a Luxon type, I misinterpreted this to mean it would also validate strings and numbers. Maybe other people have been confused similarly.