### PR TITLE
fix: Allow default initialization of DateTime/Duration/Interval

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -514,6 +514,10 @@ export default class DateTime {
    * @access private
    */
   constructor(config) {
+    if (!config) {
+      return DateTime.invalid("no config supplied");
+    }
+
     const zone = config.zone || Settings.defaultZone;
 
     let invalid =

--- a/src/duration.js
+++ b/src/duration.js
@@ -218,6 +218,10 @@ export default class Duration {
    * @private
    */
   constructor(config) {
+    if (!config) {
+      return Duration.invalid("no config supplied");
+    }
+
     const accurate = config.conversionAccuracy === "longterm" || false;
     let matrix = accurate ? accurateMatrix : casualMatrix;
 

--- a/src/impl/locale.js
+++ b/src/impl/locale.js
@@ -360,7 +360,9 @@ export default class Locale {
   }
 
   constructor(locale, numbering, outputCalendar, weekSettings, specifiedLocale) {
-    const [parsedLocale, parsedNumberingSystem, parsedOutputCalendar] = parseLocaleString(locale);
+    const [parsedLocale, parsedNumberingSystem, parsedOutputCalendar] = parseLocaleString(
+      locale || systemLocale()
+    );
 
     this.locale = parsedLocale;
     this.numberingSystem = numbering || parsedNumberingSystem || null;

--- a/src/interval.js
+++ b/src/interval.js
@@ -41,6 +41,10 @@ export default class Interval {
    * @private
    */
   constructor(config) {
+    if (!config) {
+      return Interval.invalid("no config supplied");
+    }
+
     /**
      * @access private
      */

--- a/test/datetime/create.test.js
+++ b/test/datetime/create.test.js
@@ -10,6 +10,15 @@ const withDefaultLocale = Helpers.withDefaultLocale,
   withDefaultZone = Helpers.withDefaultZone;
 
 //------
+// new
+//------
+test("Default constructor works and returns an invalid instance", () => {
+  const datetime = new DateTime();
+  expect(datetime.isValid).toBe(false);
+  expect(datetime.invalidReason).toBe("no config supplied");
+});
+
+//------
 // .now()
 //------
 test("DateTime.now has today's date", () => {

--- a/test/duration/create.test.js
+++ b/test/duration/create.test.js
@@ -3,6 +3,15 @@
 import { Duration } from "../../src/luxon";
 
 //------
+// new
+//------
+test("Default constructor works and returns an invalid instance", () => {
+  const duration = new Duration();
+  expect(duration.isValid).toBe(false);
+  expect(duration.invalidReason).toBe("no config supplied");
+});
+
+//------
 // .fromObject()
 //-------
 test("Duration.fromObject sets all the values", () => {

--- a/test/interval/create.test.js
+++ b/test/interval/create.test.js
@@ -5,6 +5,15 @@ import Helpers from "../helpers";
 const withThrowOnInvalid = Helpers.setUnset("throwOnInvalid");
 
 //------
+// new
+//------
+test("Default constructor works and returns an invalid instance", () => {
+  const interval = new Interval();
+  expect(interval.isValid).toBe(false);
+  expect(interval.invalidReason).toBe("no config supplied");
+});
+
+//------
 // .fromObject()
 //-------
 test("Interval.fromDateTimes creates an interval from datetimes", () => {


### PR DESCRIPTION
This PR default initializes the config parameter of the constructor for `DateTime`, `Duration`, and `Interval` in order to fix the following:

```
Cannot read properties of undefined (reading 'zone')
```

This can be encountered when using a third party serialization/deserialization library such as class-transformer as temporary objects may be constructed with `new` while waiting for any transformation logic to run. This is actually a very common issue for NestJS users.

Understandably, these constructors are *meant* to be private, but the unfortunate fact is that nothing can prevent `new` from being called on these types. Moreover, if you look at the constructor definitions it seems that the intent was to provide sane defaults *already*. With that in mind, it may make sense just to provide a default to sidestep the issue entirely and let the existing code handle things.

Ultimately, this is a minor adjustment which fixes some very real pain points.