### PR TITLE
DateTime.diff produces wrong results with unit quarter fix.

### DIFF
--- a/src/impl/diff.js
+++ b/src/impl/diff.js
@@ -9,7 +9,7 @@ function dayDiff(earlier, later) {
 function highOrderDiffs(cursor, later, units) {
   const differs = [
     ["years", (a, b) => b.year - a.year],
-    ["quarters", (a, b) => b.quarter - a.quarter],
+    ["quarters", (a, b) => b.quarter - a.quarter + (b.year - a.year) * 4],
     ["months", (a, b) => b.month - a.month + (b.year - a.year) * 12],
     [
       "weeks",


### PR DESCRIPTION
Resolves https://github.com/moment/luxon/issues/1266