### PR TITLE
Handle dates in year 99 rolling over into year 100 better

### DIFF
--- a/src/impl/util.js
+++ b/src/impl/util.js
@@ -166,7 +166,10 @@ export function objToLocalTS(obj) {
   // for legacy reasons, years between 0 and 99 are interpreted as 19XX; revert that
   if (obj.year < 100 && obj.year >= 0) {
     d = new Date(d);
-    d.setUTCFullYear(d.getUTCFullYear() - 1900);
+    // set the month and day again, this is necessary because year 2000 is a leap year, but year 100 is not
+    // so if obj.year is in 99, but obj.day makes it roll over into year 100,
+    // the calculations done by Date.UTC are using year 2000 - which is incorrect
+    d.setUTCFullYear(obj.year, obj.month - 1, obj.day);
   }
   return +d;
 }

--- a/test/datetime/math.test.js
+++ b/test/datetime/math.test.js
@@ -107,6 +107,13 @@ test("DateTime#plus works across the 100 barrier", () => {
   expect(d.day).toBe(2);
 });
 
+test("DateTime#plus works across the 100 barrier when passing through February", () => {
+  const d = DateTime.fromISO("0099-12-31").plus({ day: 61 });
+  expect(d.year).toBe(100);
+  expect(d.month).toBe(3);
+  expect(d.day).toBe(2);
+});
+
 test("DateTime#plus renders invalid when out of max. datetime range using days", () => {
   const d = DateTime.utc(1970, 1, 1, 0, 0, 0, 0).plus({ day: 1e8 + 1 });
   expect(d.isValid).toBe(false);


### PR DESCRIPTION
Fixes #1389

From [#1389](https://github.com/moment/luxon/issues/1389#issuecomment-1443392279):

> The problem here is not `diff`, but actually `plus`:
`DateTime.fromISO('0099-12-31', {zone: "utc"}).plus({days: 61}).toISODate()` produces `0100-03-01`, not `0100-03-02`. What is happening is that deep inside Luxon it calls `Date.UTC` with a computed date object (day, month, etc.). `Date.UTC` however treats years before 100 as 19XX. So year 99 turns into 1999. Luxon works around this by checking if the year is < 100 and if so, using `setUTCFullYear` afterwards. Here is the problem: year 2000 is a leap year, year 100 is not. So if you do a plus operation that goes from year 99 into year 100, the native JavaScript Date object thinks it is crossing from year 1999 into year 2000 - and year 2000 is a leap year. Luxon then goes in and fixes it back to year 100 - but the damage is done, the calculation was done with "this is a leap year" in mind.