### PR TITLE
docs: until returns Inverval or DateTime conditionally

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -2128,7 +2128,7 @@ export default class DateTime {
   /**
    * Return an Interval spanning between this DateTime and another DateTime
    * @param {DateTime} otherDateTime - the other end point of the Interval
-   * @return {Interval}
+   * @return {Interval|DateTime}
    */
   until(otherDateTime) {
     return this.isValid ? Interval.fromDateTimes(this, otherDateTime) : this;


### PR DESCRIPTION
DateTime.until returns Interval or DateTime conditionally.

It is already on the [type definitions](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/ec2fdb5dc09bcd3a871a46212c5f611b6cdd3a1c/types/luxon/src/datetime.d.ts#L1527) but luxon documentation is wrong with it.