### PR TITLE
feat: more rounding options to toRelative

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -448,7 +448,8 @@ function quickDT(obj, opts) {
 function diffRelative(start, end, opts) {
   const round = isUndefined(opts.round) ? true : opts.round,
     format = (c, unit) => {
-      c = roundTo(c, round || opts.calendary ? 0 : 2, true);
+      const roundTowardZero = round === true || opts.round === "down";
+      c = roundTo(c, round || opts.calendary ? 0 : 2, roundTowardZero);
       const formatter = end.loc.clone(opts).relFormatter(opts);
       return formatter.format(c, unit);
     },
@@ -2198,7 +2199,7 @@ export default class DateTime {
    * @param {DateTime} [options.base=DateTime.now()] - the DateTime to use as the basis to which this time is compared. Defaults to now.
    * @param {string} [options.style="long"] - the style of units, must be "long", "short", or "narrow"
    * @param {string|string[]} options.unit - use a specific unit or array of units; if omitted, or an array, the method will pick the best unit. Use an array or one of "years", "quarters", "months", "weeks", "days", "hours", "minutes", or "seconds"
-   * @param {boolean} [options.round=true] - whether to round the numbers in the output.
+   * @param {boolean|"nearest"|"down"} [options.round=true] - whether to round the numbers in the output. `true` is same as `"down"` for backwards compatibility.
    * @param {number} [options.padding=0] - padding in milliseconds. This allows you to round up the result if it fits inside the threshold. Don't use in combination with {round: false} because the decimal output will include the padding.
    * @param {string} options.locale - override the locale of this DateTime
    * @param {string} options.numberingSystem - override the numberingSystem of this DateTime. The Intl system may choose not to honor this

--- a/test/datetime/relative.test.js
+++ b/test/datetime/relative.test.js
@@ -78,6 +78,34 @@ test("DateTime#toRelative always rounds toward 0", () => {
   expect(base.minus({ days: 1, milliseconds: -1 }).toRelative({ base })).toBe("23 hours ago");
 });
 
+test("DateTime#toRelative rounds toward nearest integer", () => {
+  const base = DateTime.fromObject({ year: 1983, month: 10, day: 14 });
+  expect(base.plus({ minutes: 4.9 }).toRelative({ base, round: "nearest" })).toBe("in 5 minutes");
+  expect(base.plus({ minutes: 5.1 }).toRelative({ base, round: "nearest" })).toBe("in 5 minutes");
+
+  expect(base.plus({ minutes: 119 }).toRelative({ base, round: "nearest" })).toBe("in 2 hours");
+  expect(base.plus({ minutes: 121 }).toRelative({ base, round: "nearest" })).toBe("in 2 hours");
+
+  expect(base.plus({ days: 2.6 }).toRelative({ base, round: "nearest" })).toBe("in 3 days");
+  expect(base.plus({ days: 3.499 }).toRelative({ base, round: "nearest" })).toBe("in 3 days");
+
+  expect(base.plus({ months: 4.5 }).toRelative({ base, round: "nearest" })).toBe("in 5 months");
+  expect(base.plus({ months: 5.49 }).toRelative({ base, round: "nearest" })).toBe("in 5 months");
+
+  expect(base.plus({ months: 23 }).toRelative({ base, round: "nearest" })).toBe("in 2 years");
+  expect(base.plus({ months: 25 }).toRelative({ base, round: "nearest" })).toBe("in 2 years");
+});
+
+test("DateTime#toRelative rounds toward 0", () => {
+  const base = DateTime.fromObject({ year: 1983, month: 10, day: 14 });
+  expect(base.plus({ minutes: 4.9 }).toRelative({ base, round: "down" })).toBe("in 4 minutes");
+  expect(base.plus({ minutes: 4.9 }).toRelative({ base, round: true })).toBe("in 4 minutes");
+  expect(base.plus({ minutes: 119 }).toRelative({ base, round: "down" })).toBe("in 1 hour");
+  expect(base.plus({ days: 3.499 }).toRelative({ base, round: "down" })).toBe("in 3 days");
+  expect(base.plus({ months: 5.49 }).toRelative({ base, round: "down" })).toBe("in 5 months");
+  expect(base.plus({ months: 25 }).toRelative({ base, round: "down" })).toBe("in 2 years");
+});
+
 test("DateTime#toRelative uses the absolute time", () => {
   const base = DateTime.fromObject({ year: 1983, month: 10, day: 14, hour: 23, minute: 59 });
   const end = DateTime.fromObject({ year: 1983, month: 10, day: 15, hour: 0, minute: 3 });


### PR DESCRIPTION
This PR addresses the issue described in #1129 by introducing an additional rounding option: "nearest".

## Problem
Currently, the amount is always rounded down. For example, if the date is 1.99 days away, it is displayed as:

"in 1 day" (when rounded down)
"in 1.99 days" (when rounding is disabled)

## Solution
With the new "nearest" rounding option, the display will round to the closest whole number instead of always rounding down. This provides a more intuitive and accurate representation of time differences.