### PR TITLE
added .js to formatter import in info.js

### DIFF
--- a/src/info.js
+++ b/src/info.js
@@ -3,7 +3,7 @@ import Settings from "./settings.js";
 import Locale from "./impl/locale.js";
 import IANAZone from "./zones/IANAZone.js";
 import { normalizeZone } from "./impl/zoneUtil.js";
-import Formatter from "./impl/formatter";
+import Formatter from "./impl/formatter.js";
 
 import { hasRelative } from "./impl/util.js";
 


### PR DESCRIPTION
Fixes a recent issue where the module in src/impl/formatter is not found