### PR TITLE
normalize() handles partially negative inputs properly

### DIFF
--- a/test/duration/units.test.js
+++ b/test/duration/units.test.js
@@ -189,6 +189,10 @@ test("Duration#normalize handles the full grid partially negative durations", ()
       { months: 0, days: -28 },
       { months: 0, days: -28 },
     ],
+    [
+      { hours: 96, minutes: 0, seconds: -10 },
+      { hours: 95, minutes: 59, seconds: 50 },
+    ],
   ];
 
   sets.forEach(([from, to]) => {


### PR DESCRIPTION
Continuing https://github.com/moment/luxon/pull/1296/commits/1b735939d319990e53ed440aaa3a41456488c960

Fix #1233 as well as https://github.com/moment/luxon/issues/781#issuecomment-1008051278

Values like `{ hours: 96, minutes: 0, seconds: -10 }`  will be normalized to  `{ hours: 95, minutes: 59, seconds: 50 }`

This behavior is consistent with `rescale()`

Test case provided as per comment in 1296.