### PR TITLE
Alias DateTime in documentation site

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -26,6 +26,7 @@
   <script src="https://unpkg.com/docsify/lib/plugins/search.min.js"></script>
   <script src="global/luxon.js"></script>
   <script>
+    var DateTime = luxon.DateTime;
     console.log(
       "You can try Luxon right here using the `luxon` global, like `luxon.DateTime.now()`."
     );


### PR DESCRIPTION
All examples use `DateTime`. The install guide even suggests doing the alias.

The first thing I tried was to copy the example on the landing page `DateTime.now().setZone('America/New_York').minus({weeks:1}).endOf('day').toISO();`
->
`Uncaught ReferenceError: DateTime is not defined at <anonymous>:1:1`
