### PR TITLE
Fix Duration#normalize, shiftTo and shiftToAll

### DIFF
--- a/src/duration.js
+++ b/src/duration.js
@@ -734,7 +734,7 @@ export default class Duration {
    * @example Duration.fromObject({ years: 2, days: 5000 }).normalize().toObject() //=> { years: 15, days: 255 }
    * @example Duration.fromObject({ days: 5000 }).normalize().toObject() //=> { days: 5000 }
    * @example Duration.fromObject({ hours: 12, minutes: -45 }).normalize().toObject() //=> { hours: 11, minutes: 15 }
-   * @example Duration.fromObject({ years: 2.5, days: 0 })
+   * @example Duration.fromObject({ years: 2.5, days: 0, hours: 0 }).normalize().toObject() //=> { years: 2, days: 182, hours: 12 }
    * @return {Duration}
    */
   normalize() {

--- a/test/duration/units.test.js
+++ b/test/duration/units.test.js
@@ -105,6 +105,17 @@ test("Duration#shiftTo handles mixed units", () => {
   });
 });
 
+test("Duration#shiftTo does not produce unnecessary fractions in higher order units", () => {
+  const duration = Duration.fromObject(
+    { years: 2.5, weeks: -1 },
+    { conversionAccuracy: "longterm" }
+  );
+  const shifted = duration.shiftTo("years", "weeks", "minutes").toObject();
+  expect(shifted.years).toBe(2);
+  expect(shifted.weeks).toBe(25);
+  expect(shifted.minutes).toBeCloseTo(894.6, 5);
+});
+
 //------
 // #shiftToAll()
 //-------
@@ -120,6 +131,22 @@ test("Duration#shiftToAll shifts to all available units", () => {
     seconds: 0,
     milliseconds: 0,
   });
+});
+
+test("Duration#shiftToAll does not produce unnecessary fractions in higher order units", () => {
+  const duration = Duration.fromObject(
+    { years: 2.5, weeks: -1, seconds: 0 },
+    { conversionAccuracy: "longterm" }
+  );
+  const toAll = duration.shiftToAll().toObject();
+  expect(toAll.years).toBe(2);
+  expect(toAll.months).toBe(5);
+  expect(toAll.weeks).toBe(3);
+  expect(toAll.days).toBe(2);
+  expect(toAll.hours).toBe(10);
+  expect(toAll.minutes).toBe(29);
+  expect(toAll.seconds).toBe(6);
+  expect(toAll.milliseconds).toBeCloseTo(0, 5);
 });
 
 test("Duration#shiftToAll maintains invalidity", () => {

--- a/test/duration/units.test.js
+++ b/test/duration/units.test.js
@@ -243,6 +243,40 @@ test("Duration#normalize can convert all unit pairs", () => {
   }
 });
 
+test("Duration#normalize moves fractions to lower-order units", () => {
+  expect(Duration.fromObject({ years: 2.5, days: 0, hours: 0 }).normalize().toObject()).toEqual({
+    years: 2,
+    days: 182,
+    hours: 12,
+  });
+  expect(Duration.fromObject({ years: -2.5, days: 0, hours: 0 }).normalize().toObject()).toEqual({
+    years: -2,
+    days: -182,
+    hours: -12,
+  });
+  expect(Duration.fromObject({ years: 2.5, days: 12, hours: 0 }).normalize().toObject()).toEqual({
+    years: 2,
+    days: 194,
+    hours: 12,
+  });
+  expect(Duration.fromObject({ years: 2.5, days: 12.25, hours: 0 }).normalize().toObject()).toEqual(
+    { years: 2, days: 194, hours: 18 }
+  );
+});
+
+test("Duration#normalize does not produce fractions in higher order units when rolling up negative lower order unit values", () => {
+  const normalized = Duration.fromObject(
+    { years: 100, months: 0, weeks: -1, days: 0 },
+    { conversionAccuracy: "longterm" }
+  )
+    .normalize()
+    .toObject();
+  expect(normalized.years).toBe(99);
+  expect(normalized.months).toBe(11);
+  expect(normalized.weeks).toBe(3);
+  expect(normalized.days).toBeCloseTo(2.436875, 7);
+});
+
 //------
 // #rescale()
 //-------


### PR DESCRIPTION
This fixes #1496 by introducing an additional conversion step in `Duration#normalize` / `normalizeValues`.
This step converts any fractions in larger units into lower units, if possible. 
For example: `{ years: 2.5, days: 0, hours: 0 }` becomes `{ years: 2, days: 182, hours: 12 }` (assuming casual conversions).

This also affects `shiftTo` and `shiftToAll`. I have added tests for all three methods to test this behavior.

Note: This alters the behavior of `normalize`, because previously `normalize` would not do this. `{years: 2.5, days: 0}` would stay as-is. I would argue that that is a bug however, which is fixed by this pull request. `shiftTo` (and by extension `shiftToAll`) _did_ do this, prior to calling `normalize`, however I would argue that this is something that should be handled by `normalize`.