### PR TITLE
Cache unitate function

### DIFF
--- a/benchmarks/datetime.js
+++ b/benchmarks/datetime.js
@@ -1,6 +1,7 @@
 import Benchmark from "benchmark";
 import DateTime from "../src/datetime.js";
 import Settings from "../src/settings.js";
+import { resetTokenParserCache } from "../src/impl/tokenParser.js";
 
 function runDateTimeSuite() {
   return new Promise((resolve, reject) => {
@@ -27,10 +28,25 @@ function runDateTimeSuite() {
       .add("DateTime.fromFormat", () => {
         DateTime.fromFormat("1982/05/25 09:10:11.445", "yyyy/MM/dd HH:mm:ss.SSS");
       })
+      .add("DateTime.fromFormat no cache", () => {
+        DateTime.fromFormat("1982/05/25 09:10:11.445", "yyyy/MM/dd HH:mm:ss.SSS");
+        Settings.resetCaches();
+      })
       .add("DateTime.fromFormat with zone", () => {
         DateTime.fromFormat("1982/05/25 09:10:11.445", "yyyy/MM/dd HH:mm:ss.SSS", {
           zone: "America/Los_Angeles",
         });
+      })
+      .add("DateTime.fromFormat with non-English locale", () => {
+        DateTime.fromFormat("25-maj-1982 09:10:11", "dd-MMMM-yyyy hh:mm:ss", {
+          locale: "da-dk",
+        });
+      })
+      .add("DateTime.fromFormat with non-English locale no cache", () => {
+        DateTime.fromFormat("25-maj-1982 09:10:11", "dd-MMMM-yyyy hh:mm:ss", {
+          locale: "da-dk",
+        });
+        Settings.resetCaches();
       })
       .add("DateTime#setZone", () => {
         dt.setZone("America/Los_Angeles");

--- a/src/impl/locale.js
+++ b/src/impl/locale.js
@@ -323,6 +323,8 @@ const fallbackWeekSettings = {
   weekend: [6, 7],
 };
 
+let isEnglishIntlCache = {};
+
 /**
  * @private
  */
@@ -336,6 +338,14 @@ export default class Locale {
       opts.weekSettings,
       opts.defaultToEN
     );
+  }
+
+  /**
+   * Reset local caches. Should only be necessary in testing scenarios.
+   * @return {void}
+   */
+  static resetCache() {
+    isEnglishIntlCache = {};
   }
 
   static create(locale, numberingSystem, outputCalendar, weekSettings, defaultToEN = false) {
@@ -503,11 +513,14 @@ export default class Locale {
   }
 
   isEnglish() {
-    return (
-      this.locale === "en" ||
-      this.locale.toLowerCase() === "en-us" ||
-      new Intl.DateTimeFormat(this.intl).resolvedOptions().locale.startsWith("en-us")
-    );
+    if (this.locale === "en" || this.locale.toLowerCase === "en-us") return true;
+
+    if (isEnglishIntlCache[this.intl] === undefined) {
+      return (isEnglishIntlCache[this.intl] = new Intl.DateTimeFormat(this.intl)
+        .resolvedOptions()
+        .locale.startsWith("en-us"));
+    }
+    return isEnglishIntlCache[this.intl];
   }
 
   getWeekSettings() {

--- a/src/impl/tokenParser.js
+++ b/src/impl/tokenParser.js
@@ -53,12 +53,12 @@ function escapeToken(value) {
   return value.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, "\\$&");
 }
 
-/**
- * @param token
- * @param {Locale} loc
- */
-function unitForToken(token, loc) {
-  const one = digitRegex(loc),
+const unitateCache = {};
+
+function getUnitate(loc) {
+  const localeKey = loc.locale;
+  if(!unitateCache[localeKey]) {
+    const one = digitRegex(loc),
     two = digitRegex(loc, "{2}"),
     three = digitRegex(loc, "{3}"),
     four = digitRegex(loc, "{4}"),
@@ -71,7 +71,7 @@ function unitForToken(token, loc) {
     fourToSix = digitRegex(loc, "{4,6}"),
     literal = (t) => ({ regex: RegExp(escapeToken(t.val)), deser: ([s]) => s, literal: true }),
     unitate = (t) => {
-      if (token.literal) {
+      if (t.literal) {
         return literal(t);
       }
       switch (t.val) {
@@ -192,6 +192,17 @@ function unitForToken(token, loc) {
           return literal(t);
       }
     };
+    return unitateCache[localeKey] = unitate;
+  }
+  return unitateCache[localeKey];
+}
+
+/**
+ * @param token
+ * @param {Locale} loc
+ */
+function unitForToken(token, loc) {
+  const unitate = getUnitate(loc);
 
   const unit = unitate(token) || {
     invalidReason: MISSING_FTP,

--- a/src/impl/tokenParser.js
+++ b/src/impl/tokenParser.js
@@ -61,146 +61,146 @@ export function resetTokenParserCache() {
   unitateCache = {};
 }
 
-const unitateCache = {};
+let unitateCache = {};
 
 function getUnitate(loc) {
-  const localeKey = loc.locale;
-  if(!unitateCache[localeKey]) {
+  const localeKey = loc.intl;
+  if (!unitateCache[localeKey]) {
     const one = digitRegex(loc),
-    two = digitRegex(loc, "{2}"),
-    three = digitRegex(loc, "{3}"),
-    four = digitRegex(loc, "{4}"),
-    six = digitRegex(loc, "{6}"),
-    oneOrTwo = digitRegex(loc, "{1,2}"),
-    oneToThree = digitRegex(loc, "{1,3}"),
-    oneToSix = digitRegex(loc, "{1,6}"),
-    oneToNine = digitRegex(loc, "{1,9}"),
-    twoToFour = digitRegex(loc, "{2,4}"),
-    fourToSix = digitRegex(loc, "{4,6}"),
-    literal = (t) => ({ regex: RegExp(escapeToken(t.val)), deser: ([s]) => s, literal: true }),
-    unitate = (t) => {
-      if (t.literal) {
-        return literal(t);
-      }
-      switch (t.val) {
-        // era
-        case "G":
-          return oneOf(loc.eras("short"), 0);
-        case "GG":
-          return oneOf(loc.eras("long"), 0);
-        // years
-        case "y":
-          return intUnit(oneToSix);
-        case "yy":
-          return intUnit(twoToFour, untruncateYear);
-        case "yyyy":
-          return intUnit(four);
-        case "yyyyy":
-          return intUnit(fourToSix);
-        case "yyyyyy":
-          return intUnit(six);
-        // months
-        case "M":
-          return intUnit(oneOrTwo);
-        case "MM":
-          return intUnit(two);
-        case "MMM":
-          return oneOf(loc.months("short", true), 1);
-        case "MMMM":
-          return oneOf(loc.months("long", true), 1);
-        case "L":
-          return intUnit(oneOrTwo);
-        case "LL":
-          return intUnit(two);
-        case "LLL":
-          return oneOf(loc.months("short", false), 1);
-        case "LLLL":
-          return oneOf(loc.months("long", false), 1);
-        // dates
-        case "d":
-          return intUnit(oneOrTwo);
-        case "dd":
-          return intUnit(two);
-        // ordinals
-        case "o":
-          return intUnit(oneToThree);
-        case "ooo":
-          return intUnit(three);
-        // time
-        case "HH":
-          return intUnit(two);
-        case "H":
-          return intUnit(oneOrTwo);
-        case "hh":
-          return intUnit(two);
-        case "h":
-          return intUnit(oneOrTwo);
-        case "mm":
-          return intUnit(two);
-        case "m":
-          return intUnit(oneOrTwo);
-        case "q":
-          return intUnit(oneOrTwo);
-        case "qq":
-          return intUnit(two);
-        case "s":
-          return intUnit(oneOrTwo);
-        case "ss":
-          return intUnit(two);
-        case "S":
-          return intUnit(oneToThree);
-        case "SSS":
-          return intUnit(three);
-        case "u":
-          return simple(oneToNine);
-        case "uu":
-          return simple(oneOrTwo);
-        case "uuu":
-          return intUnit(one);
-        // meridiem
-        case "a":
-          return oneOf(loc.meridiems(), 0);
-        // weekYear (k)
-        case "kkkk":
-          return intUnit(four);
-        case "kk":
-          return intUnit(twoToFour, untruncateYear);
-        // weekNumber (W)
-        case "W":
-          return intUnit(oneOrTwo);
-        case "WW":
-          return intUnit(two);
-        // weekdays
-        case "E":
-        case "c":
-          return intUnit(one);
-        case "EEE":
-          return oneOf(loc.weekdays("short", false), 1);
-        case "EEEE":
-          return oneOf(loc.weekdays("long", false), 1);
-        case "ccc":
-          return oneOf(loc.weekdays("short", true), 1);
-        case "cccc":
-          return oneOf(loc.weekdays("long", true), 1);
-        // offset/zone
-        case "Z":
-        case "ZZ":
-          return offset(new RegExp(`([+-]${oneOrTwo.source})(?::(${two.source}))?`), 2);
-        case "ZZZ":
-          return offset(new RegExp(`([+-]${oneOrTwo.source})(${two.source})?`), 2);
-        // we don't support ZZZZ (PST) or ZZZZZ (Pacific Standard Time) in parsing
-        // because we don't have any way to figure out what they are
-        case "z":
-          return simple(/[a-z_+-/]{1,256}?/i);
-        // this special-case "token" represents a place where a macro-token expanded into a white-space literal
-        // in this case we accept any non-newline white-space
-        case " ":
-          return simple(/[^\S\n\r]/);
-        default:
+      two = digitRegex(loc, "{2}"),
+      three = digitRegex(loc, "{3}"),
+      four = digitRegex(loc, "{4}"),
+      six = digitRegex(loc, "{6}"),
+      oneOrTwo = digitRegex(loc, "{1,2}"),
+      oneToThree = digitRegex(loc, "{1,3}"),
+      oneToSix = digitRegex(loc, "{1,6}"),
+      oneToNine = digitRegex(loc, "{1,9}"),
+      twoToFour = digitRegex(loc, "{2,4}"),
+      fourToSix = digitRegex(loc, "{4,6}"),
+      literal = (t) => ({ regex: RegExp(escapeToken(t.val)), deser: ([s]) => s, literal: true }),
+      unitate = (t) => {
+        if (t.literal) {
           return literal(t);
-      }
-    };
-    return unitateCache[localeKey] = unitate;
+        }
+        switch (t.val) {
+          // era
+          case "G":
+            return oneOf(loc.eras("short"), 0);
+          case "GG":
+            return oneOf(loc.eras("long"), 0);
+          // years
+          case "y":
+            return intUnit(oneToSix);
+          case "yy":
+            return intUnit(twoToFour, untruncateYear);
+          case "yyyy":
+            return intUnit(four);
+          case "yyyyy":
+            return intUnit(fourToSix);
+          case "yyyyyy":
+            return intUnit(six);
+          // months
+          case "M":
+            return intUnit(oneOrTwo);
+          case "MM":
+            return intUnit(two);
+          case "MMM":
+            return oneOf(loc.months("short", true), 1);
+          case "MMMM":
+            return oneOf(loc.months("long", true), 1);
+          case "L":
+            return intUnit(oneOrTwo);
+          case "LL":
+            return intUnit(two);
+          case "LLL":
+            return oneOf(loc.months("short", false), 1);
+          case "LLLL":
+            return oneOf(loc.months("long", false), 1);
+          // dates
+          case "d":
+            return intUnit(oneOrTwo);
+          case "dd":
+            return intUnit(two);
+          // ordinals
+          case "o":
+            return intUnit(oneToThree);
+          case "ooo":
+            return intUnit(three);
+          // time
+          case "HH":
+            return intUnit(two);
+          case "H":
+            return intUnit(oneOrTwo);
+          case "hh":
+            return intUnit(two);
+          case "h":
+            return intUnit(oneOrTwo);
+          case "mm":
+            return intUnit(two);
+          case "m":
+            return intUnit(oneOrTwo);
+          case "q":
+            return intUnit(oneOrTwo);
+          case "qq":
+            return intUnit(two);
+          case "s":
+            return intUnit(oneOrTwo);
+          case "ss":
+            return intUnit(two);
+          case "S":
+            return intUnit(oneToThree);
+          case "SSS":
+            return intUnit(three);
+          case "u":
+            return simple(oneToNine);
+          case "uu":
+            return simple(oneOrTwo);
+          case "uuu":
+            return intUnit(one);
+          // meridiem
+          case "a":
+            return oneOf(loc.meridiems(), 0);
+          // weekYear (k)
+          case "kkkk":
+            return intUnit(four);
+          case "kk":
+            return intUnit(twoToFour, untruncateYear);
+          // weekNumber (W)
+          case "W":
+            return intUnit(oneOrTwo);
+          case "WW":
+            return intUnit(two);
+          // weekdays
+          case "E":
+          case "c":
+            return intUnit(one);
+          case "EEE":
+            return oneOf(loc.weekdays("short", false), 1);
+          case "EEEE":
+            return oneOf(loc.weekdays("long", false), 1);
+          case "ccc":
+            return oneOf(loc.weekdays("short", true), 1);
+          case "cccc":
+            return oneOf(loc.weekdays("long", true), 1);
+          // offset/zone
+          case "Z":
+          case "ZZ":
+            return offset(new RegExp(`([+-]${oneOrTwo.source})(?::(${two.source}))?`), 2);
+          case "ZZZ":
+            return offset(new RegExp(`([+-]${oneOrTwo.source})(${two.source})?`), 2);
+          // we don't support ZZZZ (PST) or ZZZZZ (Pacific Standard Time) in parsing
+          // because we don't have any way to figure out what they are
+          case "z":
+            return simple(/[a-z_+-/]{1,256}?/i);
+          // this special-case "token" represents a place where a macro-token expanded into a white-space literal
+          // in this case we accept any non-newline white-space
+          case " ":
+            return simple(/[^\S\n\r]/);
+          default:
+            return literal(t);
+        }
+      };
+    return (unitateCache[localeKey] = unitate);
   }
   return unitateCache[localeKey];
 }

--- a/src/impl/tokenParser.js
+++ b/src/impl/tokenParser.js
@@ -53,6 +53,14 @@ function escapeToken(value) {
   return value.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, "\\$&");
 }
 
+/**
+ * Reset local caches. Should only be necessary in testing scenarios.
+ * @return {void}
+ */
+export function resetTokenParserCache() {
+  unitateCache = {};
+}
+
 const unitateCache = {};
 
 function getUnitate(loc) {

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,6 +1,7 @@
 import SystemZone from "./zones/systemZone.js";
 import IANAZone from "./zones/IANAZone.js";
 import Locale from "./impl/locale.js";
+import { resetTokenParserCache } from "./impl/tokenParser.js";
 
 import { normalizeZone } from "./impl/zoneUtil.js";
 import { validateWeekSettings } from "./impl/util.js";
@@ -171,5 +172,6 @@ export default class Settings {
   static resetCaches() {
     Locale.resetCache();
     IANAZone.resetCache();
+    resetTokenParserCache();
   }
 }


### PR DESCRIPTION
The body of unitForToken creates a lot of objects, including a bunch of `RegExp`s. When parsing a lot of strings using `DateTime.fromFormat` in the same locale, these objects are created from scratch every time even though they are identical each time. This simple PR caches the resulting `unitate` function for each locale on first use so these objects are only created once per locale.

I have carried out a simple benchmark using the below code:

```js
const { DateTime } = require('luxon');

const TZ = 'UTC'; 

const str = '04/12/2023 20:20';

const count = 100_000;

const dts = [];

for (let index = 0; index < count; index++) {
  dts.push(DateTime.fromFormat(str, 'MM/dd/yyyy HH:mm', { zone: TZ }));
}
console.log(dts[count - 1].toISO());
```
My measurements indicate roughly a **2x** speed-up on Node 18.18.0. This might result in a low to negligible increase in memory usage due to the few cached functions.

# Edit
Benchmark results before and after:
## Before (Luxon 3.4.4)
```
DateTime.local x 1,374,058 ops/sec ±1.07% (92 runs sampled)
DateTime.fromObject with locale x 474,771 ops/sec ±0.67% (97 runs sampled)
DateTime.local with numbers x 355,343 ops/sec ±0.68% (92 runs sampled)
DateTime.fromISO x 132,521 ops/sec ±5.31% (89 runs sampled)
DateTime.fromSQL x 206,776 ops/sec ±0.37% (98 runs sampled)
DateTime.fromFormat x 25,289 ops/sec ±0.52% (95 runs sampled)
DateTime.fromFormat no cache x 7,549 ops/sec ±0.83% (91 runs sampled)
DateTime.fromFormat with zone x 11,800 ops/sec ±0.50% (96 runs sampled)
DateTime.fromFormat with non-English locale x 3,464 ops/sec ±0.96% (90 runs sampled)
DateTime.fromFormat with non-English locale no cache x 2,032 ops/sec ±1.53% (88 runs sampled)
DateTime#setZone x 75,920 ops/sec ±0.73% (93 runs sampled)
DateTime#toFormat x 452,849 ops/sec ±0.46% (98 runs sampled)
DateTime#toFormat with macro x 167,433 ops/sec ±0.80% (90 runs sampled)
DateTime#toFormat with macro no cache x 5,370 ops/sec ±3.41% (79 runs sampled)
DateTime#add x 106,457 ops/sec ±38.67% (96 runs sampled)
DateTime#toISO x 3,377,444 ops/sec ±0.24% (95 runs sampled)
DateTime#toLocaleString x 217,329 ops/sec ±0.80% (92 runs sampled)
DateTime#toLocaleString in utc x 91,215 ops/sec ±1.26% (94 runs sampled)
DateTime#toRelativeCalendar x 5,232 ops/sec ±2.63% (92 runs sampled)
```

## After
```
DateTime.local x 1,271,155 ops/sec ±2.69% (94 runs sampled)
DateTime.fromObject with locale x 466,883 ops/sec ±0.68% (95 runs sampled)
DateTime.local with numbers x 360,438 ops/sec ±0.58% (94 runs sampled)
DateTime.fromISO x 125,678 ops/sec ±0.83% (94 runs sampled)
DateTime.fromSQL x 188,691 ops/sec ±0.67% (93 runs sampled)
DateTime.fromFormat x 62,886 ops/sec ±0.48% (94 runs sampled)    <- 2x speedup
DateTime.fromFormat no cache x 9,227 ops/sec ±1.58% (88 runs sampled)    <- new
DateTime.fromFormat with zone x 16,462 ops/sec ±1.32% (97 runs sampled)
DateTime.fromFormat with non-English locale x 39,728 ops/sec ±0.64% (93 runs sampled)    <- 10x speedup, new
DateTime.fromFormat with non-English locale no cache x 2,780 ops/sec ±1.21% (89 runs sampled)    <- new
DateTime#setZone x 79,141 ops/sec ±0.51% (93 runs sampled)
DateTime#toFormat x 525,082 ops/sec ±0.46% (89 runs sampled)
DateTime#toFormat with macro x 165,672 ops/sec ±0.86% (91 runs sampled)
DateTime#toFormat with macro no cache x 5,250 ops/sec ±3.51% (80 runs sampled)
DateTime#add x 127,340 ops/sec ±14.36% (93 runs sampled)
DateTime#toISO x 3,297,937 ops/sec ±0.51% (93 runs sampled)
DateTime#toLocaleString x 213,467 ops/sec ±0.84% (93 runs sampled)
DateTime#toLocaleString in utc x 80,442 ops/sec ±5.44% (81 runs sampled)
DateTime#toRelativeCalendar x 11,187 ops/sec ±0.97% (86 runs sampled)    <- 2x speedup
```