### PR TITLE
add a new "YY" (uppercase yy) parsing option to strictly parse two digit year

### DIFF
--- a/docs/parsing.md
+++ b/docs/parsing.md
@@ -180,7 +180,7 @@ Because Luxon was able to parse the string without difficulty, the output is a l
 (Examples below given for `2014-08-06T13:07:04.054` considered as a local time in America/New_York). Note that many tokens supported by the [formatter](formatting.md) are **not** supported by the parser.
 
 | Standalone token | Format token | Description                                                    | Example                     |
-| ---------------- | ------------ | -------------------------------------------------------------- | --------------------------- |
+|------------------| ------------ |----------------------------------------------------------------| --------------------------- |
 | S                |              | millisecond, no padding                                        | `54`                        |
 | SSS              |              | millisecond, padded to 3                                       | `054`                       |
 | u                |              | fractional seconds, (5 is a half second, 54 is slightly more)  | `54`                        |
@@ -209,7 +209,8 @@ Because Luxon was able to parse the string without difficulty, the output is a l
 | MMM              | LLL          | month as an abbreviated localized string                       | `Aug`                       |
 | MMMM             | LLLL         | month as an unabbreviated localized string                     | `August`                    |
 | y                |              | year, 1-6 digits, very literally                               | `2014`                      |
-| yy               |              | two-digit year, interpreted as > 1960 (also accepts 4)         | `14`                        |
+| yy               |              | two or four digit year, interpreted as > 1960                  | `14`                        |
+| YY               |              | strictly two-digit year, interpreted as > 1960                 | `14`                        |
 | yyyy             |              | four-digit year                                                | `2014`                      |
 | yyyyy            |              | four- to six-digit years                                       | `10340`                     |
 | yyyyyy           |              | six-digit years                                                | `010340`                    |

--- a/src/impl/tokenParser.js
+++ b/src/impl/tokenParser.js
@@ -81,6 +81,8 @@ function unitForToken(token, loc) {
           return intUnit(oneToSix);
         case "yy":
           return intUnit(twoToFour, untruncateYear);
+        case "YY":
+          return intUnit(two, untruncateYear);
         case "yyyy":
           return intUnit(four);
         case "yyyyy":
@@ -303,6 +305,7 @@ function dateTimeFromMatches(matches) {
       case "M":
         return "month";
       case "y":
+      case "Y":
         return "year";
       case "E":
       case "c":

--- a/test/datetime/tokenParse.test.js
+++ b/test/datetime/tokenParse.test.js
@@ -304,6 +304,25 @@ test("DateTime.fromFormat() parses quarters", () => {
   expect(DateTime.fromFormat("2019Q04", "yyyy'Q'qq").month).toBe(10);
 });
 
+test("DateTime.fromFormat() parses basic two-digit year without separators", () => {
+  const i = DateTime.fromFormat("220316", "YYMMdd");
+  expect(i.year).toBe(2022);
+  expect(i.month).toBe(3);
+  expect(i.day).toBe(16);
+});
+
+test("DateTime.fromFormat() parses full two-digit year without separators", () => {
+  const i = DateTime.fromFormat("22031609025910", "YYMMddHHmmssu");
+  expect(i.year).toBe(2022);
+  expect(i.month).toBe(3);
+  expect(i.day).toBe(16);
+
+  expect(i.hour).toBe(9);
+  expect(i.minute).toBe(2);
+  expect(i.second).toBe(59);
+  expect(i.millisecond).toBe(100);
+});
+
 test("DateTime.fromFormat() makes trailing periods in month names optional", () => {
   const i = DateTime.fromFormat("janv 25 1982", "LLL dd yyyy", {
     locale: "fr",


### PR DESCRIPTION
the current lowercase "yy" also accepts 4-digits, which fails if the date has no separators and other not-strict length tokens in it.

eg. the date "22031609025910" fails to parse with "yyMMddHHmmssuu" -> reason: "unit out of range", explanation: "you specified 31 (of type number) as a month, which is invalid"

This commit adds a new token "YYYY" (instead of the lowercase "yyyy") which strictly limits the parser to 2 digit years. Also adds a test.

Request for Feedback: also add uppercase variants for the other token settings, so that it is more coherent? 
