### PR TITLE
Add condition for system setZone

### DIFF
--- a/src/impl/zoneUtil.js
+++ b/src/impl/zoneUtil.js
@@ -8,6 +8,7 @@ import FixedOffsetZone from "../zones/fixedOffsetZone.js";
 import InvalidZone from "../zones/invalidZone.js";
 
 import { isUndefined, isString, isNumber } from "./util.js";
+import SystemZone from "../zones/systemZone.js";
 
 export function normalizeZone(input, defaultZone) {
   let offset;
@@ -17,7 +18,8 @@ export function normalizeZone(input, defaultZone) {
     return input;
   } else if (isString(input)) {
     const lowered = input.toLowerCase();
-    if (lowered === "local" || lowered === "system") return defaultZone;
+    if (lowered === "local" || lowered === "default") return defaultZone;
+    else if (lowered === "system") return SystemZone.instance;
     else if (lowered === "utc" || lowered === "gmt") return FixedOffsetZone.utcInstance;
     else return FixedOffsetZone.parseSpecifier(lowered) || IANAZone.create(input);
   } else if (isNumber(input)) {

--- a/src/impl/zoneUtil.js
+++ b/src/impl/zoneUtil.js
@@ -18,8 +18,8 @@ export function normalizeZone(input, defaultZone) {
     return input;
   } else if (isString(input)) {
     const lowered = input.toLowerCase();
-    if (lowered === "local" || lowered === "default") return defaultZone;
-    else if (lowered === "system") return SystemZone.instance;
+    if (lowered === "default") return defaultZone;
+    else if (lowered === "local" || lowered === "system") return SystemZone.instance;
     else if (lowered === "utc" || lowered === "gmt") return FixedOffsetZone.utcInstance;
     else return FixedOffsetZone.parseSpecifier(lowered) || IANAZone.create(input);
   } else if (isNumber(input)) {

--- a/test/datetime/zone.test.js
+++ b/test/datetime/zone.test.js
@@ -83,9 +83,14 @@ test('DateTime#setZone accepts "local"', () => {
   expect(zoned.offset).toBe(DateTime.local().offset);
 });
 
-test('DateTime#setZone accepts "system" and uses the default zone', () => {
+test('DateTime#setZone accepts "system" and uses the system zone', () => {
+  const systemZone = Settings.defaultZone.name;
+  expect(DateTime.utc().setZone("system").zoneName).toBe(systemZone);
+});
+
+test('DateTime#setZone accepts "default" and uses the default zone', () => {
   Helpers.withDefaultZone("Europe/Paris", () => {
-    expect(DateTime.utc().setZone("system").zoneName).toBe("Europe/Paris");
+    expect(DateTime.utc().setZone("default").zoneName).toBe("Europe/Paris");
   });
 });
 

--- a/test/info/zones.test.js
+++ b/test/info/zones.test.js
@@ -107,9 +107,11 @@ test("Info.normalizeZone converts null and undefined to default Zone", () => {
   expect(Info.normalizeZone(undefined)).toBe(Settings.defaultZone);
 });
 
-test("Info.normalizeZone converts local to default Zone", () => {
+// Local zone no longer refers to default one but behaves as system
+// As per Docker Container, zone is America/New_York
+test("Info.normalizeZone converts local to system Zone", () => {
   expect(Info.normalizeZone("local")).toBe(Settings.defaultZone);
-  Helpers.withDefaultZone("Europe/Paris", () => {
-    expect(Info.normalizeZone("local").name).toBe("Europe/Paris");
+  Helpers.withDefaultZone("America/New_York", () => {
+    expect(Info.normalizeZone("local").name).toBe("America/New_York");
   });
 });


### PR DESCRIPTION
**What is this about:**
The original issue that led to creating this PR was `setZone('system')` is using the Timezone in `Settings.defaultZone`, not the browser Timezone (https://github.com/moment/luxon/issues/1182), the name is pretty self-explanatory.

**Changes in this PR:**

- added a condition for `system` to return `SystemZone.instance` along with `local`
- added a condition for `defaultZone` to accept also `default` parameter
- Fixed deprecated tests that took local zone as default while setting non-system one, as per "local" is a legacy name for "system"
- Add test for `setZone()` using the `system` zone