### PR TITLE
Fix and improve `Duration#normalize`

### DIFF
--- a/src/duration.js
+++ b/src/duration.js
@@ -127,19 +127,14 @@ function clone(dur, alts, clear = false) {
   return new Duration(conf);
 }
 
-// this is needed since in some test cases it would return 0.9999999999999999 instead of 1
-function removePrecisionIssue(a) {
-  return Math.trunc(a * 1e3) / 1e3;
-}
-
 // NB: mutates parameters
 function convert(matrix, fromMap, fromUnit, toMap, toUnit) {
   const conv = matrix[toUnit][fromUnit];
   const raw = fromMap[fromUnit] / conv;
   const added = signedFloor(raw);
 
-  toMap[toUnit] = removePrecisionIssue(toMap[toUnit] + added);
-  fromMap[fromUnit] = removePrecisionIssue(fromMap[fromUnit] - added * conv);
+  toMap[toUnit] = toMap[toUnit] + added;
+  fromMap[fromUnit] = fromMap[fromUnit] - added * conv;
 }
 
 // NB: mutates parameters

--- a/src/duration.js
+++ b/src/duration.js
@@ -128,7 +128,7 @@ function clone(dur, alts, clear = false) {
 
 function durationToMillis(matrix, vals) {
   let sum = vals.milliseconds ?? 0;
-  for (let unit of reverseUnits.slice(1)) {
+  for (const unit of reverseUnits.slice(1)) {
     if (vals[unit]) {
       sum += vals[unit] * matrix[unit]["milliseconds"];
     }

--- a/src/duration.js
+++ b/src/duration.js
@@ -721,7 +721,14 @@ export default class Duration {
 
   /**
    * Reduce this Duration to its canonical representation in its current units.
+   * Assuming the overall value of the Duration is positive, this means:
+   * - excessive values for lower-order units are converted to higher order units (if possible, see first and second example)
+   * - negative lower-order units are converted to higher order units (there must be such a higher order unit, otherwise
+   *   the overall value would be negative, see second example)
+   *
+   * If the overall value is negative, the result of this method is equivalent to `d.negate().normalize().negate()`.
    * @example Duration.fromObject({ years: 2, days: 5000 }).normalize().toObject() //=> { years: 15, days: 255 }
+   * @example Duration.fromObject({ days: 5000 }).normalize().toObject() //=> { days: 5000 }
    * @example Duration.fromObject({ hours: 12, minutes: -45 }).normalize().toObject() //=> { hours: 11, minutes: 15 }
    * @return {Duration}
    */

--- a/src/duration.js
+++ b/src/duration.js
@@ -149,19 +149,21 @@ function normalizeValues(matrix, vals, negative) {
         const previousVal = vals[previous] * factor;
         const conv = matrix[current][previous];
 
-        // if previousVal < 0:
-        // lower order unit is negative (e.g. { years: 2, days: -2 })
-        // normalize this by reducing the higher order unit by the appropriate amount
-        // and increasing the lower order unit
-        // this can never make the higher order unit negative, because this function only operates
-        // on positive durations, so the amount of time represented by the lower order unit cannot
-        // be larger than the higher order unit
-        // else:
-        // lower order unit is positive (e.g. { years: 2, days: 450 } or { years: -2, days: 450 })
-        // in this case we attempt to convert as much as possible from the lower order unit into
-        // the higher order one
-        const rollUp =
-          previousVal < 0 ? -Math.ceil(-previousVal / conv) : Math.floor(previousVal / conv);
+        let rollUp;
+        if (previousVal < 0) {
+          // lower order unit is negative (e.g. { years: 2, days: -2 })
+          // normalize this by reducing the higher order unit by the appropriate amount
+          // and increasing the lower order unit
+          // this can never make the higher order unit negative, because this function only operates
+          // on positive durations, so the amount of time represented by the lower order unit cannot
+          // be larger than the higher order unit
+          rollUp = -Math.ceil(-previousVal / conv);
+        } else {
+          // lower order unit is positive (e.g. { years: 2, days: 450 } or { years: -2, days: 450 })
+          // in this case we attempt to convert as much as possible from the lower order unit into
+          // the higher order one
+          rollUp = Math.floor(previousVal / conv);
+        }
         vals[current] += rollUp * factor;
         vals[previous] -= rollUp * conv * factor;
       }

--- a/src/duration.js
+++ b/src/duration.js
@@ -139,9 +139,9 @@ function convert(matrix, fromMap, fromUnit, toMap, toUnit) {
 
 // NB: mutates parameters
 function normalizeValues(matrix, vals, negative) {
-  const factor = negative ? -1 : 1;
   // the logic below assumes the overall value of the duration is positive
   // if this is not the case, factor is used to make it so
+  const factor = negative ? -1 : 1;
 
   reverseUnits.reduce((previous, current) => {
     if (!isUndefined(vals[current])) {

--- a/src/duration.js
+++ b/src/duration.js
@@ -147,26 +147,23 @@ function normalizeValues(matrix, vals, negative) {
     if (!isUndefined(vals[current])) {
       if (previous) {
         const previousVal = vals[previous] * factor;
-        if (previousVal < 0) {
-          // lower order unit is negative (e.g. { years: 2, days: -2 })
-          // normalize this by reducing the higher order unit by the appropriate amount
-          // and increasing the lower order unit
-          // this can never make the higher order unit negative, because this function only operates
-          // on positive durations, so the amount of time represented by the lower order unit cannot
-          // be larger than the higher order unit
-          const conv = matrix[current][previous];
-          const rollUp = Math.ceil(-previousVal / conv);
-          vals[current] -= rollUp * factor;
-          vals[previous] += rollUp * conv * factor;
-        } else {
-          // lower order unit is positive (e.g. { years: 2, days: 450 } or { years: -2, days: 450 })
-          // in this case we attempt to convert as much as possible from the lower order unit into
-          // the higher order one
-          const conv = matrix[current][previous];
-          const rollUp = Math.floor(previousVal / conv);
-          vals[current] += rollUp * factor;
-          vals[previous] -= rollUp * conv * factor;
-        }
+        const conv = matrix[current][previous];
+
+        // if previousVal < 0:
+        // lower order unit is negative (e.g. { years: 2, days: -2 })
+        // normalize this by reducing the higher order unit by the appropriate amount
+        // and increasing the lower order unit
+        // this can never make the higher order unit negative, because this function only operates
+        // on positive durations, so the amount of time represented by the lower order unit cannot
+        // be larger than the higher order unit
+        // else:
+        // lower order unit is positive (e.g. { years: 2, days: 450 } or { years: -2, days: 450 })
+        // in this case we attempt to convert as much as possible from the lower order unit into
+        // the higher order one
+        const rollUp =
+          previousVal < 0 ? -Math.ceil(-previousVal / conv) : Math.floor(previousVal / conv);
+        vals[current] += rollUp * factor;
+        vals[previous] -= rollUp * conv * factor;
       }
       return current;
     } else {

--- a/src/duration.js
+++ b/src/duration.js
@@ -721,7 +721,7 @@ export default class Duration {
    * - negative lower-order units are converted to higher order units (there must be such a higher order unit, otherwise
    *   the overall value would be negative, see second example)
    *
-   * If the overall value is negative, the result of this method is equivalent to `d.negate().normalize().negate()`.
+   * If the overall value is negative, the result of this method is equivalent to `this.negate().normalize().negate()`.
    * @example Duration.fromObject({ years: 2, days: 5000 }).normalize().toObject() //=> { years: 15, days: 255 }
    * @example Duration.fromObject({ days: 5000 }).normalize().toObject() //=> { days: 5000 }
    * @example Duration.fromObject({ hours: 12, minutes: -45 }).normalize().toObject() //=> { hours: 11, minutes: 15 }

--- a/src/duration.js
+++ b/src/duration.js
@@ -148,21 +148,22 @@ function normalizeValues(matrix, vals) {
         const previousVal = vals[previous] * factor;
         const conv = matrix[current][previous];
 
-        let rollUp;
-        if (previousVal < 0) {
-          // lower order unit is negative (e.g. { years: 2, days: -2 })
-          // normalize this by reducing the higher order unit by the appropriate amount
-          // and increasing the lower order unit
-          // this can never make the higher order unit negative, because this function only operates
-          // on positive durations, so the amount of time represented by the lower order unit cannot
-          // be larger than the higher order unit
-          rollUp = -Math.ceil(-previousVal / conv);
-        } else {
-          // lower order unit is positive (e.g. { years: 2, days: 450 } or { years: -2, days: 450 })
-          // in this case we attempt to convert as much as possible from the lower order unit into
-          // the higher order one
-          rollUp = Math.floor(previousVal / conv);
-        }
+        // if (previousVal < 0):
+        // lower order unit is negative (e.g. { years: 2, days: -2 })
+        // normalize this by reducing the higher order unit by the appropriate amount
+        // and increasing the lower order unit
+        // this can never make the higher order unit negative, because this function only operates
+        // on positive durations, so the amount of time represented by the lower order unit cannot
+        // be larger than the higher order unit
+        // else:
+        // lower order unit is positive (e.g. { years: 2, days: 450 } or { years: -2, days: 450 })
+        // in this case we attempt to convert as much as possible from the lower order unit into
+        // the higher order one
+        //
+        // Math.floor takes care of both of these cases, rounding away from 0
+        // if previousVal < 0 it makes the absolute value larger
+        // if previousVal >= it makes the absolute value smaller
+        const rollUp = Math.floor(previousVal / conv);
         vals[current] += rollUp * factor;
         vals[previous] -= rollUp * conv * factor;
       }

--- a/src/duration.js
+++ b/src/duration.js
@@ -127,14 +127,20 @@ function clone(dur, alts, clear = false) {
   return new Duration(conf);
 }
 
+function antiTrunc(n) {
+  return n < 0 ? Math.floor(n) : Math.ceil(n);
+}
+
 // NB: mutates parameters
 function convert(matrix, fromMap, fromUnit, toMap, toUnit) {
-  const conv = matrix[toUnit][fromUnit];
-  const raw = fromMap[fromUnit] / conv;
-  const added = signedFloor(raw);
-
-  toMap[toUnit] = toMap[toUnit] + added;
-  fromMap[fromUnit] = fromMap[fromUnit] - added * conv;
+  const conv = matrix[toUnit][fromUnit],
+    raw = fromMap[fromUnit] / conv,
+    sameSign = Math.sign(raw) === Math.sign(toMap[toUnit]),
+    // ok, so this is wild, but see the matrix in the tests
+    added =
+      !sameSign && toMap[toUnit] !== 0 && Math.abs(raw) <= 1 ? antiTrunc(raw) : Math.trunc(raw);
+  toMap[toUnit] += added;
+  fromMap[fromUnit] -= added * conv;
 }
 
 // NB: mutates parameters

--- a/src/impl/util.js
+++ b/src/impl/util.js
@@ -124,10 +124,6 @@ export function parseMillis(fraction) {
   }
 }
 
-export function signedFloor(number) {
-  return number > 0 ? Math.floor(number) : Math.ceil(number);
-}
-
 export function roundTo(number, digits, towardZero = false) {
   const factor = 10 ** digits,
     rounder = towardZero ? Math.trunc : Math.round;


### PR DESCRIPTION
Fixes #1493

In the process of fixing this, I have updated the algorithm used in `normalizeValues` to make it more clear what it actually does and improved the documentation for `Duration#normalize` to clarify what "canonical representation" means.

Additionally, I have removed the broken implementation of `convert` that was introduced in #1467. After the refactoring of `normalizeValues`, `Duration#shiftTo` was the only user of `convert`, and unnecessarily so. shiftTo used convert to perform some of the same steps that normalize already does, which shiftTo calls afterwards. As such `convert` has been removed.