### PR TITLE
Enhancement for next/previous weekday

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -2164,6 +2164,34 @@ export default class DateTime {
   }
 
   /**
+   *
+   * @param {number} weekday - The number of the required weekday (1 is Monday and 7 is Sunday)
+   * @returns {DateTime}
+   * @example DateTime.fromISO('2023-10-06T09:08:34.123').nextWeekday(weekday = 1) //=> Next Monday
+   * @example DateTime.fromISO('2023-10-06T09:08:34.123').nextWeekday(weekday = 5) //=> Next Friday
+   */
+  nextWeekday(weekday) {
+    if (!this.isValid) return this;
+
+    let daysToAdd = (7 - this.weekday + weekday) % 7;
+    return this.plus({ day: daysToAdd === 0 ? 7 : daysToAdd });
+  }
+
+  /**
+   *
+   * @param {number} weekday - The number of the required weekday (1 is Monday and 7 is Sunday)
+   * @returns {DateTime}
+   * @example DateTime.fromISO('2023-10-06T09:08:34.123').nextWeekday(weekday = 2) //=> Previous Tuesday
+   */
+  prevWeekday(weekday) {
+    if (!this.isValid) return this;
+
+    let daysToSubtract =
+      this.weekday > weekday ? this.weekday - weekday : 7 - weekday + this.weekday;
+    return this.minus({ day: daysToSubtract });
+  }
+
+  /**
    * Return the min of several date times
    * @param {...DateTime} dateTimes - the DateTimes from which to choose the minimum
    * @return {DateTime} the min DateTime, or undefined if called with no argument

--- a/test/datetime/misc.test.js
+++ b/test/datetime/misc.test.js
@@ -129,3 +129,29 @@ test("DateTime#weeksInWeekYear returns the number of days in the DateTime's year
 test("DateTime#weeksInWeekYear returns NaN for invalid DateTimes", () => {
   expect(DateTime.invalid("because").weeksInWeekYear).toBeFalsy();
 });
+
+//------
+// #nextWeekday
+//------
+test("DateTime#nextWeekday returns next weekday for current date", () => {
+  expect(DateTime.fromISO("2023-10-06T09:08:34.123").nextWeekday(1)).toStrictEqual(
+    DateTime.fromISO("2023-10-09T09:08:34.123")
+  );
+  expect(DateTime.fromISO("2023-10-06T09:08:34.123").nextWeekday(5)).toStrictEqual(
+    DateTime.fromISO("2023-10-13T09:08:34.123")
+  );
+  expect(DateTime.fromISO("invald").prevWeekday(1).isValid).toBeFalsy();
+});
+
+//------
+// #prevWeekday
+//------
+test("DateTime#prevWeekday returns previous weekday for current date", () => {
+  expect(DateTime.fromISO("2023-10-06T09:08:34.123").prevWeekday(1)).toStrictEqual(
+    DateTime.fromISO("2023-10-02T09:08:34.123")
+  );
+  expect(DateTime.fromISO("2023-10-06T09:08:34.123").prevWeekday(5)).toStrictEqual(
+    DateTime.fromISO("2023-09-29T09:08:34.123")
+  );
+  expect(DateTime.fromISO("invald").prevWeekday(1).isValid).toBeFalsy();
+});


### PR DESCRIPTION
I have a couple of questions regarding this. @diesieben07 

1. What should be the expected behaviour when weekday argument is incorrect(eg: weekday is a string or the weeday value is out of valid range). Should the method be throwing an InvalidArgumentException?

2. Currently, the method will return the DateTime with the next/previous weekday. So, if the current weekday is Monday(1) and the methods are called with argument as 1, the method does not return the current date but the previous or next Monday. Is this the correct behaviour?

resolves https://github.com/moment/luxon/issues/1517