### PR TITLE
`refrenceDate` support for `fromObject`

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -745,8 +745,10 @@ export default class DateTime {
    * @param {string} [opts.locale='system\'s locale'] - a locale to set on the resulting DateTime instance
    * @param {string} opts.outputCalendar - the output calendar to set on the resulting DateTime instance
    * @param {string} opts.numberingSystem - the numbering system to set on the resulting DateTime instance
+   * @param {DateTime|Date|Object} opts.refrenceDate - the reference date to taken for missing parts
    * @example DateTime.fromObject({ year: 1982, month: 5, day: 25}).toISODate() //=> '1982-05-25'
    * @example DateTime.fromObject({ year: 1982 }).toISODate() //=> '1982-01-01'
+   * @example DateTime.fromObject({ year: 1982 }, { refrenceDate: { day: 10 } }).toISODate() //=> '1982-01-10'
    * @example DateTime.fromObject({ hour: 10, minute: 26, second: 6 }) //~> today at 10:26:06
    * @example DateTime.fromObject({ hour: 10, minute: 26, second: 6 }, { zone: 'utc' }),
    * @example DateTime.fromObject({ hour: 10, minute: 26, second: 6 }, { zone: 'local' })
@@ -766,7 +768,9 @@ export default class DateTime {
     const normalized = normalizeObject(obj, normalizeUnitWithLocalWeeks);
     const { minDaysInFirstWeek, startOfWeek } = usesLocalWeekValues(normalized, loc);
 
-    const tsNow = Settings.now(),
+    const tsNow = isUndefined(opts.refrenceDate)
+      ? friendlyDateTime(opts.refrenceDate).toUnixInteger()
+      : opts.refrenceDate,
       offsetProvis = !isUndefined(opts.specificOffset)
         ? opts.specificOffset
         : zoneToUse.offset(tsNow),

--- a/test/datetime/create.test.js
+++ b/test/datetime/create.test.js
@@ -883,6 +883,12 @@ test("DateTime.fromObject takes a undefined to mean {}", () => {
   expect(res.year).toBe(new Date().getFullYear());
 });
 
+test("DateTime.fromObject respects `refrenceDate`", () => {
+  const res = DateTime.fromObject(undefined, { refrenceDate: { day: 10 } });
+  expect(res.year).toBe(new Date().getFullYear());
+  expect(res.day).toBe(10);
+});
+
 test("private language subtags don't break unicode subtags", () => {
   const res = DateTime.fromObject(
     {},


### PR DESCRIPTION
Analogous to _date-fns_'s `parse` method, _luxon_ should support a `referenceDate`, too.