### PR TITLE
Update parsing docs to show syntax for literals

### DIFF
--- a/docs/parsing.md
+++ b/docs/parsing.md
@@ -236,3 +236,4 @@ Because Luxon was able to parse the string without difficulty, the output is a l
 | ff               |              | less short localized date and time                             | `Aug 6, 2014, 1:07 PM`      |
 | F                |              | short localized date and time with seconds                     | `8/6/2014, 1:07:04 PM`      |
 | FF               |              | less short localized date and time with seconds                | `Aug 6, 2014, 1:07:04 PM`   |
+| '                |              | literal start/end, characters between are not tokenized        | `'T'`                       |


### PR DESCRIPTION
## Why
I could not find a location within the docs where it explains the escape/literal syntax for `fromFormat` when literal values are included in the parsed string (e.g. `T` in `2022-03-15T11:11:11.111Z`). I was able to figure it out by looking at the tests in [`tokenParse.test.js`](https://github.com/moment/luxon/blob/master/test/datetime/tokenParse.test.js#L569), so thought I would bubble it up into the docs for other users.

## What
Added a row to the token table explaining `'` is the token for starting and ending a literal. Albeit this a little weird as the literals aren't technically tokens, but `'` technically is. I can move it to be a part of the paragraph if the core maintainers prefer this. Just let me know!