### PR TITLE
Fix/12 hour format validation

### DIFF
--- a/src/impl/tokenParser.js
+++ b/src/impl/tokenParser.js
@@ -451,10 +451,13 @@ export class TokenParser {
     if (!this.isValid) {
       return { input, tokens: this.tokens, invalidReason: this.invalidReason };
     } else {
-      const [rawMatches, matches] = match(input, this.regex, this.handlers),
-        [result, zone, specificOffset] = matches
-          ? dateTimeFromMatches(matches)
-          : [null, null, undefined];
+      const [rawMatches, matches] = match(input, this.regex, this.handlers);
+      if (hasOwnProperty(matches, "h") && matches.h > 12) {
+        throw new ConflictingSpecificationError("Can't go over 12 when specifying 12-hour format");
+      }
+      const [result, zone, specificOffset] = matches
+        ? dateTimeFromMatches(matches)
+        : [null, null, undefined];
       if (hasOwnProperty(matches, "a") && hasOwnProperty(matches, "H")) {
         throw new ConflictingSpecificationError(
           "Can't include meridiem when specifying 24-hour format"

--- a/test/datetime/tokenParse.test.js
+++ b/test/datetime/tokenParse.test.js
@@ -74,6 +74,12 @@ test("DateTime.fromFormat() throws if you specify meridiem with 24-hour time", (
   expect(() => DateTime.fromFormat("930PM", "Hmma")).toThrow(ConflictingSpecificationError);
 });
 
+test("DateTime.fromFormat() throws if h is used with 24-hour time", () => {
+  expect(() => DateTime.fromFormat("18:30 AM", "h:mm a")).toThrowError(
+    ConflictingSpecificationError
+  );
+});
+
 // #714
 test("DateTime.fromFormat() makes dots optional and handles non breakable spaces", () => {
   function parseMeridiem(input, isAM) {


### PR DESCRIPTION
Fix issue: https://github.com/moment/luxon/issues/1625

## Description of the Bug
The `DateTime.fromFormat()` function incorrectly validates certain 24-hour formats as valid when they should be considered invalid. 
When using the 12-hour (h) format in the format parameter, the function does not properly invalidate times where the hour exceeds 12.

## Actual vs Expected Behavior
```javascript
DateTime.fromFormat('18:30 AM', 'h:mm a').isValid;
```
Actual: `isValid` returns true for `DateTime.fromFormat('18:30 AM', 'h:mm a')`.
Expected: `isValid` shouldn't be true because 18 is not a valid hour for the 12-hour (h) format.

## Fix Description
This PR addresses the issue by ensuring that when the 12-hour (h) format is used in the format parameter, any hour value greater than 12 is considered `invalid`, and isValid will throw error.