### PR TITLE
Fix docstring example reference

### DIFF
--- a/src/duration.js
+++ b/src/duration.js
@@ -727,7 +727,7 @@ export default class Duration {
    * Assuming the overall value of the Duration is positive, this means:
    * - excessive values for lower-order units are converted to higher-order units (if possible, see first and second example)
    * - negative lower-order units are converted to higher order units (there must be such a higher order unit, otherwise
-   *   the overall value would be negative, see second example)
+   *   the overall value would be negative, see third example)
    * - fractional values for higher-order units are converted to lower-order units (if possible, see fourth example)
    *
    * If the overall value is negative, the result of this method is equivalent to `this.negate().normalize().negate()`.


### PR DESCRIPTION
There appears to be a very small typo in the docstrings for `Duration.normalize()`. The docstring mentions negative values, but points to an example about excessive values, whereas the _third_ example appears to exemplify the point made in the docstring.

<img width="978" alt="Screenshot 2023-09-15 at 9 38 58 AM" src="https://github.com/moment/luxon/assets/101547/81af715c-47e0-450d-a14b-af8f39342df4">
