### PR TITLE
Duration support custom matrix

### DIFF
--- a/src/duration.js
+++ b/src/duration.js
@@ -173,6 +173,11 @@ export default class Duration {
    * @private
    */
   constructor(config) {
+    if (config.conversionAccuracy && config.matrix)
+      throw new Error(
+        "You cannot use a custom matrix along with the `conversionAccuracy` config property"
+      );
+
     const accurate = config.conversionAccuracy === "longterm" || false;
     let matrix = accurate ? accurateMatrix : casualMatrix;
 

--- a/src/duration.js
+++ b/src/duration.js
@@ -1,4 +1,9 @@
-import { InvalidArgumentError, InvalidDurationError, InvalidUnitError } from "./errors.js";
+import {
+  ConflictingSpecificationError,
+  InvalidArgumentError,
+  InvalidDurationError,
+  InvalidUnitError,
+} from "./errors.js";
 import Formatter from "./impl/formatter.js";
 import Invalid from "./impl/invalid.js";
 import Locale from "./impl/locale.js";
@@ -174,7 +179,7 @@ export default class Duration {
    */
   constructor(config) {
     if (config.conversionAccuracy && config.matrix)
-      throw new Error(
+      throw new ConflictingSpecificationError(
         "You cannot use a custom matrix along with the `conversionAccuracy` config property"
       );
 

--- a/test/datetime/math.test.js
+++ b/test/datetime/math.test.js
@@ -155,36 +155,6 @@ test("DateTime#plus supports positive and negative duration units", () => {
   expect(d.plus({ years: 0.5, days: -1.5 })).toEqual(d.plus({ years: 0.5 }).plus({ days: -1.5 }));
 });
 
-test("DateTime#plus behave correctly when using Duration with custom matrix", () => {
-  const businessMatrix = {
-    ...casualMatrix,
-    months: {
-      weeks: 4,
-      days: 22,
-      hours: 22 * 7,
-      minutes: 22 * 7 * 60,
-      seconds: 22 * 7 * 60 * 60,
-      milliseconds: 22 * 7 * 60 * 60 * 1000,
-    },
-    weeks: {
-      days: 5,
-      hours: 5 * 7,
-      minutes: 5 * 7 * 60,
-      seconds: 5 * 7 * 60 * 60,
-      milliseconds: 5 * 7 * 60 * 60 * 1000,
-    },
-    days: {
-      hours: 7,
-      minutes: 7 * 60,
-      seconds: 7 * 60 * 60,
-      milliseconds: 7 * 60 * 60 * 1000,
-    },
-  };
-
-  const d = DateTime.fromISO("2020-01-08T12:34");
-  const dur = Duration.fromObject({ days: 2 }, { matrix: businessMatrix });
-});
-
 //------
 // #minus()
 //------

--- a/test/datetime/math.test.js
+++ b/test/datetime/math.test.js
@@ -1,6 +1,7 @@
 /* global test expect */
 
 import { DateTime, Duration } from "../../src/luxon";
+import { casualMatrix } from "../../src/duration";
 
 function createDateTime() {
   return DateTime.fromObject({
@@ -152,6 +153,36 @@ test("DateTime#plus supports positive and negative duration units", () => {
   expect(d.plus({ months: 1, days: -1 })).toEqual(d.plus({ months: 1 }).plus({ days: -1 }));
   expect(d.plus({ years: 4, days: -1 })).toEqual(d.plus({ years: 4 }).plus({ days: -1 }));
   expect(d.plus({ years: 0.5, days: -1.5 })).toEqual(d.plus({ years: 0.5 }).plus({ days: -1.5 }));
+});
+
+test("DateTime#plus behave correctly when using Duration with custom matrix", () => {
+  const businessMatrix = {
+    ...casualMatrix,
+    months: {
+      weeks: 4,
+      days: 22,
+      hours: 22 * 7,
+      minutes: 22 * 7 * 60,
+      seconds: 22 * 7 * 60 * 60,
+      milliseconds: 22 * 7 * 60 * 60 * 1000,
+    },
+    weeks: {
+      days: 5,
+      hours: 5 * 7,
+      minutes: 5 * 7 * 60,
+      seconds: 5 * 7 * 60 * 60,
+      milliseconds: 5 * 7 * 60 * 60 * 1000,
+    },
+    days: {
+      hours: 7,
+      minutes: 7 * 60,
+      seconds: 7 * 60 * 60,
+      milliseconds: 7 * 60 * 60 * 1000,
+    },
+  };
+
+  const d = DateTime.fromISO("2020-01-08T12:34");
+  const dur = Duration.fromObject({ days: 2 }, { matrix: businessMatrix });
 });
 
 //------

--- a/test/duration/customMatrix.test.js
+++ b/test/duration/customMatrix.test.js
@@ -1,0 +1,49 @@
+/* global test expect */
+
+import { Duration } from "../../src/luxon";
+import { casualMatrix } from "../../src/duration";
+
+const businessMatrix = {
+  ...casualMatrix,
+  months: {
+    weeks: 4,
+    days: 22,
+    hours: 22 * 7,
+    minutes: 22 * 7 * 60,
+    seconds: 22 * 7 * 60 * 60,
+    milliseconds: 22 * 7 * 60 * 60 * 1000,
+  },
+  weeks: {
+    days: 5,
+    hours: 5 * 7,
+    minutes: 5 * 7 * 60,
+    seconds: 5 * 7 * 60 * 60,
+    milliseconds: 5 * 7 * 60 * 60 * 1000,
+  },
+  days: {
+    hours: 7,
+    minutes: 7 * 60,
+    seconds: 7 * 60 * 60,
+    milliseconds: 7 * 60 * 60 * 1000,
+  },
+};
+
+const convert = (amt, from, to) =>
+  Duration.fromObject({ [from]: amt }, { matrix: businessMatrix }).as(to);
+
+test("One day is made of 7 hours", () => {
+  expect(convert(1, "days", "hours")).toBeCloseTo(7, 4);
+  expect(convert(7, "hours", "days")).toBeCloseTo(1, 4);
+});
+
+test("One and a half week is made of 7 days 3 hours and 30 minutes", () => {
+  const dur = Duration.fromObject({ weeks: 1.5 }, { matrix: businessMatrix }).shiftTo(
+    "days",
+    "hours",
+    "minutes"
+  );
+
+  expect(dur.days).toBeCloseTo(7, 4);
+  expect(dur.hours).toBeCloseTo(3, 4);
+  expect(dur.minutes).toBeCloseTo(30, 4);
+});


### PR DESCRIPTION
Duration for businesses days are not calendar durations. Meaning that a day is 7 or 8 hours of work and a week probably 5 days.
So if I say a task is going to take 2 days, it means 16 hours of work.

In order to solve that I've added the support for custom matrix for `Duration`. Doing so the `shiftTo` method can transform units as we want it to.

There is a problem is with `DateTime.plus()`. I have noticed it shifts everything to milliseconds to move the clock forward. While I understand why, it raises an issue because it doesn't account for the leap in time between days for exemple. 

`2 days means 14 hours means 840 minutes means 50400 seconds means 50,400,000 millis` according to the duration matrix.

However if you add 2 days to `2022-06-15 05:00` you expect it to move forwards to `2022-06-17 05:00` and not `2022-06-15 19:00`. 

This behaviour, of course falls into a plugin's responsibility.

In order to be able to create such plugin (or extend the existing ones like https://github.com/amaidah/luxon-business-days) I would need the `Duration` to be able to accept a custom matrix. 

Hence this PR.
It's tiny so it doesn't bloat the lib, but it opens more room for extension by plugins.

What do you think ?