### PR TITLE
Update docs on react native android support

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -101,4 +101,13 @@ npm install --save-dev @types/luxon
 
 ## React Native
 
-React Native works just fine, but React Native for Android doesn't ship with Intl support, which you need for [a lot of Luxon's functionality](matrix.md). Use [jsc-android-buildscripts](https://github.com/SoftwareMansion/jsc-android-buildscripts) to fix it.
+React Native >=0.70 works just fine out of the box. Older versions of React Native for Android (or if you disable Hermes) doesn't include Intl support by default, which you need for [a lot of Luxon's functionality](matrix.md).
+
+For React Native >=0.60, you should configure the build flavor of jsc in `android/app/build.gradle`:
+
+```diff
+-def jscFlavor = 'org.webkit:android-jsc:+'
++def jscFlavor = 'org.webkit:android-jsc-intl:+'
+```
+
+For even older versions of React Native you can use [jsc-android-buildscripts](https://github.com/SoftwareMansion/jsc-android-buildscripts) to fix it.

--- a/docs/matrix.md
+++ b/docs/matrix.md
@@ -56,4 +56,11 @@ Info.features(); //=> { relative: false }
 
 Specific notes on other platforms:
 
-- **React Native on (specifically) Android** doesn't come with Intl support, so all the possible-to-be-missing capabilities above are unavailable. Use [jsc-android-buildscripts](https://github.com/SoftwareMansion/jsc-android-buildscripts) to fix it.
+- **React Native <0.70 on (specifically) Android** doesn't include Intl support by default, so all the possible-to-be-missing capabilities above are unavailable. To fix this on React Native >=0.60, you should configure the build flavor of jsc in `android/app/build.gradle`:
+
+```diff
+-def jscFlavor = 'org.webkit:android-jsc:+'
++def jscFlavor = 'org.webkit:android-jsc-intl:+'
+```
+
+For even older versions of React Native you can use [jsc-android-buildscripts](https://github.com/SoftwareMansion/jsc-android-buildscripts) to fix it.


### PR DESCRIPTION
Resurrecting #609 which was closed because the original author @roadmanfong didn't sign the CLA.

Have revised the wording, and simplified the diff for configuring jsc build flavor.