### PR TITLE
#1183 Fixing "make DateTime object available through the dev console in the docs site"

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build-global": "babel-node tasks/buildGlobal.js",
     "jest": "jest",
     "test": "jest --coverage",
-    "api-docs": "mkdir -p build && documentation build src/luxon.js -f html -o build/api-docs && sed -i.bak 's/<\\/body>/<script src=\"\\/global\\/luxon.js\"><\\/script><script>console.log(\"You can try Luxon right here using the `luxon` global, like `luxon.DateTime.now()`\");<\\/script><\\/body>/g' build/api-docs/index.html && rm build/api-docs/index.html.bak",
+    "api-docs": "mkdir -p build && documentation build src/luxon.js -f html -o build/api-docs && sed -i.bak 's/<\\/body>/<script src=\"\\..\\/global\\/luxon.js\"><\\/script><script>console.log(\"You can try Luxon right here using the `luxon` global, like `luxon.DateTime.now()`\");<\\/script><\\/body>/g' build/api-docs/index.html && rm build/api-docs/index.html.bak",
     "copy-site": "mkdir -p build && rsync -a docs/ build/docs && rsync -a site/ build",
     "site": "npm run api-docs && npm run copy-site",
     "format": "prettier --write 'src/**/*.js' 'test/**/*.js' 'benchmarks/*.js'",


### PR DESCRIPTION
### Problem
The `DateTime` object isn't available on the generated api-docs site's dev console

### Solution
Looks like the path to `/global/luxon.js` was incorrect, causing a 404

- This is my first time contributing to open source, so any feedback is appreciated :) 
- Appreciate the work everyone's put into this repo!