### PR TITLE
Perf: Memoize digitsRegex

### DIFF
--- a/src/impl/digits.js
+++ b/src/impl/digits.js
@@ -70,6 +70,18 @@ export function parseDigits(str) {
   }
 }
 
+// cache of {numberingSystem: {append: regex}}
+const digitRegexCache = {};
+
 export function digitRegex({ numberingSystem }, append = "") {
-  return new RegExp(`${numberingSystems[numberingSystem || "latn"]}${append}`);
+  const ns = numberingSystem || "latn";
+
+  if (!digitRegexCache[ns]) {
+    digitRegexCache[ns] = {};
+  }
+  if (!digitRegexCache[ns][append]) {
+    digitRegexCache[ns][append] = new RegExp(`${numberingSystems[ns]}${append}`);
+  }
+
+  return digitRegexCache[ns][append];
 }

--- a/src/impl/digits.js
+++ b/src/impl/digits.js
@@ -71,7 +71,10 @@ export function parseDigits(str) {
 }
 
 // cache of {numberingSystem: {append: regex}}
-const digitRegexCache = {};
+let digitRegexCache = {};
+export function resetDigitRegexCache() {
+  digitRegexCache = {};
+}
 
 export function digitRegex({ numberingSystem }, append = "") {
   const ns = numberingSystem || "latn";

--- a/src/settings.js
+++ b/src/settings.js
@@ -4,6 +4,7 @@ import Locale from "./impl/locale.js";
 
 import { normalizeZone } from "./impl/zoneUtil.js";
 import { validateWeekSettings } from "./impl/util.js";
+import { resetDigitRegexCache } from "./impl/digits.js";
 
 let now = () => Date.now(),
   defaultZone = "system",
@@ -171,5 +172,6 @@ export default class Settings {
   static resetCaches() {
     Locale.resetCache();
     IANAZone.resetCache();
+    resetDigitRegexCache();
   }
 }


### PR DESCRIPTION
_This is part of a series of PRs based on performance work we have done to
improve a use-case involving parsing/formatting hundreds of thousands of dates
where luxon was the bottleneck._

Profiles reveal that a substantial portion of fromFormat time is spent in digitsRegex. It is only called from unitsForToken and it is always called with 11 suffixes to match different numbers of digits.

There are 21 numbering systems, so a fully expanded cache would hold 11*21 = 231 regexes.

This is related to https://github.com/moment/luxon/pull/1530 , but involves a much more restricted cache

Benchmark Comparison (`name | before | after | after/before`):
```
DateTime.fromFormat | 60,666 ±0.17% | 113,218 ±0.20% | 1.87x
DateTime.fromFormat with zone | 26,687 ±0.18% | 33,563 ±0.19% | 1.26x
```