### PR TITLE
fix: change NBSP regex to a non-matching group #1169

### DIFF
--- a/src/impl/tokenParser.js
+++ b/src/impl/tokenParser.js
@@ -13,7 +13,7 @@ function intUnit(regex, post = (i) => i) {
 }
 
 const NBSP = String.fromCharCode(160);
-const spaceOrNBSP = `( |${NBSP})`;
+const spaceOrNBSP = `[ ${NBSP}]`;
 const spaceOrNBSPRegExp = new RegExp(spaceOrNBSP, "g");
 
 function fixListRegex(s) {


### PR DESCRIPTION
Some languages can have spaces or non-breakable spaces in the month definition.
This lead to creating a regex with more capturing groups than it should.

For example, `tháng 3` is `mars` in Vietnamese and contains a space. (see #1169)
And if you try to parse this month using: `DateTime.fromFormat("tháng 3 2022", "MMMM yyyy", {locale: "vi-VN"})`
It will create the following regex: `/^(tháng( | )1|tháng( | )...)(\d{4})$/i`
Which has a capturing group for each space.

After this commit, it will create the following regex instead: `/^(tháng[  ]1|tháng[  ]...)(\d{4})$/i`
So it does not create additional capturing groups.