### PR TITLE
Correctly handle hourCycle when expanding macro tokens

### DIFF
--- a/src/impl/formatter.js
+++ b/src/impl/formatter.js
@@ -101,24 +101,25 @@ export default class Formatter {
     return df.format();
   }
 
-  formatDateTime(dt, opts = {}) {
-    const df = this.loc.dtFormatter(dt, { ...this.opts, ...opts });
-    return df.format();
+  dtFormatter(dt, opts = {}) {
+    return this.loc.dtFormatter(dt, { ...this.opts, ...opts });
   }
 
-  formatDateTimeParts(dt, opts = {}) {
-    const df = this.loc.dtFormatter(dt, { ...this.opts, ...opts });
-    return df.formatToParts();
+  formatDateTime(dt, opts) {
+    return this.dtFormatter(dt, opts).format();
   }
 
-  formatInterval(interval, opts = {}) {
-    const df = this.loc.dtFormatter(interval.start, { ...this.opts, ...opts });
+  formatDateTimeParts(dt, opts) {
+    return this.dtFormatter(dt, opts).formatToParts();
+  }
+
+  formatInterval(interval, opts) {
+    const df = this.dtFormatter(interval.start, opts);
     return df.dtf.formatRange(interval.start.toJSDate(), interval.end.toJSDate());
   }
 
-  resolvedOptions(dt, opts = {}) {
-    const df = this.loc.dtFormatter(dt, { ...this.opts, ...opts });
-    return df.resolvedOptions();
+  resolvedOptions(dt, opts) {
+    return this.dtFormatter(dt, opts).resolvedOptions();
   }
 
   num(n, p = 0) {

--- a/test/datetime/tokenParse.test.js
+++ b/test/datetime/tokenParse.test.js
@@ -1186,6 +1186,17 @@ test("DateTime.parseFormatForOpts returns a parsing format", () => {
   const format = DateTime.parseFormatForOpts("");
   expect(format).toBeNull();
 });
+test("DateTime.parseFormatForOpts respects the hour cycle", () => {
+  const enFormat = DateTime.parseFormatForOpts(DateTime.TIME_SIMPLE, { locale: "en-US" });
+  expect(enFormat).toEqual("h:m a");
+
+  const deFormat = DateTime.parseFormatForOpts(DateTime.TIME_SIMPLE, { locale: "de-DE" });
+  expect(deFormat).toEqual("H:m");
+});
+test("DateTime.parseFormatForOpts respects the hour cycle when forced by the options", () => {
+  const format = DateTime.parseFormatForOpts(DateTime.TIME_24_SIMPLE, { locale: "en-US" });
+  expect(format).toEqual("H:m");
+});
 
 //------
 // .expandFormat
@@ -1199,4 +1210,17 @@ test("DateTime.expandFormat works with the default locale", () => {
 test("DateTime.expandFormat works with other locales", () => {
   const format = DateTime.expandFormat("D", { locale: "en-gb" });
   expect(format).toBe("d/M/yyyyy");
+});
+
+test("DateTime.expandFormat respects the hour cycle", () => {
+  const enFormat = DateTime.expandFormat("t", { locale: "en-US" });
+  expect(enFormat).toBe("h:m a");
+
+  const deFormat = DateTime.expandFormat("t", { locale: "de-DE" });
+  expect(deFormat).toBe("H:m");
+});
+
+test("DateTime.expandFormat respects the hour cycle when forced by the macro token", () => {
+  const format = DateTime.expandFormat("T", { locale: "en-US" });
+  expect(format).toBe("H:m");
 });


### PR DESCRIPTION
When expanding macro tokens, we must expand "hour" either into "h" or "H", depending on the desired hour cycle. 
This fixes #1197.

I have not changed the parsing of `h`, which currently accepts 24 hours just the same as `H`. This would be a breaking change and I am not sure it is worth introducing another special case in the parser for this.
