### PR TITLE
Correctly calculate first-century weekdays

### DIFF
--- a/src/impl/conversions.js
+++ b/src/impl/conversions.js
@@ -20,7 +20,7 @@ function unitOutOfRange(unit, value) {
 }
 
 function dayOfWeek(year, month, day) {
-  const js = new Date(Date.UTC(year, month - 1, day)).getUTCDay();
+  const js = new Date(Date.UTC((year % 400) + 800, month - 1, day)).getUTCDay();
   return js === 0 ? 7 : js;
 }
 

--- a/test/datetime/getters.test.js
+++ b/test/datetime/getters.test.js
@@ -73,6 +73,20 @@ test("DateTime#weekday returns the weekday", () => {
   expect(dateTime.weekday).toBe(2);
 });
 
+test("DateTime#weekday returns the weekday for first-century years", () => {
+  const dt = DateTime.fromObject({ year: 43, month: 4, day: 4 });
+  expect(dt.weekday).toBe(6);
+  // test again bc caching
+  expect(dt.weekday).toBe(6);
+});
+
+test("DateTime#weekday returns the weekday for BCE years", () => {
+  const dt = DateTime.fromObject({ year: -584, month: 2, day: 14 });
+  expect(dt.weekday).toBe(3);
+  // test again bc caching
+  expect(dt.weekday).toBe(3);
+});
+
 //------
 // weekdayShort/weekdayLong
 //------


### PR DESCRIPTION
Fixes #1167.

The `dayOfWeek` method uses `Date.UTC`, which is [documented](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#interpretation_of_two-digit_years) to interpret a two-digit year as being a 20th century year. That is, `Date.UTC` interprets the year `43` as `1943` rather than as `0043`. Luxon, however, interprets the year `43` as `0043`, as documented by the fact that `DateTime.fromObject({year: 43}).year` is `43`, not `1943`.

### A mathematical trick
This PR resolves that issue using a simple mathematical trick, and confirms the desired behaviour with a few tests. The mathematical trick relies on the fact that weekdays in the Gregorian calendar repeat exactly every 400 years, and therefore the weekday does not change if we do `year % 400` or `year + 400`. We have to consider that negative years are also valid, and therefore we cannot simply do `year + 400` to map `43` to `443`, because in that case the year `-357` would still have this bug (since `-357 + 400 = 43`). The mathematical trick works by doing `year % 400`, which brings all years into the range `[-399, 399]`, and than adding 800 to move the range to `[401, 1199]`. This ensures that we never give a two-digit value to `Date.UTC`.
| `year` | `year % 400` | `(year % 400) + 800` |
| --- | --- | --- |
| 2022 | 22 | 822 |
| 43 | 43 | 843 |
| 1938 | 338 | 1138 |
| -14 | -14 | 786 |
| -581 | -181 | 619 |

### An alternative
An alternative, which would require a bit more code, would have been to write
```javascript
const date = new Date(0, month - 1, day);
date.setFullYear(year);
const js = new Date(date.getUTCMilliseconds()).getUTCDay();
return js === 0 ? 7 : js;
```
I think this code is unwieldier, and I'm not entirely sure it works correctly with timezones. I'd love to hear your opinion on this.