### PR TITLE
fix: toISODate, toISO and toSQLDate methods could return null when an InvalidDate is provided

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1599,7 +1599,7 @@ export default class DateTime {
    * @example DateTime.now().toISO() //=> '2017-04-22T20:47:05.335-04:00'
    * @example DateTime.now().toISO({ includeOffset: false }) //=> '2017-04-22T20:47:05.335'
    * @example DateTime.now().toISO({ format: 'basic' }) //=> '20170422T204705.335-0400'
-   * @return {string}
+   * @return {string|null}
    */
   toISO({
     format = "extended",
@@ -1626,7 +1626,7 @@ export default class DateTime {
    * @param {string} [opts.format='extended'] - choose between the basic and extended format
    * @example DateTime.utc(1982, 5, 25).toISODate() //=> '1982-05-25'
    * @example DateTime.utc(1982, 5, 25).toISODate({ format: 'basic' }) //=> '19820525'
-   * @return {string}
+   * @return {string|null}
    */
   toISODate({ format = "extended" } = {}) {
     if (!this.isValid) {
@@ -1711,7 +1711,7 @@ export default class DateTime {
   /**
    * Returns a string representation of this DateTime appropriate for use in SQL Date
    * @example DateTime.utc(2014, 7, 13).toSQLDate() //=> '2014-07-13'
-   * @return {string}
+   * @return {string|null}
    */
   toSQLDate() {
     if (!this.isValid) {


### PR DESCRIPTION
`toISODate` method could return `null` even if it is not explicit in the method type.

```typescript
import { DateTime } from "luxon";

const invalidDate = new Date('2023-15-56'); // -> InvalidDate
const dt = DateTime.fromJSDate(invalidDate) // -> DateTime
const isoDt = dt.toISODate(); // -> null
```

A pull request for [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped) is already opened in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64919