### PR TITLE
Fix duck test to match Zone interface

### DIFF
--- a/src/impl/zoneUtil.js
+++ b/src/impl/zoneUtil.js
@@ -24,7 +24,7 @@ export function normalizeZone(input, defaultZone) {
     else return FixedOffsetZone.parseSpecifier(lowered) || IANAZone.create(input);
   } else if (isNumber(input)) {
     return FixedOffsetZone.instance(input);
-  } else if (typeof input === "object" && input.offset && typeof input.offset === "number") {
+  } else if (typeof input === "object" && "offset" in input && typeof input.offset === "function") {
     // This is dumb, but the instanceof check above doesn't seem to really work
     // so we're duck checking it
     return input;


### PR DESCRIPTION
Fixes #1426

`normalizeZone` uses `offset` on a Zone for the duck test, but incorrectly assumes it is a property that returns a number when in fact it is a function/method on Zone.

The duck test is particularly important for scenarios where package dependencies brought in their own copy of luxon (perhaps due to version mismatches), causing the `instance of` check to fail.  The duck test helps ensure compatibility with other instances of luxon modules.