### PR TITLE
Modify tokenParser tests to suit CLDR 46

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,10 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.5.1]
+        node-version:
+          - 18.20.6 # latest 18.x
+          - 20.18.3 # latest 20.x
+          - 22.14.0 # latest 22.x
 
     steps:
       - uses: actions/checkout@v3

--- a/test/datetime/tokenParse.test.js
+++ b/test/datetime/tokenParse.test.js
@@ -1086,14 +1086,10 @@ test("DateTime.fromFormatExplain() parses localized string with numberingSystem 
   expect(ex15.result).toBeInstanceOf(Object);
   expect(keyCount(ex15.result)).toBe(6);
 
-  const ex16 = DateTime.fromFormatExplain(
-    "௦௩-ஏப்ரல்-௨௦௧௯ ௦௪:௦௦:௪௧ PM",
-    "dd-MMMM-yyyy hh:mm:ss a",
-    {
-      locale: "ta",
-      numberingSystem: "tamldec",
-    }
-  );
+  const ex16 = DateTime.fromFormatExplain("௦௩-ஏப்ரல்-௨௦௧௯ ௦௪:௦௦:௪௧ PM", "dd-MMMM-yyyy hh:mm:ss a", {
+    locale: "ta",
+    numberingSystem: "tamldec",
+  });
   expect(ex16.rawMatches).toBeInstanceOf(Array);
   expect(ex16.matches).toBeInstanceOf(Object);
   expect(keyCount(ex16.matches)).toBe(7);

--- a/test/datetime/tokenParse.test.js
+++ b/test/datetime/tokenParse.test.js
@@ -1,6 +1,6 @@
 /* global test expect */
 import { DateTime } from "../../src/luxon";
-import Helpers from "../helpers";
+import Helpers, { cldrMajorVersion } from "../helpers";
 import Settings from "../../src/settings";
 import { ConflictingSpecificationError } from "../../src/errors";
 
@@ -900,8 +900,11 @@ test("DateTime.fromFormatExplain() parses zone correctly", () => {
 });
 
 test("DateTime.fromFormatExplain() parses localized string with numberingSystem correctly", () => {
+  const cldr = cldrMajorVersion();
   const ex1 = DateTime.fromFormatExplain(
-    "೦೩-ಏಪ್ರಿಲ್-೨೦೧೯ ೧೨:೨೬:೦೭ PM Asia/Calcutta",
+    cldr && cldr < 46
+      ? "೦೩-ಏಪ್ರಿಲ್-೨೦೧೯ ೧೨:೨೬:೦೭ ಅಪರಾಹ್ನ Asia/Calcutta"
+      : "೦೩-ಏಪ್ರಿಲ್-೨೦೧೯ ೧೨:೨೬:೦೭ PM Asia/Calcutta",
     "dd-MMMM-yyyy hh:mm:ss a z",
     { locale: "kn", numberingSystem: "knda" }
   );
@@ -1086,10 +1089,14 @@ test("DateTime.fromFormatExplain() parses localized string with numberingSystem 
   expect(ex15.result).toBeInstanceOf(Object);
   expect(keyCount(ex15.result)).toBe(6);
 
-  const ex16 = DateTime.fromFormatExplain("௦௩-ஏப்ரல்-௨௦௧௯ ௦௪:௦௦:௪௧ PM", "dd-MMMM-yyyy hh:mm:ss a", {
-    locale: "ta",
-    numberingSystem: "tamldec",
-  });
+  const ex16 = DateTime.fromFormatExplain(
+    cldr && cldr < 45 ? "௦௩-ஏப்ரல்-௨௦௧௯ ௦௪:௦௦:௪௧ பிற்பகல்" : "௦௩-ஏப்ரல்-௨௦௧௯ ௦௪:௦௦:௪௧ PM",
+    "dd-MMMM-yyyy hh:mm:ss a",
+    {
+      locale: "ta",
+      numberingSystem: "tamldec",
+    }
+  );
   expect(ex16.rawMatches).toBeInstanceOf(Array);
   expect(ex16.matches).toBeInstanceOf(Object);
   expect(keyCount(ex16.matches)).toBe(7);

--- a/test/datetime/tokenParse.test.js
+++ b/test/datetime/tokenParse.test.js
@@ -901,7 +901,7 @@ test("DateTime.fromFormatExplain() parses zone correctly", () => {
 
 test("DateTime.fromFormatExplain() parses localized string with numberingSystem correctly", () => {
   const ex1 = DateTime.fromFormatExplain(
-    "೦೩-ಏಪ್ರಿಲ್-೨೦೧೯ ೧೨:೨೬:೦೭ ಅಪರಾಹ್ನ Asia/Calcutta",
+    "೦೩-ಏಪ್ರಿಲ್-೨೦೧೯ ೧೨:೨೬:೦೭ PM Asia/Calcutta",
     "dd-MMMM-yyyy hh:mm:ss a z",
     { locale: "kn", numberingSystem: "knda" }
   );
@@ -1087,7 +1087,7 @@ test("DateTime.fromFormatExplain() parses localized string with numberingSystem 
   expect(keyCount(ex15.result)).toBe(6);
 
   const ex16 = DateTime.fromFormatExplain(
-    "௦௩-ஏப்ரல்-௨௦௧௯ ௦௪:௦௦:௪௧ பிற்பகல்",
+    "௦௩-ஏப்ரல்-௨௦௧௯ ௦௪:௦௦:௪௧ PM",
     "dd-MMMM-yyyy hh:mm:ss a",
     {
       locale: "ta",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -76,3 +76,18 @@ exports.setUnset = function (prop) {
 exports.atHour = function (hour) {
   return DateTime.fromObject({ year: 2017, month: 5, day: 25 }).startOf("day").set({ hour });
 };
+
+exports.cldrMajorVersion = function () {
+  try {
+    const cldr = process?.versions?.cldr;
+    if (cldr) {
+      const match = cldr.match(/^(\d+)\./);
+      if (match) {
+        return parseInt(match[1]);
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION
CLDR 46 makes changes to the kn (Kannada) and ta (Tamil) locales effectively disregarding local names for AM/PM (Kannada) and special names for afternoon. The tests have been modified to use "PM".

Fixes #1675 