### PR TITLE
Add support for ESM-style Node imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,12 @@
     "immutable"
   ],
   "repository": "https://github.com/moment/luxon",
+  "exports": {
+    ".": {
+      "import": "./src/luxon.js",
+      "require": "./build/node/luxon.js"
+    }
+  },
   "scripts": {
     "build": "babel-node tasks/buildAll.js",
     "build-node": "babel-node tasks/buildNode.js",
@@ -21,6 +27,7 @@
     "format-check": "prettier --check 'src/**/*.js' 'test/**/*.js' 'benchmarks/*.js'",
     "benchmark": "babel-node benchmarks/index.js",
     "codecov": "codecov",
+    "prepack": "babel-node tasks/buildAll.js",
     "prepare": "husky install"
   },
   "lint-staged": {

--- a/src/package.json
+++ b/src/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
Importing `luxon` in a modern Node ESM project with `"type": "module"` causes the following error. 

```
Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
```

Aside from changing the build configuration of this project, these changes are an unobtrusive way to support ESM-style Node projects. This PR will possibly close https://github.com/moment/luxon/issues/252 too.