### PR TITLE
Perf: Use computed offset passed in DateTime constructor

### DIFF
--- a/benchmarks/datetime.js
+++ b/benchmarks/datetime.js
@@ -9,7 +9,7 @@ function runDateTimeSuite() {
     const dt = DateTime.now();
 
     suite
-      .add("DateTime.local", () => {
+      .add("DateTime.now", () => {
         DateTime.now();
       })
       .add("DateTime.fromObject with locale", () => {
@@ -17,6 +17,9 @@ function runDateTimeSuite() {
       })
       .add("DateTime.local with numbers", () => {
         DateTime.local(2017, 5, 15);
+      })
+      .add("DateTime.local with numbers and zone", () => {
+        DateTime.local(2017, 5, 15, 11, 7, 35, { zone: "America/New_York" });
       })
       .add("DateTime.fromISO", () => {
         DateTime.fromISO("1982-05-25T09:10:11.445Z");

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -487,7 +487,9 @@ export default class DateTime {
       if (unchanged) {
         [c, o] = [config.old.c, config.old.o];
       } else {
-        const ot = zone.offset(this.ts);
+        // If an offset has been passed and we have not been called from
+        // clone(), we can trust it and avoid the offset calculation.
+        const ot = isNumber(config.o) && !config.old ? config.o : zone.offset(this.ts);
         c = tsToObj(this.ts, ot);
         invalid = Number.isNaN(c.year) ? new Invalid("invalid input") : null;
         c = invalid ? null : c;


### PR DESCRIPTION
_This is part of a series of PRs based on performance work we have done to
improve a use-case involving parsing/formatting hundreds of thousands of dates
where luxon was the bottleneck._

_This includes the commit from https://github.com/moment/luxon/pull/1574 to establish the benchmark_

All calls to the datetime constructor that pass an offset (o), have just
computed that offset (quickDT, fromObject) except for clone(). Clone
passes an "old" option to determine whether previous offset can be
reused. If we have config.o, but config.old is not set, then we can use
o without computing it.

This saves an expensive call to zone.offset that duplicates work that
was done immediately prior.

Benchmark Comparison (`name | before | after | after/before`):
```
DateTime.fromObject with locale | 1,112,953 ±0.08% | 1,263,335 ±0.10% | 1.14x
DateTime.local with numbers | 844,898 ±0.15% | 943,140 ±0.13% | 1.12x
DateTime.local with numbers and zone | 50,913 ±0.18% | 66,671 ±0.14% | 1.31x
DateTime.fromFormat with zone | 26,687 ±0.18% | 30,091 ±0.21% | 1.13x
```