### PR TITLE
Use getPrototypeOf instead of __proto__

### DIFF
--- a/test/datetime/proto.test.js
+++ b/test/datetime/proto.test.js
@@ -4,6 +4,6 @@ import { DateTime } from "../../src/luxon";
 test("DateTime prototype properties should not throw when accessed", () => {
   const d = DateTime.now();
   expect(() =>
-    Object.getOwnPropertyNames(d.__proto__).forEach((name) => d.__proto__[name])
+    Object.getOwnPropertyNames(Object.getPrototypeOf(d)).forEach((name) => Object.getPrototypeOf(d)[name])
   ).not.toThrow();
 });

--- a/test/duration/proto.test.js
+++ b/test/duration/proto.test.js
@@ -3,6 +3,6 @@ import { Duration } from "../../src/luxon";
 test("Duration prototype properties should not throw when addressed", () => {
   const d = Duration.fromObject({ hours: 1 });
   expect(() =>
-    Object.getOwnPropertyNames(d.__proto__).forEach((name) => d.__proto__[name])
+    Object.getOwnPropertyNames(Object.getPrototypeOf(d)).forEach((name) => Object.getPrototypeOf(d)[name])
   ).not.toThrow();
 });

--- a/test/interval/proto.test.js
+++ b/test/interval/proto.test.js
@@ -4,6 +4,6 @@ import { DateTime } from "../../src/luxon";
 test("Interval prototype properties should not throw when addressed", () => {
   const i = DateTime.fromISO("2018-01-01").until(DateTime.fromISO("2018-01-02"));
   expect(() =>
-    Object.getOwnPropertyNames(i.__proto__).forEach((name) => i.__proto__[name])
+    Object.getOwnPropertyNames(Object.getPrototypeOf(i)).forEach((name) => Object.getPrototypeOf(i)[name])
   ).not.toThrow();
 });


### PR DESCRIPTION
Debian checks what happens with running `node --disable-proto=throw`.
Because __proto__ brings so many trivial-to-exploit security issues, we might disable-proto by default.
Here it's just used in the tests, nonetheless, it's an old js feature that might just be phased out, hopefully.


 