### PR TITLE
Fix: Remove "TTT" from valid parsing tokens

### DIFF
--- a/docs/parsing.md
+++ b/docs/parsing.md
@@ -235,7 +235,6 @@ Because Luxon was able to parse the string without difficulty, the output is a l
 | tt               |              | localized time with seconds                                       | `1:07:04 PM`                |
 | T                |              | localized 24-hour time                                            | `13:07`                     |
 | TT               |              | localized 24-hour time with seconds                               | `13:07:04`                  |
-| TTT              |              | localized 24-hour time with seconds and abbreviated offset        | `13:07:04 EDT`              |
 | f                |              | short localized date and time                                     | `8/6/2014, 1:07 PM`         |
 | ff               |              | less short localized date and time                                | `Aug 6, 2014, 1:07 PM`      |
 | F                |              | short localized date and time with seconds                        | `8/6/2014, 1:07:04 PM`      |


### PR DESCRIPTION
One-liner change. Spent a while trying to figure out why I couldn't use fromFormat with `TTT`, and ended up being not supported by the function even though it's in the parsing table of valid tokens, which may be confusing, albeit also already stating that `Luxon also doesn't support the "macro" tokens that include offset names, such as "ttt" and "FFFF"`.