### PR TITLE
Fix Interval#count counting the endpoint as part of the interval

### DIFF
--- a/src/interval.js
+++ b/src/interval.js
@@ -238,7 +238,7 @@ export default class Interval {
     if (!this.isValid) return NaN;
     const start = this.start.startOf(unit),
       end = this.end.startOf(unit);
-    return Math.floor(end.diff(start, unit).get(unit)) + 1;
+    return Math.floor(end.diff(start, unit).get(unit)) + (end.valueOf() !== this.end.valueOf());
   }
 
   /**

--- a/test/interval/info.test.js
+++ b/test/interval/info.test.js
@@ -54,9 +54,14 @@ test("Interval#count('years') returns 2 if the interval crosses the new year", (
   expect(i.count("years")).toBe(2);
 });
 
+test("Interval#count() does not count the endpoint of the interval", () => {
+  const i = DateTime.fromISO("2022-10-01").until(DateTime.fromISO("2022-10-03"));
+  expect(i.count("days")).toBe(2);
+})
+
 test("Interval#count() uses milliseconds by default", () => {
   const i = DateTime.fromISO("2016-05-25T03:00").until(DateTime.fromISO("2016-05-25T14:00"));
-  expect(i.count()).toBe(39600001);
+  expect(i.count()).toBe(39600000);
 });
 
 test("Interval#count() returns NaN for invalid intervals", () => {

--- a/test/interval/info.test.js
+++ b/test/interval/info.test.js
@@ -57,7 +57,7 @@ test("Interval#count('years') returns 2 if the interval crosses the new year", (
 test("Interval#count() does not count the endpoint of the interval", () => {
   const i = DateTime.fromISO("2022-10-01").until(DateTime.fromISO("2022-10-03"));
   expect(i.count("days")).toBe(2);
-})
+});
 
 test("Interval#count() uses milliseconds by default", () => {
   const i = DateTime.fromISO("2016-05-25T03:00").until(DateTime.fromISO("2016-05-25T14:00"));


### PR DESCRIPTION
Fixes #1306

One of the tests actually tested this incorrect behavior, which I have adjusted. I have also added a new test, explicitly testing the correct behavior.