### PR TITLE
Improve IANAZone.offset performance

### DIFF
--- a/src/zones/IANAZone.js
+++ b/src/zones/IANAZone.js
@@ -1,9 +1,23 @@
 import { formatOffset, parseZoneInfo, isUndefined, objToLocalTS } from "../impl/util.js";
 import Zone from "../zone.js";
 
-const dtfCache = new Map();
-function makeDTF(zoneName) {
-  let dtf = dtfCache.get(zoneName);
+const directOffsetDTFCache = new Map();
+function makeDirectOffsetDTF(zoneName) {
+  let dtf = directOffsetDTFCache.get(zoneName);
+  if (dtf === undefined) {
+    dtf = new Intl.DateTimeFormat("en-US", {
+      timeZone: zoneName,
+      timeZoneName: "longOffset",
+      year: "numeric",
+    });
+    directOffsetDTFCache.set(zoneName, dtf);
+  }
+  return dtf;
+}
+
+const calculatedOffsetDTFCache = new Map();
+function makeCalculatedOffsetDTF(zoneName) {
+  let dtf = calculatedOffsetDTFCache.get(zoneName);
   if (dtf === undefined) {
     dtf = new Intl.DateTimeFormat("en-US", {
       hour12: false,
@@ -16,7 +30,7 @@ function makeDTF(zoneName) {
       second: "2-digit",
       era: "short",
     });
-    dtfCache.set(zoneName, dtf);
+    calculatedOffsetDTFCache.set(zoneName, dtf);
   }
   return dtf;
 }
@@ -54,7 +68,65 @@ function partsOffset(dtf, date) {
   return filled;
 }
 
+function calculatedOffset(zone, ts) {
+  const date = new Date(ts);
+
+  if (isNaN(date)) return NaN;
+
+  const dtf = makeCalculatedOffsetDTF(zone);
+  let [year, month, day, adOrBc, hour, minute, second] = dtf.formatToParts
+    ? partsOffset(dtf, date)
+    : hackyOffset(dtf, date);
+
+  if (adOrBc === "BC") {
+    year = -Math.abs(year) + 1;
+  }
+
+  // because we're using hour12 and https://bugs.chromium.org/p/chromium/issues/detail?id=1025564&can=2&q=%2224%3A00%22%20datetimeformat
+  const adjustedHour = hour === 24 ? 0 : hour;
+
+  const asUTC = objToLocalTS({
+    year,
+    month,
+    day,
+    hour: adjustedHour,
+    minute,
+    second,
+    millisecond: 0,
+  });
+
+  let asTS = +date;
+  const over = asTS % 1000;
+  asTS -= over >= 0 ? over : 1000 + over;
+  return (asUTC - asTS) / (60 * 1000);
+}
+
+function directOffset(zone, ts) {
+  const dtf = makeDirectOffsetDTF(zone);
+
+  let formatted;
+
+  try {
+    formatted = dtf.format(ts);
+  } catch (e) {
+    return NaN;
+  }
+
+  const idx = formatted.search(/GMT([+-][0-9][0-9]:[0-9][0-9](:[0-9][0-9])?)?/);
+  const sign = formatted.charCodeAt(idx + 3);
+
+  if (isNaN(sign)) return 0;
+
+  return (
+    (44 - sign) *
+    (Number(formatted.slice(idx + 4, idx + 6)) * 60 +
+      Number(formatted.slice(idx + 7, idx + 9)) +
+      Number(formatted.slice(idx + 10, idx + 12)) / 60)
+  );
+}
+
 const ianaZoneCache = new Map();
+let offsetFunc;
 /**
  * A zone identified by an IANA identifier, like America/New_York
  * @implements {Zone}
@@ -78,7 +150,8 @@ export default class IANAZone extends Zone {
    */
   static resetCache() {
     ianaZoneCache.clear();
-    dtfCache.clear();
+    calculatedOffsetDTFCache.clear();
+    directOffsetDTFCache.clear();
   }
 
   /**
@@ -182,36 +255,25 @@ export default class IANAZone extends Zone {
    */
   offset(ts) {
     if (!this.valid) return NaN;
-    const date = new Date(ts);
 
-    if (isNaN(date)) return NaN;
-
-    const dtf = makeDTF(this.name);
-    let [year, month, day, adOrBc, hour, minute, second] = dtf.formatToParts
-      ? partsOffset(dtf, date)
-      : hackyOffset(dtf, date);
-
-    if (adOrBc === "BC") {
-      year = -Math.abs(year) + 1;
+    if (offsetFunc === undefined) {
+      try {
+        const ts = Date.now();
+        // directOffset will raise an error if not supported by the engine
+        // also check it works correctly as it relies on a specific format
+        if (
+          directOffset("Etc/GMT", ts) !== 0 ||
+          directOffset("Etc/GMT+1", ts) !== -60 ||
+          directOffset("Etc/GMT-1", ts) !== +60
+        )
+          throw new Error("Invalid offset");
+        offsetFunc = directOffset;
+      } catch (e) {
+        offsetFunc = calculatedOffset;
+      }
     }
 
-    // because we're using hour12 and https://bugs.chromium.org/p/chromium/issues/detail?id=1025564&can=2&q=%2224%3A00%22%20datetimeformat
-    const adjustedHour = hour === 24 ? 0 : hour;
-
-    const asUTC = objToLocalTS({
-      year,
-      month,
-      day,
-      hour: adjustedHour,
-      minute,
-      second,
-      millisecond: 0,
-    });
-
-    let asTS = +date;
-    const over = asTS % 1000;
-    asTS -= over >= 0 ? over : 1000 + over;
-    return (asUTC - asTS) / (60 * 1000);
+    return offsetFunc(this.name, ts);
   }
 
   /**


### PR DESCRIPTION
This is more than 2.5x faster in my testing. Example benchmark script:

```javascript
import { setTimeout } from 'timers/promises';

import { DateTime } from './src/luxon.js';

// Warm up
for (let i = 0; i < 10; i++) {
  DateTime.fromJSDate(new Date(), { zone: 'America/New_York' });
}

await setTimeout(200);

console.time('run');
for (let i = 0; i < 10000; i++) {
  DateTime.fromJSDate(new Date(), { zone: 'America/New_York' });
}
console.timeEnd('run');
```