### PR TITLE
Update link to CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ See [contributing](CONTRIBUTING.md).
 [test-coverage-url]: https://codecov.io/gh/moment/luxon
 [test-coverage-image]: https://codecov.io/gh/moment/luxon/branch/master/graph/badge.svg
 
-[contributing-url]: https://github.com/moment/luxon/blob/master/contributing.md
+[contributing-url]: https://github.com/moment/luxon/blob/master/CONTRIBUTING.md
 [contributing-image]: https://img.shields.io/badge/PRs-welcome-brightgreen.svg
 
 [phasers-image]: https://img.shields.io/badge/phasers-stun-brightgreen.svg


### PR DESCRIPTION
The old one gives 404. This link is used for the PR Welcome badge:

<img width="138" alt="Screen Shot 2022-08-26 at 16 51 25" src="https://user-images.githubusercontent.com/22447849/186918955-0694a1eb-ffa8-43e4-aeab-dfb5e2823041.png">

