### PR TITLE
feat: add rescale option to Duration.normalize method

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-  workflow_dispatch:
 
 jobs:
   build-and-test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   build-and-test:

--- a/src/duration.js
+++ b/src/duration.js
@@ -690,14 +690,29 @@ export default class Duration {
 
   /**
    * Reduce this Duration to its canonical representation in its current units.
+   * @param {Object} opts - options
+   * @param {boolean} [opts.rescale=false] - Rescale units to its largest representation
    * @example Duration.fromObject({ years: 2, days: 5000 }).normalize().toObject() //=> { years: 15, days: 255 }
    * @example Duration.fromObject({ hours: 12, minutes: -45 }).normalize().toObject() //=> { hours: 11, minutes: 15 }
    * @return {Duration}
    */
-  normalize() {
+  normalize(opts = {}) {
     if (!this.isValid) return this;
-    const vals = this.toObject();
+    let vals = this.toObject();
     normalizeValues(this.matrix, vals);
+    if (opts.rescale) {
+      const dur = Duration.fromObject(vals).shiftTo('years', 'months', 'weeks', 'days', 'hours', 'minutes', 'seconds', 'milliseconds').toObject();
+      vals = {
+        ...dur.years > 0 && { years: dur.years },
+        ...dur.months > 0 && { months: dur.months },
+        ...dur.weeks > 0 && { weeks: dur.weeks },
+        ...dur.days > 0 && { days: dur.days },
+        ...dur.hours > 0 && { hours: dur.hours },
+        ...dur.minutes > 0 && { minutes: dur.minutes },
+        ...dur.seconds > 0 && { seconds: dur.seconds },
+        ...dur.milliseconds > 0 && { milliseconds: dur.milliseconds }
+      };
+    }
     return clone(this, { values: vals }, true);
   }
 

--- a/src/duration.js
+++ b/src/duration.js
@@ -694,25 +694,30 @@ export default class Duration {
    * @param {boolean} [opts.rescale=false] - Rescale units to its largest representation
    * @example Duration.fromObject({ years: 2, days: 5000 }).normalize().toObject() //=> { years: 15, days: 255 }
    * @example Duration.fromObject({ hours: 12, minutes: -45 }).normalize().toObject() //=> { hours: 11, minutes: 15 }
+   * @example Duration.fromObject({ milliseconds: 90000 }).normalize({ rescale: true }).toObject() //=> { minutes: 1, seconds: 30 }
    * @return {Duration}
    */
   normalize(opts = {}) {
     if (!this.isValid) return this;
     let vals = this.toObject();
     normalizeValues(this.matrix, vals);
+
     if (opts.rescale) {
-      const dur = Duration.fromObject(vals).shiftTo('years', 'months', 'weeks', 'days', 'hours', 'minutes', 'seconds', 'milliseconds').toObject();
+      const dur = clone(this, { values: vals }, true)
+        .shiftTo("years", "months", "weeks", "days", "hours", "minutes", "seconds", "milliseconds")
+        .toObject();
       vals = {
-        ...dur.years > 0 && { years: dur.years },
-        ...dur.months > 0 && { months: dur.months },
-        ...dur.weeks > 0 && { weeks: dur.weeks },
-        ...dur.days > 0 && { days: dur.days },
-        ...dur.hours > 0 && { hours: dur.hours },
-        ...dur.minutes > 0 && { minutes: dur.minutes },
-        ...dur.seconds > 0 && { seconds: dur.seconds },
-        ...dur.milliseconds > 0 && { milliseconds: dur.milliseconds }
+        ...(dur.years !== 0 && { years: dur.years }),
+        ...(dur.months !== 0 && { months: dur.months }),
+        ...(dur.weeks !== 0 && { weeks: dur.weeks }),
+        ...(dur.days !== 0 && { days: dur.days }),
+        ...(dur.hours !== 0 && { hours: dur.hours }),
+        ...(dur.minutes !== 0 && { minutes: dur.minutes }),
+        ...(dur.seconds !== 0 && { seconds: dur.seconds }),
+        ...(dur.milliseconds !== 0 && { milliseconds: dur.milliseconds }),
       };
     }
+
     return clone(this, { values: vals }, true);
   }
 

--- a/test/duration/units.test.js
+++ b/test/duration/units.test.js
@@ -207,6 +207,21 @@ test("Duration#normalize can convert all unit pairs", () => {
   }
 });
 
+test("Duration#normalize can rescale units", () => {
+  const sets = [
+    [{ milliseconds: 90000 }, { minutes: 1, seconds: 30 }],
+    [
+      { minutes: 70, milliseconds: 121 },
+      { hours: 1, minutes: 10, seconds: 12, milliseconds: 100 },
+    ],
+    [{ months: 2, days: -30 }, { months: 1 }],
+  ];
+
+  sets.forEach(([from, to]) => {
+    expect(Duration.fromObject(from).normalize({ rescale: true }).toObject()).toEqual(to);
+  });
+});
+
 //------
 // #as()
 //-------

--- a/test/duration/units.test.js
+++ b/test/duration/units.test.js
@@ -97,6 +97,29 @@ test("Duration#shiftTo boils hours down to hours and minutes", () => {
 });
 
 //------
+// #shiftToAll()
+//-------
+test("Duration#shiftToAll shifts to all available units", () => {
+  const dur = Duration.fromMillis(5760000).shiftToAll();
+  expect(dur.toObject()).toEqual({
+    years: 0,
+    months: 0,
+    weeks: 0,
+    days: 0,
+    hours: 1,
+    minutes: 36,
+    seconds: 0,
+    milliseconds: 0,
+  });
+});
+
+test("Duration#shiftToAll maintains invalidity", () => {
+  const dur = Duration.invalid("because").shiftToAll();
+  expect(dur.isValid).toBe(false);
+  expect(dur.invalidReason).toBe("because");
+});
+
+//------
 // #normalize()
 //-------
 test("Duration#normalize rebalances negative units", () => {
@@ -207,7 +230,10 @@ test("Duration#normalize can convert all unit pairs", () => {
   }
 });
 
-test("Duration#normalize can rescale units", () => {
+//------
+// #rescale()
+//-------
+test("Duration#rescale normalizes, shifts to all units and remove units with a value of 0", () => {
   const sets = [
     [{ milliseconds: 90000 }, { minutes: 1, seconds: 30 }],
     [
@@ -218,8 +244,14 @@ test("Duration#normalize can rescale units", () => {
   ];
 
   sets.forEach(([from, to]) => {
-    expect(Duration.fromObject(from).normalize({ rescale: true }).toObject()).toEqual(to);
+    expect(Duration.fromObject(from).rescale().toObject()).toEqual(to);
   });
+});
+
+test("Duration#rescale maintains invalidity", () => {
+  const dur = Duration.invalid("because").rescale();
+  expect(dur.isValid).toBe(false);
+  expect(dur.invalidReason).toBe("because");
 });
 
 //------

--- a/test/duration/units.test.js
+++ b/test/duration/units.test.js
@@ -211,7 +211,7 @@ test("Duration#normalize can rescale units", () => {
   const sets = [
     [{ milliseconds: 90000 }, { minutes: 1, seconds: 30 }],
     [
-      { minutes: 70, milliseconds: 121 },
+      { minutes: 70, milliseconds: 12100 },
       { hours: 1, minutes: 10, seconds: 12, milliseconds: 100 },
     ],
     [{ months: 2, days: -30 }, { months: 1 }],


### PR DESCRIPTION
## The Problem

There's a use case right now where you have a duration from a set of units but want them to be displayed to the user in a more "human readable" format.

For example, you might want to display the duration between various 2 datetimes, which can defer in hours or just a few seconds:

```js
const dur = Interval.fromDateTimes(start, end).toDuration(['hours', 'minutes', 'seconds', 'milliseconds'])
console.log(dur.toHuman())

// example outputs:
// 4 hours, 0 minutes, 12 seconds and 0 milliseconds
// 0 hours, 0 minutes, 5 seconds and 0 milliseconds
// 0 hours, 54 minutes, 0 seconds and 0 milliseconds
```

Because the duration can vary greatly between just a few seconds and many hours, the current output is completely useless.
One would expect the `normalize()` method to solve this problem but unfortunately, **the current implementation only adjust the  units currently in use**.

```js
const dur = Duration.fromObject({ milliseconds: 90000 })
console.log(dur.normalize().toHuman())

// output: 90000 milliseconds
```

In this example, normalizing 90000 milliseconds will still get you... 90000 milliseconds. Not useful at all. Again, because the duration can vary greatly, using `shiftTo()` is not a viable option.

## The Solution

This PR adds a `rescale` option to the `normalize()` method which also shifts units to their largest representation, on top of the current normalization. This basically remove any units with values of 0, giving you a clean output.

```js
const dur = Interval.fromDateTimes(start, end).toDuration(['hours', 'minutes', 'seconds', 'milliseconds'])
console.log(dur.normalize({ rescale: true }).toHuman())

// example outputs:
// 4 hours and 12 seconds
// 5 seconds
// 54 minutes
```

```js
const dur = Duration.fromObject({ milliseconds: 90000 })
console.log(dur.normalize({ rescale: true }).toHuman())

// output: 1 minute and 30 seconds
```

## Notes

This could possibly be its own method (e.g. `rescale()`), but in my opinion, this is what you would expect the `normalize()` method to do. Therefore, I think it makes more sense to simply add an optional flag to the current `normalize()` method.

Thanks!