### PR TITLE
Implement localized week information

### DIFF
--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -177,7 +177,7 @@ The macro options available correspond one-to-one with the preset formats define
 (Examples below given for `2014-08-06T13:07:04.054` considered as a local time in America/New_York).
 
 | Standalone token | Format token | Description                                                    | Example                                                       |
-| ---------------- | ------------ | -------------------------------------------------------------- | ------------------------------------------------------------- |
+|------------------| ------------ |----------------------------------------------------------------| ------------------------------------------------------------- |
 | S                |              | millisecond, no padding                                        | `54`                                                          |
 | SSS              |              | millisecond, padded to 3                                       | `054`                                                         |
 | u                |              | fractional seconds, functionally identical to SSS              | `054`                                                         |
@@ -219,6 +219,10 @@ The macro options available correspond one-to-one with the preset formats define
 | kkkk             |              | ISO week year, padded to 4                                     | `2014`                                                        |
 | W                |              | ISO week number, unpadded                                      | `32`                                                          |
 | WW               |              | ISO week number, padded to 2                                   | `32`                                                          |
+| ii               |              | Local week year, unpadded                                      | `14`                                                          |
+| iiii             |              | Local week year, padded to 4                                   | `2014`                                                        |
+| n                |              | Local week number, unpadded                                    | `32`                                                          |
+| nn               |              | Local week number, padded to 2                                 | `32`                                                          |
 | o                |              | ordinal (day of year), unpadded                                | `218`                                                         |
 | ooo              |              | ordinal (day of year), padded to 3                             | `218`                                                         |
 | q                |              | quarter, no padding                                            | `3`                                                           |

--- a/docs/intl.md
+++ b/docs/intl.md
@@ -152,8 +152,7 @@ Settings.defaultNumberingSystem = "beng";
 ## Locale-based weeks
 
 Most of Luxon uses the [ISO week date](https://en.wikipedia.org/wiki/ISO_week_date) system when working with week-related data.
-This means that the week starts on Monday, the weekend is Saturday and Sunday and the first week of the year is that week, which
-has 4 or more of its days in January.
+This means that the week starts on Monday and the first week of the year is that week, which has 4 or more of its days in January.
 
 This definition works for most use-cases, however locales can define different rules. For example, in many English-speaking countries
 the week is said to start on Sunday and the 1 January always defines the first week of the year. This information is

--- a/docs/intl.md
+++ b/docs/intl.md
@@ -148,3 +148,72 @@ Similar to `locale`, you can set the default numbering system for new instances:
 ```js
 Settings.defaultNumberingSystem = "beng";
 ```
+
+## Locale-based weeks
+
+Most of Luxon uses the [ISO week date](https://en.wikipedia.org/wiki/ISO_week_date) system when working with week-related data.
+This means that the week starts on Monday, the weekend is Saturday and Sunday and the first week of the year is that week, which
+has 4 or more of its days in January.
+
+This definition works for most use-cases, however locales can define different rules. For example, in many English-speaking countries
+the week is said to start on Sunday and the 1 January always defines the first week of the year. This information is
+available through the Luxon as well.
+
+Note that your runtime needs to support [`Intl.Locale#getWeekInfo`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getWeekInfo) for this to have an effect. If unsupported, Luxon will fall back
+to using the ISO week dates.
+
+### Accessing locale-based week info
+
+The `Info` class exposes methods `getStartOfWeek`, `getMinimumDaysInFirstWeek` and `getWeekendWeekdays` for informational
+purposes.
+
+### Accessing locale-based week data
+
+```js
+const dt = DateTime.local(2022, 1, 1, { locale: "en-US" });
+dt.localWeekday // 7, because Saturday is the 7th day of the week in en-US
+dt.localWeekNumber // 1, because 1 January is always in the first week in en-US
+dt.localWeekYear // 2022, because 1 January is always in the first week in en-US
+dt.weeksInLocalWeekYear // 53, because 2022 has 53 weeks in en-US
+```
+
+### Using locale-based week data when creating DateTimes
+
+When creating a DateTime instance using `fromObject`, you can use the `localWeekday`, `localWeekNumber` and `localWeekYear`
+properties. They will use the same locale that the newly created DateTime will use, either explicitly provided or falling back
+to the system default.
+
+```js
+const dt = DateTime.fromObject({localWeekYear: 2022, localWeekNumber: 53, localWeekday: 7});
+dt.toISODate(); // 2022-12-31
+```
+
+### Setting locale-based week data
+
+When modifying an existing DateTime instance using `set`, you can use the `localWeekday`, `localWeekNumber` and `localWeekYear`
+properties. They will use the locale of the existing DateTime as reference.
+
+```js
+const dt = DateTime.local(2022, 1, 2, { locale: "en-US" });
+const modified = dt.set({localWeekNumber: 2});
+modified.toISODate(); // 2022-01-08
+```
+
+### Locale-based weeks with math
+
+The methods `startOf`, `endOf`, `hasSame` of `DateTime` as well as `count` of `Interval` accept an option `useLocaleWeeks`. 
+If enabled, the methods will treat the `week` unit according to the locale, respecting the correct start of the week.
+
+```js
+const dt = DateTime.local(2022, 1, 6, { locale: "en-US" });
+const startOfWeek = dt.startOf('week', {useLocaleWeeks: true});
+startOfWeek.toISODate(); // 2022-01-02, a Sunday
+```
+
+### Overriding defaults
+
+You can override the runtime-provided defaults for the week settings using `Settings.defaultWeekSettings`:
+
+```js
+Settings.defaultWeekSettings = { firstDay: 7, minimalDays: 1, weekend: [6, 7] }
+```

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -57,11 +57,28 @@ function unsupportedZone(zone) {
 }
 
 // we cache week data on the DT object and this intermediates the cache
+/**
+ * @param {DateTime} dt
+ */
 function possiblyCachedWeekData(dt) {
   if (dt.weekData === null) {
     dt.weekData = gregorianToWeek(dt.c);
   }
   return dt.weekData;
+}
+
+/**
+ * @param {DateTime} dt
+ */
+function possiblyCachedLocalWeekData(dt) {
+  if (dt.localWeekData === null) {
+    dt.localWeekData = gregorianToWeek(
+      dt.c,
+      dt.loc.getMinDaysInFirstWeek(),
+      dt.loc.getStartOfWeek()
+    );
+  }
+  return dt.localWeekData;
 }
 
 // clone really means, "make a new object with these modifications". all "setters" really use this
@@ -477,6 +494,10 @@ export default class DateTime {
      * @access private
      */
     this.weekData = null;
+    /**
+     * @access private
+     */
+    this.localWeekData = null;
     /**
      * @access private
      */
@@ -1140,18 +1161,20 @@ export default class DateTime {
 
   /**
    * Get the of the week according to the locale.
-   * 0 is the first day of the week and 6 is the last day of the week.
-   * If the locale assigns Monday as the first day of the week, then a date which is a Monday will return 0,
+   * 1 is the first day of the week and 7 is the last day of the week.
+   * If the locale assigns Monday as the first day of the week, then a date which is a Monday will return 1,
    * @returns {number}
    */
-  get localDayOfWeek() {
-    return this.isValid ? isoWeekdayToLocal(this.weekday, this.loc.getStartOfWeek()) : NaN;
+  get localWeekday() {
+    return this.isValid ? possiblyCachedLocalWeekData(this).weekday : NaN;
   }
 
-  get localeWeekNumber() {
-    if (!this.isValid) {
-      return NaN;
-    }
+  get localWeekNumber() {
+    return this.isValid ? possiblyCachedLocalWeekData(this).weekNumber : NaN;
+  }
+
+  get localWeekYear() {
+    return this.isValid ? possiblyCachedLocalWeekData(this).weekYear : NaN;
   }
 
   /**

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1636,7 +1636,7 @@ export default class DateTime {
 
     if (normalizedUnit === "weeks") {
       if (useLocaleWeeks) {
-        const startOfWeek = this.loc.startOfWeek;
+        const startOfWeek = this.loc.getStartOfWeek();
         const { weekday } = this;
         if (weekday < startOfWeek) {
           o.weekNumber = this.weekNumber - 1;

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1502,6 +1502,32 @@ export default class DateTime {
    */
   startOf(unit) {
     if (!this.isValid) return this;
+
+    // handle locale-dependent week
+    if (unit === "localeWeek" || unit === "localeWeeks") {
+      const startOfWeek = this.loc.getStartOfWeek();
+      if (isUndefined(startOfWeek)) {
+        return DateTime.invalid("Missing Intl.Locale.getWeekData API");
+      }
+      let { weekday, weekNumber, weekYear } = this;
+      if (weekday < startOfWeek) {
+        weekNumber--;
+      }
+      if (weekNumber === 0) {
+        weekNumber = 0;
+        weekYear--;
+      }
+      return this.set({
+        weekday: startOfWeek,
+        weekNumber,
+        weekYear,
+        hour: 0,
+        minute: 0,
+        second: 0,
+        millisecond: 0,
+      });
+    }
+
     const o = {},
       normalizedUnit = Duration.normalizeUnit(unit);
     switch (normalizedUnit) {

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1160,19 +1160,30 @@ export default class DateTime {
   }
 
   /**
-   * Get the of the week according to the locale.
+   * Get the day of the week according to the locale.
    * 1 is the first day of the week and 7 is the last day of the week.
-   * If the locale assigns Monday as the first day of the week, then a date which is a Monday will return 1,
+   * If the locale assigns Sunday as the first day of the week, then a date which is a Sunday will return 1,
    * @returns {number}
    */
   get localWeekday() {
     return this.isValid ? possiblyCachedLocalWeekData(this).weekday : NaN;
   }
 
+  /**
+   * Get the week number of the week year according to the locale. Different locales assign week numbers differently,
+   * because the week can start on different days of the week (see localWeekday) and because a different number of days
+   * is required for a week to count as the first week of a year.
+   * @returns {number}
+   */
   get localWeekNumber() {
     return this.isValid ? possiblyCachedLocalWeekData(this).weekNumber : NaN;
   }
 
+  /**
+   * Get the week year according to the locale. Different locales assign week numbers (and therefor week years)
+   * differently, see localWeekNumber.
+   * @returns {number}
+   */
   get localWeekYear() {
     return this.isValid ? possiblyCachedLocalWeekData(this).weekYear : NaN;
   }

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1530,10 +1530,6 @@ export default class DateTime {
   startOf(unit, { useLocaleWeeks = false } = {}) {
     if (!this.isValid) return this;
 
-    // handle locale-dependent week
-    if (unit === "localeWeek" || unit === "localeWeeks") {
-    }
-
     const o = {},
       normalizedUnit = Duration.normalizeUnit(unit);
     switch (normalizedUnit) {
@@ -1565,12 +1561,11 @@ export default class DateTime {
     if (normalizedUnit === "weeks") {
       if (useLocaleWeeks) {
         const startOfWeek = this.loc.getStartOfWeek();
-        let { weekday, weekNumber } = this;
+        const { weekday } = this;
         if (weekday < startOfWeek) {
-          weekNumber--;
+          o.weekNumber = this.weekNumber - 1;
         }
         o.weekday = startOfWeek;
-        o.weekNumber = weekNumber;
       } else {
         o.weekday = 1;
       }

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1973,7 +1973,7 @@ export default class DateTime {
    * @param {DateTime} otherDateTime - the other DateTime
    * @param {string} unit - the unit of time to check sameness on
    * @param {Object} opts - options
-   * @param {boolean} [opts.useLocaleWeeks=false] - If true, use weeks based on the locale, i.e. use the locale-dependent start of the week
+   * @param {boolean} [opts.useLocaleWeeks=false] - If true, use weeks based on the locale, i.e. use the locale-dependent start of the week; only the locale of this DateTime is used
    * @example DateTime.now().hasSame(otherDT, 'day'); //~> true if otherDT is in the same current calendar day
    * @return {boolean}
    */
@@ -1982,7 +1982,9 @@ export default class DateTime {
 
     const inputMs = otherDateTime.valueOf();
     const adjustedToZone = this.setZone(otherDateTime.zone, { keepLocalTime: true });
-    return adjustedToZone.startOf(unit) <= inputMs && inputMs <= adjustedToZone.endOf(unit);
+    return (
+      adjustedToZone.startOf(unit, opts) <= inputMs && inputMs <= adjustedToZone.endOf(unit, opts)
+    );
   }
 
   /**

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -38,6 +38,7 @@ import {
   hasInvalidWeekData,
   hasInvalidOrdinalData,
   hasInvalidTimeData,
+  isoWeekdayToLocal,
 } from "./impl/conversions.js";
 import * as Formats from "./impl/formats.js";
 import {
@@ -1127,6 +1128,30 @@ export default class DateTime {
    */
   get weekday() {
     return this.isValid ? possiblyCachedWeekData(this).weekday : NaN;
+  }
+
+  /**
+   * Returns true if this date is on a weekend according to the locale, false otherwise
+   * @returns {boolean}
+   */
+  get isWeekend() {
+    return this.isValid && this.loc.getWeekendDays().includes(this.weekday);
+  }
+
+  /**
+   * Get the of the week according to the locale.
+   * 0 is the first day of the week and 6 is the last day of the week.
+   * If the locale assigns Monday as the first day of the week, then a date which is a Monday will return 0,
+   * @returns {number}
+   */
+  get localDayOfWeek() {
+    return this.isValid ? isoWeekdayToLocal(this.weekday, this.loc.getStartOfWeek()) : NaN;
+  }
+
+  get localeWeekNumber() {
+    if (!this.isValid) {
+      return NaN;
+    }
   }
 
   /**

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -716,11 +716,7 @@ export default class DateTime {
 
     const loc = Locale.fromObject(opts);
     const normalized = normalizeObject(obj, normalizeUnitWithLocalWeeks);
-    const {
-      minDaysInFirstWeek,
-      startOfWeek,
-      local: localWeeks,
-    } = usesLocalWeekValues(normalized, loc);
+    const { minDaysInFirstWeek, startOfWeek } = usesLocalWeekValues(normalized, loc);
 
     const tsNow = Settings.now(),
       offsetProvis = !isUndefined(opts.specificOffset)

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1540,9 +1540,6 @@ export default class DateTime {
     if (normalizedUnit === "weeks") {
       if (useLocaleWeeks) {
         const startOfWeek = this.loc.getStartOfWeek();
-        if (isUndefined(startOfWeek)) {
-          return DateTime.invalid("Missing Intl.Locale.getWeekData API");
-        }
         let { weekday, weekNumber } = this;
         if (weekday < startOfWeek) {
           weekNumber--;

--- a/src/duration.js
+++ b/src/duration.js
@@ -373,6 +373,8 @@ export default class Duration {
       months: "months",
       week: "weeks",
       weeks: "weeks",
+      localeweek: "weeks",
+      localeweeks: "weeks",
       day: "days",
       days: "days",
       hour: "hours",

--- a/src/duration.js
+++ b/src/duration.js
@@ -373,8 +373,6 @@ export default class Duration {
       months: "months",
       week: "weeks",
       weeks: "weeks",
-      localeweek: "weeks",
-      localeweeks: "weeks",
       day: "days",
       days: "days",
       hour: "hours",

--- a/src/impl/conversions.js
+++ b/src/impl/conversions.js
@@ -135,7 +135,7 @@ export function usesLocalWeekValues(obj, loc) {
     delete obj.localWeekYear;
     return {
       minDaysInFirstWeek: loc.getMinDaysInFirstWeek(),
-      startOfWeek: loc.getMinDaysInFirstWeek(),
+      startOfWeek: loc.getStartOfWeek(),
     };
   } else {
     return { minDaysInFirstWeek: 4, startOfWeek: 1 };

--- a/src/impl/conversions.js
+++ b/src/impl/conversions.js
@@ -42,16 +42,20 @@ function uncomputeOrdinal(year, ordinal) {
   return { month: month0 + 1, day };
 }
 
+export function isoWeekdayToLocal(isoWeekday, startOfWeek) {
+  return (isoWeekday - startOfWeek + 7) % 7;
+}
+
 /**
  * @private
  */
 
-export function gregorianToWeek(gregObj) {
+export function gregorianToWeek(gregObj, minDaysInFirstWeek = 4) {
   const { year, month, day } = gregObj,
     ordinal = computeOrdinal(year, month, day),
     weekday = dayOfWeek(year, month, day);
 
-  let weekNumber = Math.floor((ordinal - weekday + 10) / 7),
+  let weekNumber = Math.floor((ordinal - weekday + 14 - minDaysInFirstWeek) / 7),
     weekYear;
 
   if (weekNumber < 1) {

--- a/src/impl/conversions.js
+++ b/src/impl/conversions.js
@@ -43,17 +43,17 @@ function uncomputeOrdinal(year, ordinal) {
 }
 
 export function isoWeekdayToLocal(isoWeekday, startOfWeek) {
-  return (isoWeekday - startOfWeek + 7) % 7;
+  return ((isoWeekday - startOfWeek + 7) % 7) + 1;
 }
 
 /**
  * @private
  */
 
-export function gregorianToWeek(gregObj, minDaysInFirstWeek = 4) {
+export function gregorianToWeek(gregObj, minDaysInFirstWeek = 4, startOfWeek = 1) {
   const { year, month, day } = gregObj,
     ordinal = computeOrdinal(year, month, day),
-    weekday = dayOfWeek(year, month, day);
+    weekday = isoWeekdayToLocal(dayOfWeek(year, month, day), startOfWeek);
 
   let weekNumber = Math.floor((ordinal - weekday + 14 - minDaysInFirstWeek) / 7),
     weekYear;

--- a/src/impl/conversions.js
+++ b/src/impl/conversions.js
@@ -136,10 +136,9 @@ export function usesLocalWeekValues(obj, loc) {
     return {
       minDaysInFirstWeek: loc.getMinDaysInFirstWeek(),
       startOfWeek: loc.getStartOfWeek(),
-      local: true,
     };
   } else {
-    return { minDaysInFirstWeek: 4, startOfWeek: 1, local: false };
+    return { minDaysInFirstWeek: 4, startOfWeek: 1 };
   }
 }
 

--- a/src/impl/conversions.js
+++ b/src/impl/conversions.js
@@ -136,9 +136,10 @@ export function usesLocalWeekValues(obj, loc) {
     return {
       minDaysInFirstWeek: loc.getMinDaysInFirstWeek(),
       startOfWeek: loc.getStartOfWeek(),
+      local: true,
     };
   } else {
-    return { minDaysInFirstWeek: 4, startOfWeek: 1 };
+    return { minDaysInFirstWeek: 4, startOfWeek: 1, local: false };
   }
 }
 

--- a/src/impl/formatter.js
+++ b/src/impl/formatter.js
@@ -342,9 +342,9 @@ export default class Formatter {
           case "nn":
             return this.num(dt.localWeekNumber, 2);
           case "ii":
-            return this.num(dt.weekYear.toString().slice(-2), 2);
+            return this.num(dt.localWeekYear.toString().slice(-2), 2);
           case "iiii":
-            return this.num(dt.weekYear, 4);
+            return this.num(dt.localWeekYear, 4);
           case "o":
             return this.num(dt.ordinal);
           case "ooo":

--- a/src/impl/formatter.js
+++ b/src/impl/formatter.js
@@ -337,6 +337,14 @@ export default class Formatter {
             return this.num(dt.weekNumber);
           case "WW":
             return this.num(dt.weekNumber, 2);
+          case "n":
+            return this.num(dt.localWeekNumber);
+          case "nn":
+            return this.num(dt.localWeekNumber, 2);
+          case "ii":
+            return this.num(dt.weekYear.toString().slice(-2), 2);
+          case "iiii":
+            return this.num(dt.weekYear, 4);
           case "o":
             return this.num(dt.ordinal);
           case "ooo":

--- a/src/impl/locale.js
+++ b/src/impl/locale.js
@@ -1,4 +1,4 @@
-import { padStart, roundTo, hasRelative, hasLocaleWeekInfo } from "./util.js";
+import { hasLocaleWeekInfo, hasRelative, padStart, roundTo } from "./util.js";
 import * as English from "./english.js";
 import Settings from "../settings.js";
 import DateTime from "../datetime.js";
@@ -500,8 +500,23 @@ export default class Locale {
     if (!hasLocaleWeekInfo()) {
       return 1;
     } else {
-      const data = getCachedWeekInfo(this.locale);
-      return data.firstDay;
+      return getCachedWeekInfo(this.locale).firstDay;
+    }
+  }
+
+  getMinDaysInFirstWeek() {
+    if (!hasLocaleWeekInfo()) {
+      return 4;
+    } else {
+      return getCachedWeekInfo(this.locale).minimalDays;
+    }
+  }
+
+  getWeekendDays() {
+    if (!hasLocaleWeekInfo()) {
+      return [6, 7];
+    } else {
+      return getCachedWeekInfo(this.locale).weekend;
     }
   }
 

--- a/src/impl/locale.js
+++ b/src/impl/locale.js
@@ -1,4 +1,4 @@
-import { hasLocaleWeekInfo, hasRelative, padStart, roundTo } from "./util.js";
+import { hasLocaleWeekInfo, hasRelative, padStart, roundTo, validateWeekSettings } from "./util.js";
 import * as English from "./english.js";
 import Settings from "../settings.js";
 import DateTime from "../datetime.js";
@@ -317,22 +317,35 @@ class PolyRelFormatter {
   }
 }
 
+const fallbackWeekSettings = {
+  firstDay: 1,
+  minimalDays: 4,
+  weekend: [6, 7],
+};
+
 /**
  * @private
  */
 
 export default class Locale {
   static fromOpts(opts) {
-    return Locale.create(opts.locale, opts.numberingSystem, opts.outputCalendar, opts.defaultToEN);
+    return Locale.create(
+      opts.locale,
+      opts.numberingSystem,
+      opts.outputCalendar,
+      opts.weekSettings,
+      opts.defaultToEN
+    );
   }
 
-  static create(locale, numberingSystem, outputCalendar, defaultToEN = false) {
+  static create(locale, numberingSystem, outputCalendar, weekSettings, defaultToEN = false) {
     const specifiedLocale = locale || Settings.defaultLocale;
     // the system locale is useful for human readable strings but annoying for parsing/formatting known formats
     const localeR = specifiedLocale || (defaultToEN ? "en-US" : systemLocale());
     const numberingSystemR = numberingSystem || Settings.defaultNumberingSystem;
     const outputCalendarR = outputCalendar || Settings.defaultOutputCalendar;
-    return new Locale(localeR, numberingSystemR, outputCalendarR, specifiedLocale);
+    const weekSettingsR = validateWeekSettings(weekSettings) || Settings.defaultWeekSettings;
+    return new Locale(localeR, numberingSystemR, outputCalendarR, weekSettingsR, specifiedLocale);
   }
 
   static resetCache() {
@@ -342,16 +355,17 @@ export default class Locale {
     intlRelCache = {};
   }
 
-  static fromObject({ locale, numberingSystem, outputCalendar } = {}) {
-    return Locale.create(locale, numberingSystem, outputCalendar);
+  static fromObject({ locale, numberingSystem, outputCalendar, weekSettings } = {}) {
+    return Locale.create(locale, numberingSystem, outputCalendar, weekSettings);
   }
 
-  constructor(locale, numbering, outputCalendar, specifiedLocale) {
+  constructor(locale, numbering, outputCalendar, weekSettings, specifiedLocale) {
     const [parsedLocale, parsedNumberingSystem, parsedOutputCalendar] = parseLocaleString(locale);
 
     this.locale = parsedLocale;
     this.numberingSystem = numbering || parsedNumberingSystem || null;
     this.outputCalendar = outputCalendar || parsedOutputCalendar || null;
+    this.weekSettings = weekSettings;
     this.intl = intlConfigString(this.locale, this.numberingSystem, this.outputCalendar);
 
     this.weekdaysCache = { format: {}, standalone: {} };
@@ -387,6 +401,7 @@ export default class Locale {
         alts.locale || this.specifiedLocale,
         alts.numberingSystem || this.numberingSystem,
         alts.outputCalendar || this.outputCalendar,
+        validateWeekSettings(alts.weekSettings) || this.weekSettings,
         alts.defaultToEN || false
       );
     }
@@ -495,28 +510,26 @@ export default class Locale {
     );
   }
 
-  getStartOfWeek() {
-    if (!hasLocaleWeekInfo()) {
-      return 1;
+  getWeekSettings() {
+    if (this.weekSettings) {
+      return this.weekSettings;
+    } else if (!hasLocaleWeekInfo()) {
+      return fallbackWeekSettings;
     } else {
-      return getCachedWeekInfo(this.locale).firstDay;
+      return getCachedWeekInfo(this.locale);
     }
+  }
+
+  getStartOfWeek() {
+    return this.getWeekSettings().firstDay;
   }
 
   getMinDaysInFirstWeek() {
-    if (!hasLocaleWeekInfo()) {
-      return 4;
-    } else {
-      return getCachedWeekInfo(this.locale).minimalDays;
-    }
+    return this.getWeekSettings().minimalDays;
   }
 
   getWeekendDays() {
-    if (!hasLocaleWeekInfo()) {
-      return [6, 7];
-    } else {
-      return getCachedWeekInfo(this.locale).weekend;
-    }
+    return this.getWeekSettings().weekend;
   }
 
   equals(other) {

--- a/src/impl/locale.js
+++ b/src/impl/locale.js
@@ -1,4 +1,4 @@
-import { padStart, roundTo, hasRelative, formatOffset } from "./util.js";
+import { padStart, roundTo, hasRelative, hasLocaleWeekInfo } from "./util.js";
 import * as English from "./english.js";
 import Settings from "../settings.js";
 import DateTime from "../datetime.js";
@@ -64,7 +64,7 @@ function systemLocale() {
 let weekInfoCache = {};
 function getCachedWeekInfo(locString) {
   let data = weekInfoCache[locString];
-  if (!data && Intl.Locale) {
+  if (!data) {
     const locale = new Intl.Locale(locString);
     // browsers currently implement this as a property, but spec says it should be a getter function
     data = "getWeekInfo" in locale ? locale.getWeekInfo() : locale.weekInfo;
@@ -497,11 +497,11 @@ export default class Locale {
   }
 
   getStartOfWeek() {
-    if (this.isEnglish()) {
-      return 7;
+    if (!hasLocaleWeekInfo()) {
+      return 1;
     } else {
       const data = getCachedWeekInfo(this.locale);
-      return data?.firstDay;
+      return data.firstDay;
     }
   }
 

--- a/src/impl/locale.js
+++ b/src/impl/locale.js
@@ -61,6 +61,18 @@ function systemLocale() {
   }
 }
 
+let weekInfoCache = {};
+function getCachedWeekInfo(locString) {
+  let data = weekInfoCache[locString];
+  if (!data && Intl.Locale) {
+    const locale = new Intl.Locale(locString);
+    // browsers currently implement this as a property, but spec says it should be a getter function
+    data = "getWeekInfo" in locale ? locale.getWeekInfo() : locale.weekInfo;
+    weekInfoCache[locString] = data;
+  }
+  return data;
+}
+
 function parseLocaleString(localeStr) {
   // I really want to avoid writing a BCP 47 parser
   // see, e.g. https://github.com/wooorm/bcp-47
@@ -482,6 +494,15 @@ export default class Locale {
       this.locale.toLowerCase() === "en-us" ||
       new Intl.DateTimeFormat(this.intl).resolvedOptions().locale.startsWith("en-us")
     );
+  }
+
+  getStartOfWeek() {
+    if (this.isEnglish()) {
+      return 7;
+    } else {
+      const data = getCachedWeekInfo(this.locale);
+      return data?.firstDay;
+    }
   }
 
   equals(other) {

--- a/src/impl/util.js
+++ b/src/impl/util.js
@@ -7,7 +7,6 @@
 import { InvalidArgumentError } from "../errors.js";
 import Settings from "../settings.js";
 import { dayOfWeek, isoWeekdayToLocal } from "./conversions.js";
-import { set } from "husky";
 
 /**
  * @private

--- a/src/impl/util.js
+++ b/src/impl/util.js
@@ -43,6 +43,18 @@ export function hasRelative() {
   }
 }
 
+export function hasLocaleWeekInfo() {
+  try {
+    return (
+      typeof Intl !== "undefined" &&
+      !!Intl.Locale &&
+      ("weekInfo" in Intl.Locale.prototype || "getWeekInfo" in Intl.Locale.prototype)
+    );
+  } catch (e) {
+    return false;
+  }
+}
+
 // OBJECTS AND ARRAYS
 
 export function maybeArray(thing) {

--- a/src/impl/util.js
+++ b/src/impl/util.js
@@ -6,6 +6,7 @@
 
 import { InvalidArgumentError } from "../errors.js";
 import Settings from "../settings.js";
+import { dayOfWeek, isoWeekdayToLocal } from "./conversions.js";
 
 /**
  * @private
@@ -186,16 +187,16 @@ export function objToLocalTS(obj) {
   return +d;
 }
 
-export function weeksInWeekYear(weekYear) {
-  const p1 =
-      (weekYear +
-        Math.floor(weekYear / 4) -
-        Math.floor(weekYear / 100) +
-        Math.floor(weekYear / 400)) %
-      7,
-    last = weekYear - 1,
-    p2 = (last + Math.floor(last / 4) - Math.floor(last / 100) + Math.floor(last / 400)) % 7;
-  return p1 === 4 || p2 === 3 ? 53 : 52;
+// adapted from moment.js: https://github.com/moment/moment/blob/000ac1800e620f770f4eb31b5ae908f6167b0ab2/src/lib/units/week-calendar-utils.js
+function firstWeekOffset(year, minDaysInFirstWeek, startOfWeek) {
+  const fwdlw = isoWeekdayToLocal(dayOfWeek(year, 1, minDaysInFirstWeek), startOfWeek);
+  return -fwdlw + minDaysInFirstWeek - 1;
+}
+
+export function weeksInWeekYear(weekYear, minDaysInFirstWeek = 4, startOfWeek = 1) {
+  const weekOffset = firstWeekOffset(weekYear, minDaysInFirstWeek, startOfWeek);
+  const weekOffsetNext = firstWeekOffset(weekYear + 1, minDaysInFirstWeek, startOfWeek);
+  return (daysInYear(weekYear) - weekOffset + weekOffsetNext) / 7;
 }
 
 export function untruncateYear(year) {

--- a/src/impl/util.js
+++ b/src/impl/util.js
@@ -7,6 +7,7 @@
 import { InvalidArgumentError } from "../errors.js";
 import Settings from "../settings.js";
 import { dayOfWeek, isoWeekdayToLocal } from "./conversions.js";
+import { set } from "husky";
 
 /**
  * @private
@@ -87,6 +88,28 @@ export function pick(obj, keys) {
 
 export function hasOwnProperty(obj, prop) {
   return Object.prototype.hasOwnProperty.call(obj, prop);
+}
+
+export function validateWeekSettings(settings) {
+  if (settings == null) {
+    return null;
+  } else if (typeof settings !== "object") {
+    throw new InvalidArgumentError("Week settings must be an object");
+  } else {
+    if (
+      !integerBetween(settings.firstDay, 1, 7) ||
+      !integerBetween(settings.minimalDays, 1, 7) ||
+      !Array.isArray(settings.weekend) ||
+      settings.weekend.some((v) => !integerBetween(v, 1, 7))
+    ) {
+      throw new InvalidArgumentError("Invalid week settings");
+    }
+    return {
+      firstDay: settings.firstDay,
+      minimalDays: settings.minimalDays,
+      weekend: Array.from(settings.weekend),
+    };
+  }
 }
 
 // NUMBERS AND STRINGS

--- a/src/info.js
+++ b/src/info.js
@@ -49,6 +49,17 @@ export default class Info {
   }
 
   /**
+   * Get the weekday on which the week starts according to the given locale.
+   * @param {Object} opts - options
+   * @param {string} [opts.locale] - the locale code
+   * @param {string} [opts.locObj=null] - an existing locale object to use
+   * @returns {number} the start of the week, 1 for Monday through 7 for Sunday
+   */
+  static getStartOfWeek({ locale = null, locObj = null } = {}) {
+    return (locObj || Locale.create(locale)).getStartOfWeek();
+  }
+
+  /**
    * Return an array of standalone month names.
    * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat
    * @param {string} [length='long'] - the length of the month representation, such as "numeric", "2-digit", "narrow", "short", "long"

--- a/src/info.js
+++ b/src/info.js
@@ -60,6 +60,29 @@ export default class Info {
   }
 
   /**
+   * Get the minimum number of days necessary in a week before it is considered part of the next year according
+   * to the given locale.
+   * @param {Object} opts - options
+   * @param {string} [opts.locale] - the locale code
+   * @param {string} [opts.locObj=null] - an existing locale object to use
+   * @returns {number}
+   */
+  static getMinimumDaysInFirstWeek({ locale = null, locObj = null } = {}) {
+    return (locObj || Locale.create(locale)).getMinDaysInFirstWeek();
+  }
+
+  /**
+   * Get the weekdays, which are considered the weekend according to the given locale
+   * @param {Object} opts - options
+   * @param {string} [opts.locale] - the locale code
+   * @param {string} [opts.locObj=null] - an existing locale object to use
+   * @returns {number[]} an array of weekdays, 1 for Monday through 7 for Sunday
+   */
+  static getWeekendWeekdays({ locale = null, locObj = null } = {}) {
+    return (locObj || Locale.create(locale)).getWeekendDays();
+  }
+
+  /**
    * Return an array of standalone month names.
    * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat
    * @param {string} [length='long'] - the length of the month representation, such as "numeric", "2-digit", "narrow", "short", "long"

--- a/src/info.js
+++ b/src/info.js
@@ -79,7 +79,8 @@ export default class Info {
    * @returns {number[]} an array of weekdays, 1 for Monday through 7 for Sunday
    */
   static getWeekendWeekdays({ locale = null, locObj = null } = {}) {
-    return (locObj || Locale.create(locale)).getWeekendDays();
+    // copy the array, because we cache it internally
+    return (locObj || Locale.create(locale)).getWeekendDays().slice();
   }
 
   /**

--- a/src/info.js
+++ b/src/info.js
@@ -4,7 +4,7 @@ import Locale from "./impl/locale.js";
 import IANAZone from "./zones/IANAZone.js";
 import { normalizeZone } from "./impl/zoneUtil.js";
 
-import { hasRelative } from "./impl/util.js";
+import { hasLocaleWeekInfo, hasRelative } from "./impl/util.js";
 
 /**
  * The Info class contains static methods for retrieving general time and date related data. For example, it has methods for finding out if a time zone has a DST, for listing the months in any supported locale, and for discovering which of Luxon features are available in the current environment.
@@ -160,10 +160,11 @@ export default class Info {
    * Some features of Luxon are not available in all environments. For example, on older browsers, relative time formatting support is not available. Use this function to figure out if that's the case.
    * Keys:
    * * `relative`: whether this environment supports relative time formatting
-   * @example Info.features() //=> { relative: false }
+   * * `localeWeek`: whether this environment supports different weekdays for the start of the week based on the locale
+   * @example Info.features() //=> { relative: false, localeWeek: true }
    * @return {Object}
    */
   static features() {
-    return { relative: hasRelative() };
+    return { relative: hasRelative(), localeWeek: hasLocaleWeekInfo() };
   }
 }

--- a/src/interval.js
+++ b/src/interval.js
@@ -238,6 +238,7 @@ export default class Interval {
    */
   count(unit = "milliseconds") {
     if (!this.isValid) return NaN;
+    // TODO: implement locale weeks
     const start = this.start.startOf(unit),
       end = this.end.startOf(unit);
     return Math.floor(end.diff(start, unit).get(unit)) + (end.valueOf() !== this.end.valueOf());

--- a/src/interval.js
+++ b/src/interval.js
@@ -234,13 +234,20 @@ export default class Interval {
    * Unlike {@link Interval#length} this counts sections of the calendar, not periods of time, e.g. specifying 'day'
    * asks 'what dates are included in this interval?', not 'how many days long is this interval?'
    * @param {string} [unit='milliseconds'] - the unit of time to count.
+   * @param {Object} opts - options
+   * @param {boolean} [opts.useLocaleWeeks=false] - If true, use weeks based on the locale, i.e. use the locale-dependent start of the week; this operation will always use the locale of the start DateTime
    * @return {number}
    */
-  count(unit = "milliseconds") {
+  count(unit = "milliseconds", opts) {
     if (!this.isValid) return NaN;
-    // TODO: implement locale weeks
-    const start = this.start.startOf(unit),
-      end = this.end.startOf(unit);
+    const start = this.start.startOf(unit, opts);
+    let end;
+    if (opts?.useLocaleWeeks) {
+      end = this.end.reconfigure({ locale: start.locale });
+    } else {
+      end = this.end;
+    }
+    end = end.startOf(unit, opts);
     return Math.floor(end.diff(start, unit).get(unit)) + (end.valueOf() !== this.end.valueOf());
   }
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -3,6 +3,7 @@ import IANAZone from "./zones/IANAZone.js";
 import Locale from "./impl/locale.js";
 
 import { normalizeZone } from "./impl/zoneUtil.js";
+import { validateWeekSettings } from "./impl/util.js";
 
 let now = () => Date.now(),
   defaultZone = "system",
@@ -10,7 +11,8 @@ let now = () => Date.now(),
   defaultNumberingSystem = null,
   defaultOutputCalendar = null,
   twoDigitCutoffYear = 60,
-  throwOnInvalid;
+  throwOnInvalid,
+  defaultWeekSettings = null;
 
 /**
  * Settings contains static getters and setters that control Luxon's overall behavior. Luxon is a simple library with few options, but the ones it does have live here.
@@ -99,6 +101,31 @@ export default class Settings {
    */
   static set defaultOutputCalendar(outputCalendar) {
     defaultOutputCalendar = outputCalendar;
+  }
+
+  /**
+   * @typedef {Object} WeekSettings
+   * @property {number} firstDay
+   * @property {number} minimalDays
+   * @property {number[]} weekend
+   */
+
+  /**
+   * @return {WeekSettings|null}
+   */
+  static get defaultWeekSettings() {
+    return defaultWeekSettings;
+  }
+
+  /**
+   * Allows overriding the default locale week settings, i.e. the start of the week, the weekend and
+   * how many days are required in the first week of a year.
+   * Does not affect existing instances.
+   *
+   * @param {WeekSettings|null} weekSettings
+   */
+  static set defaultWeekSettings(weekSettings) {
+    defaultWeekSettings = validateWeekSettings(weekSettings);
   }
 
   /**

--- a/test/datetime/create.test.js
+++ b/test/datetime/create.test.js
@@ -595,6 +595,77 @@ test("DateTime.fromObject() w/weeks defaults low-order values to their minimums"
   expect(dt.millisecond).toBe(0);
 });
 
+test("DateTime.fromObject() w/locale weeks defaults low-order values to their minimums", () => {
+  const dt = DateTime.fromObject({ localWeekYear: 2016 }, { locale: "en-US" });
+
+  expect(dt.localWeekYear).toBe(2016);
+  expect(dt.localWeekNumber).toBe(1);
+  expect(dt.localWeekday).toBe(1);
+  expect(dt.hour).toBe(0);
+  expect(dt.minute).toBe(0);
+  expect(dt.second).toBe(0);
+  expect(dt.millisecond).toBe(0);
+});
+
+test("DateTime.fromObject() w/locale weeks defaults high-order values to the current date", () => {
+  const dt = DateTime.fromObject({ localWeekday: 2 }, { locale: "en-US" }),
+    now = DateTime.local({ locale: "en-US" });
+
+  expect(dt.localWeekYear).toBe(now.localWeekYear);
+  expect(dt.localWeekNumber).toBe(now.localWeekNumber);
+  expect(dt.localWeekday).toBe(2);
+});
+
+test("DateTime.fromObject() w/locale weeks handles fully specified dates", () => {
+  const dt = DateTime.fromObject(
+    {
+      localWeekYear: 2022,
+      localWeekNumber: 2,
+      localWeekday: 3,
+      hour: 9,
+      minute: 23,
+      second: 54,
+      millisecond: 123,
+    },
+    { locale: "en-US" }
+  );
+  expect(dt.localWeekYear).toBe(2022);
+  expect(dt.localWeekNumber).toBe(2);
+  expect(dt.localWeekday).toBe(3);
+  expect(dt.year).toBe(2022);
+  expect(dt.month).toBe(1);
+  expect(dt.day).toBe(4);
+});
+
+test("DateTime.fromObject() w/localWeekYears handles skew with Gregorian years", () => {
+  let dt = DateTime.fromObject(
+    { localWeekYear: 2022, localWeekNumber: 1, localWeekday: 1 },
+    { locale: "en-US" }
+  );
+  expect(dt.localWeekYear).toBe(2022);
+  expect(dt.localWeekNumber).toBe(1);
+  expect(dt.localWeekday).toBe(1);
+  expect(dt.year).toBe(2021);
+  expect(dt.month).toBe(12);
+  expect(dt.day).toBe(26);
+
+  dt = DateTime.fromObject(
+    { localWeekYear: 2009, localWeekNumber: 53, localWeekday: 5 },
+    { locale: "de-DE" }
+  );
+  expect(dt.localWeekYear).toBe(2009);
+  expect(dt.localWeekNumber).toBe(53);
+  expect(dt.localWeekday).toBe(5);
+  expect(dt.year).toBe(2010);
+  expect(dt.month).toBe(1);
+  expect(dt.day).toBe(1);
+});
+
+test("DateTime.fromObject throws when both locale based weeks and ISO-weeks are specified", () => {
+  expect(() => DateTime.fromObject({ localWeekYear: 2022, weekNumber: 12 })).toThrow();
+  expect(() => DateTime.fromObject({ localWeekYear: 2022, weekday: 2 })).toThrow();
+});
+
 test("DateTime.fromObject() w/ordinals handles fully specified dates", () => {
   const dt = DateTime.fromObject({
     year: 2016,

--- a/test/datetime/localeWeek.test.js
+++ b/test/datetime/localeWeek.test.js
@@ -1,0 +1,43 @@
+/* global test expect */
+
+import { DateTime } from "../../src/luxon";
+
+//------
+// .startOf() with useLocaleWeeks
+//------
+test("startOf locale week adheres to the locale", () => {
+  const dt = DateTime.fromISO("2023-06-14T13:00:00Z", { setZone: true });
+  expect(
+    dt.reconfigure({ locale: "de-DE" }).startOf("week", { useLocaleWeeks: true }).toISO()
+  ).toBe("2023-06-12T00:00:00.000Z");
+  expect(
+    dt.reconfigure({ locale: "en-US" }).startOf("week", { useLocaleWeeks: true }).toISO()
+  ).toBe("2023-06-11T00:00:00.000Z");
+});
+
+test("startOf locale week handles crossing into the previous year", () => {
+  const dt = DateTime.fromISO("2023-01-01T13:00:00Z", { setZone: true });
+  expect(
+    dt.reconfigure({ locale: "de-DE" }).startOf("week", { useLocaleWeeks: true }).toISO()
+  ).toBe("2022-12-26T00:00:00.000Z");
+});
+
+//------
+// .endOf() with useLocaleWeeks
+//------
+test("endOf locale week adheres to the locale", () => {
+  const dt = DateTime.fromISO("2023-06-14T13:00:00Z", { setZone: true });
+  expect(dt.reconfigure({ locale: "de-DE" }).endOf("week", { useLocaleWeeks: true }).toISO()).toBe(
+    "2023-06-18T23:59:59.999Z"
+  );
+  expect(dt.reconfigure({ locale: "en-US" }).endOf("week", { useLocaleWeeks: true }).toISO()).toBe(
+    "2023-06-17T23:59:59.999Z"
+  );
+});
+
+test("endOf locale week handles crossing into the next year", () => {
+  const dt = DateTime.fromISO("2022-12-31T13:00:00Z", { setZone: true });
+  expect(dt.reconfigure({ locale: "de-DE" }).endOf("week", { useLocaleWeeks: true }).toISO()).toBe(
+    "2023-01-01T23:59:59.999Z"
+  );
+});

--- a/test/datetime/localeWeek.test.js
+++ b/test/datetime/localeWeek.test.js
@@ -210,3 +210,18 @@ describe("localWeekday in locale de-DE", () => {
     expect(dt.localWeekday).toBe(7);
   });
 });
+
+describe("weeksInLocalWeekYear", () => {
+  test("2018 should have 53 weeks in en-US", () => {
+    expect(DateTime.local(2018, 6, 1, { locale: "en-US" }).weeksInLocalWeekYear).toBe(52);
+  });
+  test("2022 should have 53 weeks in en-US", () => {
+    expect(DateTime.local(2022, 6, 1, { locale: "en-US" }).weeksInLocalWeekYear).toBe(53);
+  });
+  test("2022 should have 52 weeks in de-DE", () => {
+    expect(DateTime.local(2022, 6, 1, { locale: "de-DE" }).weeksInLocalWeekYear).toBe(52);
+  });
+  test("2020 should have 53 weeks in de-DE", () => {
+    expect(DateTime.local(2020, 6, 1, { locale: "de-DE" }).weeksInLocalWeekYear).toBe(53);
+  });
+});

--- a/test/datetime/localeWeek.test.js
+++ b/test/datetime/localeWeek.test.js
@@ -61,3 +61,28 @@ test("hasSame(week) with useLocaleWeeks ignores the locale of otherDateTime", ()
   expect(dt1.hasSame(dt2, "week", { useLocaleWeeks: true })).toBe(true);
   expect(dt2.hasSame(dt1, "week", { useLocaleWeeks: true })).toBe(false);
 });
+
+//------
+// .isWeekend
+//------
+
+const week = [
+  "2023-07-31T00:00:00Z", // Monday
+  "2023-08-01T00:00:00Z",
+  "2023-08-02T00:00:00Z",
+  "2023-08-03T00:00:00Z",
+  "2023-08-04T00:00:00Z",
+  "2023-08-05T00:00:00Z",
+  "2023-08-06T00:00:00Z", // Sunday
+];
+test("isWeekend in locale en-US reports Saturday and Sunday as weekend", () => {
+  const dates = week.map(
+    (iso) => DateTime.fromISO(iso, { setZone: true, locale: "en-US" }).isWeekend
+  );
+  expect(dates).toStrictEqual([false, false, false, false, false, true, true]);
+});
+
+test("isWeekend in locale he reports Friday and Saturday as weekend", () => {
+  const dates = week.map((iso) => DateTime.fromISO(iso, { setZone: true, locale: "he" }).isWeekend);
+  expect(dates).toStrictEqual([false, false, false, false, true, true, false]);
+});

--- a/test/datetime/localeWeek.test.js
+++ b/test/datetime/localeWeek.test.js
@@ -145,3 +145,68 @@ describe("localWeekNumber in locale en-US", () => {
     expect(dt.localWeekYear).toBe(2012);
   });
 });
+
+//------
+// .localWeekday
+//------
+describe("localWeekday in locale en-US", () => {
+  test("Sunday should be reported as the 1st day of the week", () => {
+    const dt = DateTime.fromISO("2023-08-06", { locale: "en-US" });
+    expect(dt.localWeekday).toBe(1);
+  });
+  test("Monday should be reported as the 2nd day of the week", () => {
+    const dt = DateTime.fromISO("2023-08-07", { locale: "en-US" });
+    expect(dt.localWeekday).toBe(2);
+  });
+  test("Tuesday should be reported as the 3rd day of the week", () => {
+    const dt = DateTime.fromISO("2023-08-08", { locale: "en-US" });
+    expect(dt.localWeekday).toBe(3);
+  });
+  test("Wednesday should be reported as the 4th day of the week", () => {
+    const dt = DateTime.fromISO("2023-08-09", { locale: "en-US" });
+    expect(dt.localWeekday).toBe(4);
+  });
+  test("Thursday should be reported as the 5th day of the week", () => {
+    const dt = DateTime.fromISO("2023-08-10", { locale: "en-US" });
+    expect(dt.localWeekday).toBe(5);
+  });
+  test("Friday should be reported as the 6th day of the week", () => {
+    const dt = DateTime.fromISO("2023-08-11", { locale: "en-US" });
+    expect(dt.localWeekday).toBe(6);
+  });
+  test("Saturday should be reported as the 7th day of the week", () => {
+    const dt = DateTime.fromISO("2023-08-12", { locale: "en-US" });
+    expect(dt.localWeekday).toBe(7);
+  });
+});
+
+describe("localWeekday in locale de-DE", () => {
+  test("Monday should be reported as the 1st day of the week", () => {
+    const dt = DateTime.fromISO("2023-08-07", { locale: "de-DE" });
+    expect(dt.localWeekday).toBe(1);
+  });
+  test("Tuesday should be reported as the 2nd day of the week", () => {
+    const dt = DateTime.fromISO("2023-08-08", { locale: "de-DE" });
+    expect(dt.localWeekday).toBe(2);
+  });
+  test("Wednesday should be reported as the 3rd day of the week", () => {
+    const dt = DateTime.fromISO("2023-08-09", { locale: "de-DE" });
+    expect(dt.localWeekday).toBe(3);
+  });
+  test("Thursday should be reported as the 4th day of the week", () => {
+    const dt = DateTime.fromISO("2023-08-10", { locale: "de-DE" });
+    expect(dt.localWeekday).toBe(4);
+  });
+  test("Friday should be reported as the 5th day of the week", () => {
+    const dt = DateTime.fromISO("2023-08-11", { locale: "de-DE" });
+    expect(dt.localWeekday).toBe(5);
+  });
+  test("Saturday should be reported as the 6th day of the week", () => {
+    const dt = DateTime.fromISO("2023-08-12", { locale: "de-DE" });
+    expect(dt.localWeekday).toBe(6);
+  });
+  test("Sunday should be reported as the 7th day of the week", () => {
+    const dt = DateTime.fromISO("2023-08-13", { locale: "de-DE" });
+    expect(dt.localWeekday).toBe(7);
+  });
+});

--- a/test/datetime/localeWeek.test.js
+++ b/test/datetime/localeWeek.test.js
@@ -86,3 +86,62 @@ test("isWeekend in locale he reports Friday and Saturday as weekend", () => {
   const dates = week.map((iso) => DateTime.fromISO(iso, { setZone: true, locale: "he" }).isWeekend);
   expect(dates).toStrictEqual([false, false, false, false, true, true, false]);
 });
+
+//------
+// .localWeekNumber / .localWeekYear
+//------
+describe("localWeekNumber in locale de-DE", () => {
+  test("Jan  1 2012 should be week 52, year 2011", () => {
+    const dt = DateTime.fromISO("2012-01-01", { locale: "de-DE" });
+    expect(dt.localWeekNumber).toBe(52);
+    expect(dt.localWeekYear).toBe(2011);
+  });
+  test("Jan  2 2012 should be week 1, year 2012", () => {
+    const dt = DateTime.fromISO("2012-01-02", { locale: "de-DE" });
+    expect(dt.localWeekNumber).toBe(1);
+    expect(dt.localWeekYear).toBe(2012);
+  });
+  test("Jan  8 2012 should be week 1, year 2012", () => {
+    const dt = DateTime.fromISO("2012-01-08", { locale: "de-DE" });
+    expect(dt.localWeekNumber).toBe(1);
+    expect(dt.localWeekYear).toBe(2012);
+  });
+  test("Jan  9 2012 should be week 2, year 2012", () => {
+    const dt = DateTime.fromISO("2012-01-09", { locale: "de-DE" });
+    expect(dt.localWeekNumber).toBe(2);
+    expect(dt.localWeekYear).toBe(2012);
+  });
+  test("Jan  15 2012 should be week 2, year 2012", () => {
+    const dt = DateTime.fromISO("2012-01-15", { locale: "de-DE" });
+    expect(dt.localWeekNumber).toBe(2);
+    expect(dt.localWeekYear).toBe(2012);
+  });
+});
+
+describe("localWeekNumber in locale en-US", () => {
+  test("Jan  1 2012 should be week 1, year 2012", () => {
+    const dt = DateTime.fromISO("2012-01-01", { locale: "en-US" });
+    expect(dt.localWeekNumber).toBe(1);
+    expect(dt.localWeekYear).toBe(2012);
+  });
+  test("Jan  7 2012 should be week 1, year 2012", () => {
+    const dt = DateTime.fromISO("2012-01-07", { locale: "en-US" });
+    expect(dt.localWeekNumber).toBe(1);
+    expect(dt.localWeekYear).toBe(2012);
+  });
+  test("Jan  8 2012 should be week 2, year 2012", () => {
+    const dt = DateTime.fromISO("2012-01-08", { locale: "en-US" });
+    expect(dt.localWeekNumber).toBe(2);
+    expect(dt.localWeekYear).toBe(2012);
+  });
+  test("Jan  14 2012 should be week 2, year 2012", () => {
+    const dt = DateTime.fromISO("2012-01-14", { locale: "en-US" });
+    expect(dt.localWeekNumber).toBe(2);
+    expect(dt.localWeekYear).toBe(2012);
+  });
+  test("Jan  15 2012 should be week 3, year 2012", () => {
+    const dt = DateTime.fromISO("2012-01-15", { locale: "en-US" });
+    expect(dt.localWeekNumber).toBe(3);
+    expect(dt.localWeekYear).toBe(2012);
+  });
+});

--- a/test/datetime/localeWeek.test.js
+++ b/test/datetime/localeWeek.test.js
@@ -5,7 +5,7 @@ import { DateTime } from "../../src/luxon";
 //------
 // .startOf() with useLocaleWeeks
 //------
-test("startOf locale week adheres to the locale", () => {
+test("startOf(week) with useLocaleWeeks adheres to the locale", () => {
   const dt = DateTime.fromISO("2023-06-14T13:00:00Z", { setZone: true });
   expect(
     dt.reconfigure({ locale: "de-DE" }).startOf("week", { useLocaleWeeks: true }).toISO()
@@ -15,7 +15,7 @@ test("startOf locale week adheres to the locale", () => {
   ).toBe("2023-06-11T00:00:00.000Z");
 });
 
-test("startOf locale week handles crossing into the previous year", () => {
+test("startOf(week) with useLocaleWeeks handles crossing into the previous year", () => {
   const dt = DateTime.fromISO("2023-01-01T13:00:00Z", { setZone: true });
   expect(
     dt.reconfigure({ locale: "de-DE" }).startOf("week", { useLocaleWeeks: true }).toISO()
@@ -25,7 +25,7 @@ test("startOf locale week handles crossing into the previous year", () => {
 //------
 // .endOf() with useLocaleWeeks
 //------
-test("endOf locale week adheres to the locale", () => {
+test("endOf(week) with useLocaleWeeks adheres to the locale", () => {
   const dt = DateTime.fromISO("2023-06-14T13:00:00Z", { setZone: true });
   expect(dt.reconfigure({ locale: "de-DE" }).endOf("week", { useLocaleWeeks: true }).toISO()).toBe(
     "2023-06-18T23:59:59.999Z"
@@ -35,9 +35,29 @@ test("endOf locale week adheres to the locale", () => {
   );
 });
 
-test("endOf locale week handles crossing into the next year", () => {
+test("endOf(week) with useLocaleWeeks handles crossing into the next year", () => {
   const dt = DateTime.fromISO("2022-12-31T13:00:00Z", { setZone: true });
   expect(dt.reconfigure({ locale: "de-DE" }).endOf("week", { useLocaleWeeks: true }).toISO()).toBe(
     "2023-01-01T23:59:59.999Z"
   );
+});
+
+//------
+// .hasSame() with useLocaleWeeks
+//------
+test("hasSame(week) with useLocaleWeeks adheres to the locale", () => {
+  const dt1 = DateTime.fromISO("2023-06-11T03:00:00Z", { setZone: true, locale: "en-US" });
+  const dt2 = DateTime.fromISO("2023-06-14T03:00:00Z", { setZone: true, locale: "en-US" });
+  expect(dt1.hasSame(dt2, "week", { useLocaleWeeks: true })).toBe(true);
+
+  const dt3 = DateTime.fromISO("2023-06-14T03:00:00Z", { setZone: true, locale: "en-US" });
+  const dt4 = DateTime.fromISO("2023-06-18T03:00:00Z", { setZone: true, locale: "en-US" });
+  expect(dt3.hasSame(dt4, "week", { useLocaleWeeks: true })).toBe(false);
+});
+
+test("hasSame(week) with useLocaleWeeks ignores the locale of otherDateTime", () => {
+  const dt1 = DateTime.fromISO("2023-06-11T03:00:00Z", { setZone: true, locale: "en-US" });
+  const dt2 = DateTime.fromISO("2023-06-14T03:00:00Z", { setZone: true, locale: "de-DE" });
+  expect(dt1.hasSame(dt2, "week", { useLocaleWeeks: true })).toBe(true);
+  expect(dt2.hasSame(dt1, "week", { useLocaleWeeks: true })).toBe(false);
 });

--- a/test/datetime/set.test.js
+++ b/test/datetime/set.test.js
@@ -87,6 +87,120 @@ test("DateTime#set({ weekday }) handles week year edge cases", () => {
 });
 
 //------
+// locale-based week units
+//------
+
+test("DateTime#set({ localWeekday }) sets the weekday to this week's matching day based on the locale (en-US)", () => {
+  const modified = dt.reconfigure({ locale: "en-US" }).set({ localWeekday: 1 });
+  expect(modified.localWeekday).toBe(1);
+  expect(modified.weekday).toBe(7);
+  expect(modified.year).toBe(1982);
+  expect(modified.month).toBe(5);
+  expect(modified.day).toBe(23);
+  expect(modified.hour).toBe(9);
+  expect(modified.minute).toBe(23);
+  expect(modified.second).toBe(54);
+  expect(modified.millisecond).toBe(123);
+});
+
+test("DateTime#set({ localWeekday }) sets the weekday to this week's matching day based on the locale (de-DE)", () => {
+  const modified = dt.reconfigure({ locale: "de-DE" }).set({ localWeekday: 1 });
+  expect(modified.localWeekday).toBe(1);
+  expect(modified.weekday).toBe(1);
+  expect(modified.year).toBe(1982);
+  expect(modified.month).toBe(5);
+  expect(modified.day).toBe(24);
+  expect(modified.hour).toBe(9);
+  expect(modified.minute).toBe(23);
+  expect(modified.second).toBe(54);
+  expect(modified.millisecond).toBe(123);
+});
+
+test("DateTime#set({ localWeekday }) handles crossing over into the previous year", () => {
+  const modified = DateTime.local(2022, 1, 1, 9, 23, 54, 123, { locale: "en-US" }).set({
+    localWeekday: 2,
+  });
+  expect(modified.localWeekday).toBe(2);
+  expect(modified.weekday).toBe(1);
+  expect(modified.year).toBe(2021);
+  expect(modified.month).toBe(12);
+  expect(modified.day).toBe(27);
+  expect(modified.hour).toBe(9);
+  expect(modified.minute).toBe(23);
+  expect(modified.second).toBe(54);
+  expect(modified.millisecond).toBe(123);
+});
+
+test("DateTime#set({ localWeekday }) handles crossing over into the previous year", () => {
+  const modified = DateTime.local(2022, 1, 1, 9, 23, 54, 123, { locale: "en-US" }).set({
+    localWeekday: 2,
+  });
+  expect(modified.localWeekday).toBe(2);
+  expect(modified.weekday).toBe(1);
+  expect(modified.year).toBe(2021);
+  expect(modified.month).toBe(12);
+  expect(modified.day).toBe(27);
+  expect(modified.hour).toBe(9);
+  expect(modified.minute).toBe(23);
+  expect(modified.second).toBe(54);
+  expect(modified.millisecond).toBe(123);
+});
+
+test("DateTime#set({ localWeekNumber }) sets the date to the same weekday of the target weekNumber (en-US)", () => {
+  const modified = dt.reconfigure({ locale: "en-US" }).set({ localWeekNumber: 2 });
+  expect(modified.weekday).toBe(2); // still tuesday
+  expect(modified.localWeekNumber).toBe(2);
+  expect(modified.year).toBe(1982);
+  expect(modified.month).toBe(1);
+  expect(modified.day).toBe(5);
+  expect(modified.hour).toBe(9);
+  expect(modified.minute).toBe(23);
+  expect(modified.second).toBe(54);
+  expect(modified.millisecond).toBe(123);
+});
+
+test("DateTime#set({ localWeekNumber }) sets the date to the same weekday of the target weekNumber (de-DE)", () => {
+  const modified = dt.reconfigure({ locale: "de-DE" }).set({ localWeekNumber: 2 });
+  expect(modified.weekday).toBe(2); // still tuesday
+  expect(modified.localWeekNumber).toBe(2);
+  expect(modified.year).toBe(1982);
+  expect(modified.month).toBe(1);
+  expect(modified.day).toBe(12);
+  expect(modified.hour).toBe(9);
+  expect(modified.minute).toBe(23);
+  expect(modified.second).toBe(54);
+  expect(modified.millisecond).toBe(123);
+});
+
+test("DateTime#set({ localWeekYear }) sets the date to the same weekNumber/weekday of the target weekYear (en-US)", () => {
+  const modified = dt.reconfigure({ locale: "en-US" }).set({ localWeekYear: 2017 });
+  expect(modified.localWeekday).toBe(3); // still tuesday
+  expect(modified.localWeekNumber).toBe(22); // still week 22
+  expect(modified.localWeekYear).toBe(2017);
+  expect(modified.year).toBe(2017);
+  expect(modified.month).toBe(5);
+  expect(modified.day).toBe(30); // 2017-W22-3 is the 30
+  expect(modified.hour).toBe(9);
+  expect(modified.minute).toBe(23);
+  expect(modified.second).toBe(54);
+  expect(modified.millisecond).toBe(123);
+});
+
+test("DateTime#set({ localWeekYear }) sets the date to the same weekNumber/weekday of the target weekYear (de-DE)", () => {
+  const modified = dt.reconfigure({ locale: "de-DE" }).set({ localWeekYear: 2017 });
+  expect(modified.localWeekday).toBe(2); // still tuesday
+  expect(modified.localWeekNumber).toBe(21); // still week 21
+  expect(modified.localWeekYear).toBe(2017);
+  expect(modified.year).toBe(2017);
+  expect(modified.month).toBe(5);
+  expect(modified.day).toBe(23); // 2017-W21-2 is the 30
+  expect(modified.hour).toBe(9);
+  expect(modified.minute).toBe(23);
+  expect(modified.second).toBe(54);
+  expect(modified.millisecond).toBe(123);
+});
+
+//------
 // year/ordinal
 //------
 test("DateTime#set({ ordinal }) sets the date to the ordinal within the current year", () => {
@@ -127,6 +241,10 @@ test("DateTime#set throws for mixing incompatible units", () => {
   expect(() => dt.set({ year: 2020, weekNumber: 22 })).toThrow();
   expect(() => dt.set({ ordinal: 200, weekNumber: 22 })).toThrow();
   expect(() => dt.set({ ordinal: 200, month: 8 })).toThrow();
+  expect(() => dt.set({ year: 2020, localWeekNumber: 22 })).toThrow();
+  expect(() => dt.set({ ordinal: 200, localWeekNumber: 22 })).toThrow();
+  expect(() => dt.set({ weekday: 2, localWeekNumber: 22 })).toThrow();
+  expect(() => dt.set({ weekday: 2, localWeekYear: 2022 })).toThrow();
 });
 
 test("DateTime#set maintains invalidity", () => {

--- a/test/datetime/toFormat.test.js
+++ b/test/datetime/toFormat.test.js
@@ -553,3 +553,23 @@ test("DateTime#toFormat('X') rounds down", () => {
 test("DateTime#toFormat('x') returns a Unix timestamp in milliseconds", () => {
   expect(dt.toFormat("x")).toBe("391166634123");
 });
+
+test("DateTime#toFormat('n')", () => {
+  expect(DateTime.fromISO("2012-01-01", { locale: "de-DE" }).toFormat("n")).toBe("52");
+  expect(DateTime.fromISO("2012-01-01", { locale: "en-US" }).toFormat("n")).toBe("1");
+});
+
+test("DateTime#toFormat('nn')", () => {
+  expect(DateTime.fromISO("2012-01-01", { locale: "de-DE" }).toFormat("nn")).toBe("52");
+  expect(DateTime.fromISO("2012-01-01", { locale: "en-US" }).toFormat("nn")).toBe("01");
+});
+
+test("DateTime#toFormat('ii')", () => {
+  expect(DateTime.fromISO("2012-01-01", { locale: "de-DE" }).toFormat("ii")).toBe("11");
+  expect(DateTime.fromISO("2012-01-01", { locale: "en-US" }).toFormat("ii")).toBe("12");
+});
+
+test("DateTime#toFormat('iiii')", () => {
+  expect(DateTime.fromISO("2012-01-01", { locale: "de-DE" }).toFormat("iiii")).toBe("2011");
+  expect(DateTime.fromISO("2012-01-01", { locale: "en-US" }).toFormat("iiii")).toBe("2012");
+});

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -15,6 +15,20 @@ exports.withoutRTF = function (name, f) {
   });
 };
 
+exports.withoutLocaleWeekInfo = function (name, f) {
+  const fullName = `With no Intl.Locale.weekInfo support, ${name}`;
+  test(fullName, () => {
+    const l = Intl.Locale;
+    try {
+      Intl.Locale = undefined;
+      Settings.resetCaches();
+      f();
+    } finally {
+      Intl.Locale = l;
+    }
+  });
+};
+
 exports.withNow = function (name, dt, f) {
   test(name, () => {
     const oldNow = Settings.now;

--- a/test/info/features.test.js
+++ b/test/info/features.test.js
@@ -5,8 +5,13 @@ const Helpers = require("../helpers");
 
 test("Info.features shows this environment supports all the features", () => {
   expect(Info.features().relative).toBe(true);
+  expect(Info.features().localeWeek).toBe(true);
 });
 
 Helpers.withoutRTF("Info.features shows no support", () => {
   expect(Info.features().relative).toBe(false);
+});
+
+Helpers.withoutLocaleWeekInfo("Info.features shows no support", () => {
+  expect(Info.features().localeWeek).toBe(false);
 });

--- a/test/info/localeWeek.test.js
+++ b/test/info/localeWeek.test.js
@@ -1,0 +1,24 @@
+/* global test expect */
+import { Info } from "../../src/luxon";
+
+const Helpers = require("../helpers");
+
+test("Info.getStartOfWeek reports the correct start of the week", () => {
+  expect(Info.getStartOfWeek({ locale: "en-US" })).toBe(7);
+  expect(Info.getStartOfWeek({ locale: "de-DE" })).toBe(1);
+});
+
+Helpers.withoutLocaleWeekInfo("Info.getStartOfWeek reports Monday as the start of the week", () => {
+  expect(Info.getStartOfWeek({ locale: "en-US" })).toBe(1);
+  expect(Info.getStartOfWeek({ locale: "de-DE" })).toBe(1);
+});
+
+test("Info.getStartOfWeek honors the default locale", () => {
+  Helpers.withDefaultLocale("en-US", () => {
+    expect(Info.getStartOfWeek()).toBe(7);
+  });
+
+  Helpers.withDefaultLocale("de-DE", () => {
+    expect(Info.getStartOfWeek()).toBe(1);
+  });
+});

--- a/test/info/localeWeek.test.js
+++ b/test/info/localeWeek.test.js
@@ -13,12 +13,42 @@ Helpers.withoutLocaleWeekInfo("Info.getStartOfWeek reports Monday as the start o
   expect(Info.getStartOfWeek({ locale: "de-DE" })).toBe(1);
 });
 
+test("Info.getMinimumDaysInFirstWeek reports the correct value", () => {
+  expect(Info.getMinimumDaysInFirstWeek({ locale: "en-US" })).toBe(1);
+  expect(Info.getMinimumDaysInFirstWeek({ locale: "de-DE" })).toBe(4);
+});
+
+Helpers.withoutLocaleWeekInfo("Info.getMinimumDaysInFirstWeek reports 4", () => {
+  expect(Info.getMinimumDaysInFirstWeek({ locale: "en-US" })).toBe(4);
+  expect(Info.getMinimumDaysInFirstWeek({ locale: "de-DE" })).toBe(4);
+});
+
+test("Info.getWeekendWeekdays reports the correct value", () => {
+  expect(Info.getWeekendWeekdays({ locale: "en-US" })).toStrictEqual([6, 7]);
+  expect(Info.getWeekendWeekdays({ locale: "he" })).toStrictEqual([5, 6]);
+});
+
+Helpers.withoutLocaleWeekInfo("Info.getWeekendWeekdays reports [6, 7]", () => {
+  expect(Info.getWeekendWeekdays({ locale: "en-US" })).toStrictEqual([6, 7]);
+  expect(Info.getWeekendWeekdays({ locale: "he" })).toStrictEqual([6, 7]);
+});
+
 test("Info.getStartOfWeek honors the default locale", () => {
   Helpers.withDefaultLocale("en-US", () => {
     expect(Info.getStartOfWeek()).toBe(7);
+    expect(Info.getMinimumDaysInFirstWeek()).toBe(1);
+    expect(Info.getWeekendWeekdays()).toStrictEqual([6, 7]);
   });
 
   Helpers.withDefaultLocale("de-DE", () => {
     expect(Info.getStartOfWeek()).toBe(1);
+  });
+
+  Helpers.withDefaultLocale("he", () => {
+    expect(Info.getWeekendWeekdays()).toStrictEqual([5, 6]);
+  });
+
+  Helpers.withDefaultLocale("he", () => {
+    expect(Info.getWeekendWeekdays()).toStrictEqual([5, 6]);
   });
 });

--- a/test/interval/localeWeek.test.js
+++ b/test/interval/localeWeek.test.js
@@ -1,0 +1,22 @@
+/* global test expect */
+
+import { DateTime, Interval } from "../../src/luxon";
+
+//------
+// .count() with useLocaleWeeks
+//------
+test("count(weeks) with useLocaleWeeks adheres to the locale", () => {
+  const start = DateTime.fromISO("2023-06-04T13:00:00Z", { setZone: true, locale: "en-US" });
+  const end = DateTime.fromISO("2023-06-23T13:00:00Z", { setZone: true, locale: "en-US" });
+  const interval = Interval.fromDateTimes(start, end);
+
+  expect(interval.count("weeks", { useLocaleWeeks: true })).toBe(3);
+});
+
+test("count(weeks) with useLocaleWeeks uses the start locale", () => {
+  const start = DateTime.fromISO("2023-06-04T13:00:00Z", { setZone: true, locale: "de-DE" });
+  const end = DateTime.fromISO("2023-06-23T13:00:00Z", { setZone: true, locale: "en-US" });
+  const interval = Interval.fromDateTimes(start, end);
+
+  expect(interval.count("weeks", { useLocaleWeeks: true })).toBe(4);
+});


### PR DESCRIPTION
Use [`Intl.Locale#getWeekInfo`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getWeekInfo) to provide locale-dependent week information, such as the start of the week.

Fixes #1447

### Current status:

- [x] `Info.features` reports on whether localized week info is available in the current environment
- [x] `Info.getStartOfWeek`: returns 1 (Monday) through 7 (Sunday) for first day of the week according to locale
- [x] `Info.getMinimumDaysInFirstWeek` for getting minimum days in the first week of the year
- [X] `Info.getWeekendWeekdays`  for getting weekend days
- [x] `DateTime#isWeekend`: returns whether the current date is on the weekend according to the locale
- [x] `DateTime#localWeekday`: returns 1-7 for first to last day according to locale
- [x] `DateTime#localWeekNumber` and `DateTime#localWeekYear`; same as weekNumber and weekYear, but respecting the locale. I need to understand the math here before I can implement it.
- [x] `DateTime#hasSame`, `DateTime#startOf`, `DateTime#endOf` and `Interval#count` accept a new option `useLocaleWeeks`, when enabled the `week` unit will act according to the locale week information
- [x] Tests
- [x] (Potentially) Caching for the localized week data (weekNumber, weekYear)
- [X] Investigate how to let the user override the defaults. There are BCP tags to set the start of the week, but browsers seem to ignore them, so we probably need to provide our own configuration option, similar to `numberingSystem`.
- [X] Accept locale-based week units in `DateTime.fromObject` and `DateTime#set`
- [X] Add `DateTime#weeksInLocalWeekYear`, analogous to `weeksInWeekYear`
- [x] Investigate supporting formatting tokens for `localWeekNumber` and `localWeekYear`.
- [X] Documentation