### PR TITLE
Add custom inspect for node without depedency

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1815,6 +1815,18 @@ export default class DateTime {
   }
 
   /**
+   * Returns a string representation of this DateTime appropriate for the REPL.
+   * @return {string}
+   */
+  [Symbol.for("nodejs.util.inspect.custom")]() {
+    if (this.isValid) {
+      return `DateTime { ts: ${this.toISO()}, zone: ${this.zone.name}, locale: ${this.locale} }`;
+    } else {
+      return `DateTime { Invalid, reason: ${this.invalidReason} }`;
+    }
+  }
+
+  /**
    * Returns the epoch milliseconds of this DateTime. Alias of {@link DateTime#toMillis}
    * @return {number}
    */

--- a/src/duration.js
+++ b/src/duration.js
@@ -608,6 +608,18 @@ export default class Duration {
   }
 
   /**
+   * Returns a string representation of this Duration appropriate for the REPL.
+   * @return {string}
+   */
+  [Symbol.for("nodejs.util.inspect.custom")]() {
+    if (this.isValid) {
+      return `Duration { values: ${JSON.stringify(this.values)} }`;
+    } else {
+      return `Duration { Invalid, reason: ${this.invalidReason} }`;
+    }
+  }
+
+  /**
    * Returns an milliseconds value of this Duration.
    * @return {number}
    */

--- a/src/interval.js
+++ b/src/interval.js
@@ -532,6 +532,18 @@ export default class Interval {
   }
 
   /**
+   * Returns a string representation of this Interval appropriate for the REPL.
+   * @return {string}
+   */
+  [Symbol.for("nodejs.util.inspect.custom")]() {
+    if (this.isValid) {
+      return `Interval { start: ${this.s.toISO()}, end: ${this.e.toISO()} }`;
+    } else {
+      return `Interval { Invalid, reason: ${this.invalidReason} }`;
+    }
+  }
+
+  /**
    * Returns a localized string representing this Interval. Accepts the same options as the
    * Intl.DateTimeFormat constructor and any presets defined by Luxon, such as
    * {@link DateTime.DATE_FULL} or {@link DateTime.TIME_SIMPLE}. The exact behavior of this method


### PR DESCRIPTION
Adds back the custom inspection functions for node.js, first added by #281 then removed by #318 and [55ac17e]. This change avoids the default node's object inspection listing all fields recursively. This time there are no node imports or any run-time dependency. We simply expose the inspect functions as symbol-named attribute `Symbol.for('nodejs.util.inspect.custom')` as described in the [docs](https://nodejs.org/api/util.html#utilinspectcustom).

Note: I've simplified the formats from the original addition to make it single line and simpler.

## Testing done
* npm run build
* npm run format-check
* ./scripts/test
* Manual
```
const { DateTime, Duration, Interval } = require('./build/cjs-browser/luxon')
Duration.fromObject({ seconds: 10 })
Interval.fromDateTimes(DateTime.now().minus({ days: 1 }), DateTime.now())
DateTime.now()

// output:
Duration { values: {"seconds":10} }
Interval { start: 2023-10-09T16:20:51.017-03:00, end: 2023-10-10T16:20:51.019-03:00 }
DateTime { ts: 2023-10-10T16:20:59.623-03:00, zone: America/Sao_Paulo, locale: en-US }
```