### PR TITLE
build: use the es6 build for ESM exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "repository": "https://github.com/moment/luxon",
   "exports": {
     ".": {
-      "import": "./src/luxon.js",
+      "import": "./build/es6/luxon.js",
       "require": "./build/node/luxon.js"
     },
     "./package.json": "./package.json"


### PR DESCRIPTION
Currently it seems that Metro (from React Native) isn't resolving Luxon correctly due to the incorrect exports configuration. 

It seems that ESM imports prefer the source code instead of the built code. Changing this to the es6 build resolves the issue.

This is the error with the old export: 
![image](https://github.com/user-attachments/assets/8a8f1934-a4c0-45f5-9a7c-662bded702de)
