### PR TITLE
Add toUnixInteger() to the formatting documentation.

### DIFF
--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -37,6 +37,7 @@ DateTime objects can also be converted to numerical [Unix timestamps](https://en
 ```js
 dt.toMillis(); //=> 1492702320000
 dt.toSeconds(); //=> 1492702320.000
+dt.toUnixInteger(); // => 1492702320
 dt.valueOf(); //=> 1492702320000, same as .toMillis()
 ```
 


### PR DESCRIPTION
I noticed that #1114 introduced `toUnixInteger()` but it wasn't included in the documentation.