### PR TITLE
Truncate milliseconds shorthand in ISO

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -217,24 +217,33 @@ function toISOTime(
   extended,
   suppressSeconds,
   suppressMilliseconds,
+  truncateMilliseconds,
   includeOffset,
   extendedZone
 ) {
   let c = padStart(o.c.hour);
+
+  const includeMilliseconds =
+    (o.c.millisecond !== 0 && !truncateMilliseconds) ||
+    ((o.c.second !== 0 || !suppressSeconds) && !suppressMilliseconds && !truncateMilliseconds);
+
+  const includeSeconds = includeMilliseconds || o.c.second !== 0 || !suppressSeconds;
+
   if (extended) {
     c += ":";
     c += padStart(o.c.minute);
-    if (o.c.millisecond !== 0 || o.c.second !== 0 || !suppressSeconds) {
+
+    if (includeSeconds) {
       c += ":";
     }
   } else {
     c += padStart(o.c.minute);
   }
 
-  if (o.c.millisecond !== 0 || o.c.second !== 0 || !suppressSeconds) {
+  if (includeSeconds) {
     c += padStart(o.c.second);
 
-    if (o.c.millisecond !== 0 || !suppressMilliseconds) {
+    if (includeMilliseconds) {
       c += ".";
       c += padStart(o.c.millisecond, 3);
     }
@@ -1630,6 +1639,7 @@ export default class DateTime {
    * @param {string} [opts.format='extended'] - choose between the basic and extended format
    * @param {boolean} [opts.suppressSeconds=false] - exclude seconds from the format if they're 0
    * @param {boolean} [opts.suppressMilliseconds=false] - exclude milliseconds from the format if they're 0
+   * @param {boolean} [opts.truncateMilliseconds=false] - truncate the milliseconds from the format, irrespective of their value
    * @param {boolean} [opts.includeOffset=true] - include the offset, such as 'Z' or '-04:00'
    * @param {boolean} [opts.extendedZone=false] - add the time zone format extension
    * @example DateTime.utc(1983, 5, 25).toISO() //=> '1982-05-25T00:00:00.000Z'
@@ -1642,6 +1652,7 @@ export default class DateTime {
     format = "extended",
     suppressSeconds = false,
     suppressMilliseconds = false,
+    truncateMilliseconds = false,
     includeOffset = true,
     extendedZone = false,
   } = {}) {
@@ -1653,7 +1664,15 @@ export default class DateTime {
 
     let c = toISODate(this, ext);
     c += "T";
-    c += toISOTime(this, ext, suppressSeconds, suppressMilliseconds, includeOffset, extendedZone);
+    c += toISOTime(
+      this,
+      ext,
+      suppressSeconds,
+      suppressMilliseconds,
+      truncateMilliseconds,
+      includeOffset,
+      extendedZone
+    );
     return c;
   }
 
@@ -1699,6 +1718,7 @@ export default class DateTime {
    */
   toISOTime({
     suppressMilliseconds = false,
+    truncateMilliseconds = false,
     suppressSeconds = false,
     includeOffset = true,
     includePrefix = false,
@@ -1717,6 +1737,7 @@ export default class DateTime {
         format === "extended",
         suppressSeconds,
         suppressMilliseconds,
+        truncateMilliseconds,
         includeOffset,
         extendedZone
       )

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1627,11 +1627,11 @@ export default class DateTime {
   /**
    * Returns an ISO 8601-compliant string representation of this DateTime
    * @param {Object} opts - options
-   * @param {boolean} [opts.suppressMilliseconds=false] - exclude milliseconds from the format if they're 0
+   * @param {string} [opts.format='extended'] - choose between the basic and extended format
    * @param {boolean} [opts.suppressSeconds=false] - exclude seconds from the format if they're 0
+   * @param {boolean} [opts.suppressMilliseconds=false] - exclude milliseconds from the format if they're 0
    * @param {boolean} [opts.includeOffset=true] - include the offset, such as 'Z' or '-04:00'
    * @param {boolean} [opts.extendedZone=false] - add the time zone format extension
-   * @param {string} [opts.format='extended'] - choose between the basic and extended format
    * @example DateTime.utc(1983, 5, 25).toISO() //=> '1982-05-25T00:00:00.000Z'
    * @example DateTime.now().toISO() //=> '2017-04-22T20:47:05.335-04:00'
    * @example DateTime.now().toISO({ includeOffset: false }) //=> '2017-04-22T20:47:05.335'

--- a/test/datetime/format.test.js
+++ b/test/datetime/format.test.js
@@ -104,6 +104,33 @@ test("DateTime#toISO() suppresses [milli]seconds", () => {
   );
 });
 
+test("DateTime#toISO() truncates [milli]seconds", () => {
+  const truncateMilliseconds = { truncateMilliseconds: true };
+  expect(dt.toISO(truncateMilliseconds)).toBe("1982-05-25T09:23:54Z");
+  expect(dt.set({ millisecond: 0 }).toISO(truncateMilliseconds)).toBe("1982-05-25T09:23:54Z");
+
+  const noZeroSeconds = {
+    suppressSeconds: true,
+    suppressMilliseconds: true,
+    truncateMilliseconds: true,
+  };
+  expect(dt.set({ seconds: 0 }).toISO(noZeroSeconds)).toBe("1982-05-25T09:23Z");
+  expect(dt.set({ millisecond: 0 }).toISO(noZeroSeconds)).toBe("1982-05-25T09:23:54Z");
+  expect(dt.set({ seconds: 0, milliseconds: 0 }).toISO(noZeroSeconds)).toBe("1982-05-25T09:23Z");
+
+  const suppressOnlySeconds = { suppressSeconds: true };
+  expect(dt.set({ seconds: 0 }).toISO(suppressOnlySeconds)).toBe("1982-05-25T09:23:00.123Z");
+  expect(dt.set({ seconds: 0, milliseconds: 0 }).toISO(suppressOnlySeconds)).toBe(
+    "1982-05-25T09:23Z"
+  );
+
+  const suppressMillisecondsOnly = { suppressMilliseconds: true };
+  expect(dt.toISO(suppressMillisecondsOnly)).toBe("1982-05-25T09:23:54.123Z");
+  expect(dt.set({ seconds: 0, milliseconds: 0 }).toISO(suppressMillisecondsOnly)).toBe(
+    "1982-05-25T09:23:00Z"
+  );
+});
+
 test("DateTime#toISO() returns null for invalid DateTimes", () => {
   expect(invalid.toISO()).toBe(null);
 });
@@ -221,12 +248,24 @@ test("DateTime#toISOTime() won't suppress milliseconds by default", () => {
   expect(dt.startOf("second").toISOTime()).toBe("09:23:54.000Z");
 });
 
+test("DateTime#toISOTime() won't truncate milliseconds by default", () => {
+  expect(dt.toISOTime()).toBe("09:23:54.123Z");
+});
+
 test("DateTime#toISOTime({suppressMilliseconds: true}) won't suppress milliseconds if they're nonzero", () => {
   expect(dt.toISOTime({ suppressMilliseconds: true })).toBe("09:23:54.123Z");
 });
 
 test("DateTime#toISOTime({suppressMilliseconds: true}) will suppress milliseconds if they're zero", () => {
   expect(dt.set({ millisecond: 0 }).toISOTime({ suppressMilliseconds: true })).toBe("09:23:54Z");
+});
+
+test("DateTime#toISOTime({truncateMilliseconds: true}) will truncate milliseconds if value is not zero", () => {
+  expect(dt.toISOTime({ truncateMilliseconds: true })).toBe("09:23:54Z");
+});
+
+test("DateTime#toISOTime({truncateMilliseconds: true}) will truncate milliseconds if value is zero", () => {
+  expect(dt.set({ millisecond: 0 }).toISOTime({ truncateMilliseconds: true })).toBe("09:23:54Z");
 });
 
 test("DateTime#toISOTime({suppressSeconds: true}) won't suppress milliseconds if they're nonzero", () => {


### PR DESCRIPTION
Adds a new parameter to DateTime#toISO and toISOTime called truncateMilliseconds which will remove the milliseconds from the format, irrespective of their value.

Added tests