### PR TITLE
Remove comma from listStyle:long output

### DIFF
--- a/src/duration.js
+++ b/src/duration.js
@@ -457,7 +457,7 @@ export default class Duration {
    * ```js
    * var dur = Duration.fromObject({ days: 1, hours: 5, minutes: 6 })
    * dur.toHuman() //=> '1 day, 5 hours, 6 minutes'
-   * dur.toHuman({ listStyle: "long" }) //=> '1 day, 5 hours, and 6 minutes'
+   * dur.toHuman({ listStyle: "long" }) //=> '1 day, 5 hours and 6 minutes'
    * dur.toHuman({ unitDisplay: "short" }) //=> '1 day, 5 hr, 6 min'
    * ```
    */

--- a/test/duration/format.test.js
+++ b/test/duration/format.test.js
@@ -293,7 +293,7 @@ test("Duration#toHuman only shows the units you have", () => {
 
 test("Duration#toHuman accepts a listStyle", () => {
   expect(dur().toHuman({ listStyle: "long" })).toEqual(
-    "1 year, 2 months, 1 week, 3 days, 4 hours, 5 minutes, 6 seconds, and 7 milliseconds"
+    "1 year, 2 months, 1 week, 3 days, 4 hours, 5 minutes, 6 seconds and 7 milliseconds"
   );
 });
 


### PR DESCRIPTION
`duration.toHuman({ listStyle: "long" })` doesn't actually output the comma before `and`.