### PR TITLE
fix: DateTime throws when year is invalid and throwOnInvalid is true

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -810,6 +810,10 @@ export default class DateTime {
       );
     }
 
+    if (!inst.isValid) {
+      return DateTime.invalid(inst.invalid);
+    }
+
     return inst;
   }
 

--- a/test/datetime/invalid.test.js
+++ b/test/datetime/invalid.test.js
@@ -72,3 +72,18 @@ test("throwOnInvalid throws", () => {
 test("DateTime.invalid throws if you don't provide a reason", () => {
   expect(() => DateTime.invalid()).toThrow();
 });
+
+test("throwOnInvalid throws if year is too big", () => {
+  try {
+    Settings.throwOnInvalid = true;
+    expect(() =>
+      DateTime.fromObject({
+        year: 9999999,
+        month: 5,
+        day: 25,
+      })
+    ).toThrow();
+  } finally {
+    Settings.throwOnInvalid = false;
+  }
+});


### PR DESCRIPTION
Fixes #1449.

### What I did

So the issue here is that whenever the year passed is too big, `DateTime.fromObject` goes all the way through execution and ends up returning the DateTime instance.

The instance, which is being instantiated [here](https://github.com/moment/luxon/blob/master/src/datetime.js#L798), is invalid. This is because DateTime's constructor checks on the year [here](https://github.com/moment/luxon/blob/master/src/datetime.js#L492) and assigns `invalid`. The problem is that, unlike other invalid cases, in this one (and probably others) we never go through `DateTime.invalid`, therefore we do not check on `throwIfInvalid` (and eventually throw).

So here I'm checking if the DateTime instance is invalid before returning, and if it is, i'm going through the same `DateTime.invalid` method. 

The good thing is that we're reusing the same logic for throwing. The not so good thing is that, should `throwIfInvalid` be `false`, we would be returning basically the same thing that we started with. But I think this is a good compromise!

I've also added a unit test.