### PR TITLE
[package.json] Add ./package.json to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     ".": {
       "import": "./src/luxon.js",
       "require": "./build/node/luxon.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "build": "babel-node tasks/buildAll.js",


### PR DESCRIPTION
This PR fixes the compatibility between react-native and the last `luxon` versions (broken since [v2.5.0](https://github.com/moment/luxon/releases/tag/2.5.0)).

It adds the `package.json` to the exports section
```diff
  "exports": {
    ".": {
      "import": "./src/luxon.js",
      "require": "./build/node/luxon.js"
    },
+   "./package.json": "./package.json",
  },
```

It is something you can find in other popular libraries that have to deal with multiple js environments and bundlers, such as `react-native`.
Something similar happened to the [`uuidjs/uuid`](https://github.com/uuidjs/uuid) repository:
 - [Issue](https://github.com/uuidjs/uuid/issues/444)
 - [PR](https://github.com/uuidjs/uuid/pull/449)
 - [Release](https://github.com/uuidjs/uuid/blob/16e9cc9017663a24588c4925bb3e63ae624ad1d4/CHANGELOG.md#bug-fixes-3)
 - [Source code now](https://github.com/uuidjs/uuid/blob/d0d6e834d4a557cd092e7273839b0106f1825d2f/package.json#L30)


This PR will close https://github.com/moment/luxon/issues/1238