### PR TITLE
Default config DateTime constructor

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -432,7 +432,7 @@ export default class DateTime {
   /**
    * @access private
    */
-  constructor(config) {
+  constructor(config = {}) {
     const zone = config.zone || Settings.defaultZone;
 
     let invalid =


### PR DESCRIPTION
When using DateTime with mappers such as class-transfomers, these libraries will try to use the DateTime constructor without parameters. This currently will throw an exception. Setting a default value for config in the constructor solves this problem.