### PR TITLE
fix: Info.months for Islamic calendar

### DIFF
--- a/src/impl/locale.js
+++ b/src/impl/locale.js
@@ -120,7 +120,7 @@ function intlConfigString(localeStr, numberingSystem, outputCalendar) {
 function mapMonths(f) {
   const ms = [];
   for (let i = 1; i <= 12; i++) {
-    const dt = DateTime.utc(2016, i, 1);
+    const dt = DateTime.utc(2009, i, 1);
     ms.push(f(dt));
   }
   return ms;

--- a/test/info/listers.test.js
+++ b/test/info/listers.test.js
@@ -105,6 +105,8 @@ test("Info.months respects the numbering system", () => {
 
 test("Info.months respects the calendar", () => {
   expect(Info.months("long", { locale: "en", outputCalendar: "islamic" })).toEqual([
+    "Muharram",
+    "Safar",
     "Rabiʻ I",
     "Rabiʻ II",
     "Jumada I",
@@ -115,8 +117,6 @@ test("Info.months respects the calendar", () => {
     "Shawwal",
     "Dhuʻl-Qiʻdah",
     "Dhuʻl-Hijjah",
-    "Safar",
-    "Rabiʻ I",
   ]);
 });
 


### PR DESCRIPTION
`Info.months()` for Islamic has duplicate month "**Rabiʻ I**" and also Islamic months' order is incorrect.

Fixed by changing the year from 2016 to 2009 which is the most recent year that Islamic and Gregorian months are sync.

[Islamic months and their order](https://en.wikipedia.org/wiki/Islamic_calendar#Months)