### PR TITLE
Fix DateTime#diff for cross-zone diffs by checking where dayDiff is off by 2 days (#1165)

### DIFF
--- a/src/impl/diff.js
+++ b/src/impl/diff.js
@@ -34,6 +34,13 @@ function highOrderDiffs(cursor, later, units) {
 
       if (highWater > later) {
         results[unit]--;
+
+        const highWater2 = earlier.plus(results);
+        if (highWater2 > later) {
+          results[unit]--;
+          highWater = highWater2;
+        }
+
         cursor = earlier.plus(results);
       } else {
         cursor = highWater;

--- a/test/datetime/diff.test.js
+++ b/test/datetime/diff.test.js
@@ -313,6 +313,20 @@ test("DateTime#diff handles Feb-29 edge case logic for higher order units in a m
   expect(left.plus(diff).equals(right)).toBe(true);
 });
 
+// see https://github.com/moment/luxon/issues/1165
+test("DateTime#diff handles datetimes whose dayDiff is off by 2 days instead of the usual 1 due to zone differences", () => {
+  // Notice how `end` is 5 days away, but actually the diff should be 3 days and 23 hours (off by 2)
+  // because Europe/Madrid here has an offset of +02:00.
+  const start = DateTime.fromISO("2022-05-05T23:00", { zone: "UTC" });
+  const end = DateTime.fromISO("2022-05-10T00:00", { zone: "Europe/Madrid" });
+
+  const diff1 = end.diff(start, ["days", "hours", "minutes"]).toObject();
+  expect(diff1).toEqual({ days: 3, hours: 23, minutes: 0 });
+
+  const diff2 = end.diff(start, ["days"]);
+  expect(diff2.days).toBeCloseTo(3.958333, 6);
+});
+
 //------
 // diffNow
 //-------


### PR DESCRIPTION
Fixes #1165 (I think). Please review code and see if correct; I am not a datetime expert and this date stuff can be hard.