### PR TITLE
docs(src-datetime): fix minor typo

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1926,7 +1926,7 @@ export default class DateTime {
 
   /**
    * Equality check
-   * Two DateTimes are equal iff they represent the same millisecond, have the same zone and location, and are both valid.
+   * Two DateTimes are equal if they represent the same millisecond, have the same zone and location, and are both valid.
    * To compare just the millisecond values, use `+dt1 === +dt2`.
    * @param {DateTime} other - the other DateTime
    * @return {boolean}


### PR DESCRIPTION
Just a quick fix for an extremely minor typo. 