### PR TITLE
Include documentation that toSeconds() returns a floating point number

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -2030,7 +2030,7 @@ export default class DateTime {
   }
 
   /**
-   * Returns the epoch seconds (as a floating point number) of this DateTime.
+   * Returns the epoch seconds (including milliseconds in the fractional part) of this DateTime.
    * @return {number}
    */
   toSeconds() {

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -2030,7 +2030,7 @@ export default class DateTime {
   }
 
   /**
-   * Returns the epoch seconds of this DateTime.
+   * Returns the epoch seconds (as a floating point number) of this DateTime.
    * @return {number}
    */
   toSeconds() {


### PR DESCRIPTION
Relevant discussion here: https://github.com/moment/luxon/issues/565

Newest discussion was brought up again here, indicating users are still having issues with toSeconds() returning the milliseconds as the floating point part of the number: https://github.com/moment/luxon/issues/1644

I've updated the doc string to match the toUnixInteger's format of indicating it returns a floating point instead of a whole number.