### PR TITLE
Add lastMoment getter to Interval

### DIFF
--- a/src/interval.js
+++ b/src/interval.js
@@ -195,10 +195,10 @@ export default class Interval {
   }
   
   /**
-   * Returns the last moment included in the interval (since end is not part of the interval)
+   * Returns the last DateTime included in the interval (since end is not part of the interval)
    * @type {DateTime}
    */
-  get lastMoment() {
+  get lastDateTime() {
     return this.isValid ? this.e.minus(1) : null;
   }
 

--- a/src/interval.js
+++ b/src/interval.js
@@ -193,6 +193,14 @@ export default class Interval {
   get end() {
     return this.isValid ? this.e : null;
   }
+  
+  /**
+   * Returns the last moment included in the interval (since end is not part of the interval)
+   * @type {DateTime}
+   */
+  get lastMoment() {
+    return this.isValid ? this.e.minus(1) : null;
+  }
 
   /**
    * Returns whether this Interval's end is at least its start, meaning that the Interval isn't 'backwards'.


### PR DESCRIPTION
Convenient way to get the last moment that is actually included in the interval. Makes it easier to properly use the fact that intervals are half open.

My use case: displaying end date of a monthly subscription.

I'm not sure `lastMoment` is the best way to name this, but it was the first thing that I thought of.