### PR TITLE
Fixed parameter to check cached resolved options

### DIFF
--- a/src/impl/locale.js
+++ b/src/impl/locale.js
@@ -175,7 +175,7 @@ function supportsFastNumbers(loc) {
       loc.numberingSystem === "latn" ||
       !loc.locale ||
       loc.locale.startsWith("en") ||
-      getCachedIntResolvedOptions(loc.locale).numberingSystem === "latn"
+      getCachedIntResolvedOptions(loc.intl).numberingSystem === "latn"
     );
   }
 }


### PR DESCRIPTION
As mentioned by @mohd-akram : https://github.com/moment/luxon/pull/1642#discussion_r1753777385 we have to use intl instead of locale