### PR TITLE
Update datetime.js documentation

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -894,7 +894,7 @@ export default class DateTime {
 
   /**
    * Create an invalid DateTime.
-   * @param {DateTime} reason - simple string of why this DateTime is invalid. Should not contain parameters or anything else data-dependent
+   * @param {string} reason - simple string of why this DateTime is invalid. Should not contain parameters or anything else data-dependent.
    * @param {string} [explanation=null] - longer explanation, may include parameters and other useful debugging information
    * @return {DateTime}
    */


### PR DESCRIPTION
the @param as {DateTime} was incorrect and while it technically accepts {string|Invalid}, looking at the code and original documentation lended the impression you'd prefer a string argument for the public API docs