### PR TITLE
refactor: remove always-false if check in listStuff

### DIFF
--- a/src/impl/locale.js
+++ b/src/impl/locale.js
@@ -138,9 +138,7 @@ function mapWeekdays(f) {
 function listStuff(loc, length, englishFn, intlFn) {
   const mode = loc.listingMode();
 
-  if (mode === "error") {
-    return null;
-  } else if (mode === "en") {
+  if (mode === "en") {
     return englishFn(length);
   } else {
     return intlFn(length);


### PR DESCRIPTION
`loc.listingMode()` always returns either "en" or "intl", so `mode === "error"` would never succeed.