### PR TITLE
use ISO string when converting system zone to JS date

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -47,6 +47,7 @@ import {
   InvalidDateTimeError,
 } from "./errors.js";
 import Invalid from "./impl/invalid.js";
+import SystemZone from "./zones/systemZone.js";
 
 const INVALID = "Invalid DateTime";
 const MAX_DATE = 8.64e15;
@@ -1887,7 +1888,13 @@ export default class DateTime {
    * @return {Date}
    */
   toJSDate() {
-    return new Date(this.isValid ? this.ts : NaN);
+    if (!this.isValid) {
+      return new Date(NaN);
+    } else if (this.zone == SystemZone.instance) {
+      return new Date(this.toISO({ includeOffset: false }));
+    } else {
+      return new Date(this.ts);
+    }
   }
 
   // COMPARE

--- a/test/datetime/transform.test.js
+++ b/test/datetime/transform.test.js
@@ -63,6 +63,12 @@ test("DateTime#toJSDate() returns a native Date equivalent", () => {
   expect(js.getTime()).toBe(dt.toMillis());
 });
 
+test("DateTime#toJSDate() works for historic dates with weird offsets", () => {
+  const js = DateTime.fromISO("1800-01-01").toJSDate();
+  expect(js).toBeInstanceOf(Date);
+  expect(js.getFullYear()).toBe(1800);
+});
+
 //------
 // #toBSON()
 //------


### PR DESCRIPTION
I'm of two minds about whether this is a good idea or not. This is to fix issues where historic zones have offsets that aren't whole minutes. Examples:

* https://github.com/moment/luxon/issues/1506
* https://github.com/moment/luxon/issues/1399
* https://github.com/moment/luxon/issues/684

I'm sure there are others. Anyway, if it's a SystemZone date, we are using `getTimezoneOffset` (which provides whole minutes) to compute the epoch milliseconds from the input string, which will be off by however many seconds in the offset. When we convert we convert that to a JS date (for example, to format it), it will then be the wrong date. This fixes that by providing the ISO string directly to the JS Date, which will parse it using the more accurate offset the native date has access to internally.

The problem with the fix is that it may lead to other inconsistencies. The epoch millis in the DateTime will be different from the epoch millis in the native date. It's not clear to me whether this is making things better or merely making them _weirder_.