### PR TITLE
Fix Interval.splitAt datetime sorting

### DIFF
--- a/src/interval.js
+++ b/src/interval.js
@@ -312,7 +312,7 @@ export default class Interval {
     const sorted = dateTimes
         .map(friendlyDateTime)
         .filter((d) => this.contains(d))
-        .sort(),
+        .sort((a, b) => a.toMillis() - b.toMillis()),
       results = [];
     let { s } = this,
       i = 0;

--- a/test/interval/many.test.js
+++ b/test/interval/many.test.js
@@ -301,6 +301,24 @@ test("Interval#splitAt ignores times outside the interval", () => {
   expect(oneAfterOneDuring[1]).toEqual(todayFrom(11, 13));
 });
 
+test("Interval#splitAt handles DST shifts", () => {
+  const zone = "Europe/Berlin";
+  const dayStart = DateTime.fromISO("2023-10-29T00:00:00+02:00", { zone });
+  const dayEnd = DateTime.fromISO("2023-10-30T00:00:00+01:00", { zone });
+  const dstShiftStart = DateTime.fromISO("2023-10-29T02:00:00+02:00", { zone });
+  const dstShiftEnd = DateTime.fromISO("2023-10-29T02:00:00+01:00", { zone });
+
+  const splitByDSTStartAndEnd = Interval.fromDateTimes(dayStart, dayEnd)
+    .splitAt(dstShiftStart, dstShiftEnd)
+    .map((i) => i.toISO());
+
+  expect(splitByDSTStartAndEnd).toEqual([
+    "2023-10-29T00:00:00.000+02:00/2023-10-29T02:00:00.000+02:00",
+    "2023-10-29T02:00:00.000+02:00/2023-10-29T02:00:00.000+01:00",
+    "2023-10-29T02:00:00.000+01:00/2023-10-30T00:00:00.000+01:00",
+  ]);
+});
+
 //-------
 // #splitBy()
 //-------


### PR DESCRIPTION
`Interval#splitAt` is incorrectly sorting the input `DateTime`s by ISO strings (`Array.sort` implicitly calls `toString`), which leads to invalid intervals when trying to split at DST shifted hours.
This PR changes the sorting to use the underlying epoch milliseconds instead.