### PR TITLE
add dark theme to docs

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -8,13 +8,14 @@
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
   <link rel="stylesheet" href="https://unpkg.com/docsify/lib/themes/vue.css">
   <link rel="stylesheet" href="https://unpkg.com/docsify/lib/themes/dark.css">
+  <link rel="stylesheet" href="plugins/dark-theme-toggle.css">
   <style>
-  .dark .sidebar li {
-    margin-right: 0;
-  }
-  .dark .cover.show {
-    background-color: rgb(79 58 120) !important;
-  }
+    .dark .sidebar li {
+      margin-right: 0;
+    }
+    .dark .cover.show {
+      background-color: rgb(79 58 120) !important;
+    }
   </style>
 </head>
 <body>

--- a/site/index.html
+++ b/site/index.html
@@ -8,6 +8,14 @@
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
   <link rel="stylesheet" href="https://unpkg.com/docsify/lib/themes/vue.css">
   <link rel="stylesheet" href="https://unpkg.com/docsify/lib/themes/dark.css">
+  <style>
+  .dark .sidebar li {
+    margin-right: 0;
+  }
+  .dark .cover.show {
+    background-color: rgb(79 58 120) !important;
+  }
+  </style>
 </head>
 <body>
   <div id="app"></div>

--- a/site/index.html
+++ b/site/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="Immutable date wrapper">
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
   <link rel="stylesheet" href="https://unpkg.com/docsify/lib/themes/vue.css">
+  <link rel="stylesheet" href="https://unpkg.com/docsify/lib/themes/dark.css">
 </head>
 <body>
   <div id="app"></div>
@@ -24,6 +25,7 @@
   </script>
   <script src="https://unpkg.com/docsify/lib/docsify.min.js"></script>
   <script src="https://unpkg.com/docsify/lib/plugins/search.min.js"></script>
+  <script src="plugins/dark-theme-toggle.js"></script>
   <script src="global/luxon.js"></script>
   <script>
     var DateTime = luxon.DateTime;

--- a/site/plugins/dark-theme-toggle.css
+++ b/site/plugins/dark-theme-toggle.css
@@ -1,0 +1,72 @@
+#docsify-dark-theme-toggle {
+  position: absolute;
+  display: inline-block;
+  width: 52px;
+  height: 28px;
+  margin-left: 2rem;
+  margin-top: 1.5rem;
+  left: 0;
+  top: 0;
+  z-index: 0;
+  cursor: pointer;
+}
+.sidebar > .app-name {
+  position: relative;
+}
+.app-name > #docsify-dark-theme-toggle {
+  margin-right: 1rem;
+  margin-top: 0;
+  right: 0;
+  left: unset;
+}
+#docsify-dark-theme-toggle::before, #docsify-dark-theme-toggle::after {
+  position: absolute;
+  top: 0.1em;
+  font-size: 16px;
+  transition: opacity 0.3s;
+}
+#docsify-dark-theme-toggle::before {
+  content: "🌙";
+  left: 0.1em;
+  opacity: 0;
+  z-index: 1;
+}
+#docsify-dark-theme-toggle::after {
+  content: "🌞";
+  right: 0.1em;
+  opacity: 1;
+}
+#docsify-dark-theme-toggle > span {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--theme-color, #42b983);
+  border-radius: 28px;
+  transition: background-color 0.3s;
+}
+#docsify-dark-theme-toggle > span::before {
+  content: "";
+  position: absolute;
+  height: 22px;
+  width: 22px;
+  left: 3px;
+  top: 3px;
+  z-index: 1;
+  background-color: white;
+  border-radius: 50%;
+  transition: transform 0.3s;
+}
+.dark #docsify-dark-theme-toggle::after {
+  opacity: 0;
+}
+.dark #docsify-dark-theme-toggle::before {
+  opacity: 1;
+}
+.dark #docsify-dark-theme-toggle > span {
+  background-color: var(--theme-color, #ea6f5a);
+}
+.dark #docsify-dark-theme-toggle > span::before {
+  transform: translateX(24px);
+}

--- a/site/plugins/dark-theme-toggle.js
+++ b/site/plugins/dark-theme-toggle.js
@@ -4,19 +4,14 @@
       dom = Docsify.dom,
       darkThemeStyleSheet = dom.find('link[href$="dark.css"]'),
       toggleEl = dom.create("div", "<span />"),
-      isDarkThemeEnabled = () => localStorage[TOGGLE_ID] === "true",
       applyTheme = (swap = false) => {
-        const isDark = localStorage[TOGGLE_ID] = swap ? !isDarkThemeEnabled() : isDarkThemeEnabled();
+        const isDark = (localStorage[TOGGLE_ID] = Boolean(
+          swap ^ (localStorage[TOGGLE_ID] == "true")
+        ));
         darkThemeStyleSheet.disabled = !isDark;
         dom.toggleClass(dom.body, isDark ? "add" : "remove", "dark");
       },
-      findTargetEl = () => dom.find(".cover.show") || dom.find(".sidebar > .app-name");
-    localStorage[TOGGLE_ID] ??= matchMedia("(prefers-color-scheme: dark)").matches;
-    toggleEl.id = TOGGLE_ID;
-    dom.on(toggleEl, "click", applyTheme.bind(this, true));
-    hook.init(applyTheme);
-    hook.doneEach(() => dom.before(findTargetEl(), toggleEl));
-    dom.style(`#${TOGGLE_ID} {
+      toggleStyle = `#${TOGGLE_ID} {
   position: absolute;
   display: inline-block;
   width: 52px;
@@ -87,13 +82,17 @@
 }
 .dark #${TOGGLE_ID} > span::before {
   transform: translateX(24px);
-}
-.dark .sidebar li {
-  margin-right: 0;
-}
-.dark .cover.show {
-  background-color: rgb(79 58 120) !important;
-}`);};
+}`;
+    localStorage[TOGGLE_ID] ??= matchMedia("(prefers-color-scheme: dark)").matches;
+    toggleEl.id = TOGGLE_ID;
+    dom.on(toggleEl, "click", applyTheme.bind(this, true));
+    hook.init(applyTheme);
+    hook.doneEach(() => {
+      const targetEl = dom.find(".cover.show") || dom.find(".sidebar > .app-name");
+      dom.before(targetEl, toggleEl);
+    });
+    dom.style(toggleStyle);
+  };
   $docsify = $docsify || {};
   $docsify.plugins = [].concat($docsify.plugins || [], darkThemeTogglePlugin);
 })();

--- a/site/plugins/dark-theme-toggle.js
+++ b/site/plugins/dark-theme-toggle.js
@@ -56,6 +56,7 @@
 			width: 22px;
 			left: 3px;
 			top: 3px;
+      z-index: 2;
 			background-color: white;
 			border-radius: 50%;
 			transition: transform 0.3s;

--- a/site/plugins/dark-theme-toggle.js
+++ b/site/plugins/dark-theme-toggle.js
@@ -1,103 +1,102 @@
 (function () {
   const darkThemeTogglePlugin = function (hook, vm) {
-    const CHECKBOX_ID = "dark-theme-input";
-    const STORAGE_KEY = "docsify-toggle-dark-theme";
-    localStorage[STORAGE_KEY] ??= matchMedia("(prefers-color-scheme: dark)").matches;
-    const initialValue = localStorage[STORAGE_KEY] === "true";
-    const dom = Docsify.dom;
-    const darkThemeStyleSheet = dom.find('link[href$="dark.css"]');
-    const toggleDarkMode = (isDark) => (darkThemeStyleSheet.disabled = !isDark);
-    const pluginStyleEl = dom.create("style");
-    pluginStyleEl.textContent = `#${CHECKBOX_ID} {
-			display: none;
-		}
-		.dark-theme-label {
-			position: absolute;
-			display: inline-block;
-			width: 52px;
-			height: 28px;
-			margin-left: 2rem;
-			margin-top: 2rem;
-			z-index: 0;
-			cursor: pointer;
-		}
-		.dark-theme-label::before, .dark-theme-label::after {
-			position: absolute;
-			top: 0.1em;
-			font-size: 16px;
-			transition: opacity 0.3s;
-		}
-		.dark-theme-label::after {
-			content: "🌞";
-			right: 0.1em;
-			opacity: 1;
-		}
-		.dark-theme-label::before {
-			content: "🌙";
-			left: 0.1em;
-			opacity: 0;
-			z-index: 1;
-		}
-		.slider {
-			position: absolute;
-			top: 0;
-			left: 0;
-			right: 0;
-			bottom: 0;
-			background-color: var(--theme-color, #42b983);
-			border-radius: 28px;
-			transition: background-color 0.3s;
-		}
-		.slider::before {
-			content: "";
-			position: absolute;
-			height: 22px;
-			width: 22px;
-			left: 3px;
-			top: 3px;
-			z-index: 1;
-			background-color: white;
-			border-radius: 50%;
-			transition: transform 0.3s;
-		}
-		#${CHECKBOX_ID}:checked + .dark-theme-label::after {
-			opacity: 0;
-		}
-		#${CHECKBOX_ID}:checked + .dark-theme-label::before {
-			opacity: 1;
-		}
-		#${CHECKBOX_ID}:checked + .dark-theme-label .slider {
-			background-color: var(--theme-color, #ea6f5a);
-		}
-		#${CHECKBOX_ID}:checked + .dark-theme-label .slider::before {
-			transform: translateX(24px);
-		}
-		#${CHECKBOX_ID}:checked ~ section.cover.show {
-			background-color: rgb(79 58 120) !important;
-		}
-		section.cover.show {
-			z-index: -1;
-		}`;
-    dom.head.appendChild(pluginStyleEl);
-    hook.init(() => toggleDarkMode(initialValue));
-    hook.ready(() => {
-      const body = dom.body;
-      const checkbox = dom.create("input");
-      checkbox.id = CHECKBOX_ID;
-      checkbox.type = "checkbox";
-      checkbox.checked = initialValue;
-      checkbox.addEventListener("change", () => {
-        toggleDarkMode((localStorage[STORAGE_KEY] = checkbox.checked));
-      });
-      const label = dom.create("label");
-      label.setAttribute("for", CHECKBOX_ID);
-      label.className = "dark-theme-label";
-      const slider = dom.create("span");
-      slider.className = "slider";
-      label.appendChild(slider);
-      body.prepend(label);
-      body.prepend(checkbox);
-    });
+    const TOGGLE_ID = `${vm.config.name}-docsify-dark-theme-toggle`,
+      dom = Docsify.dom,
+      darkThemeStyleSheet = dom.find('link[href$="dark.css"]'),
+      toggleDarkTheme = () => {
+        const isDark = localStorage[TOGGLE_ID] = checkbox.checked;
+        darkThemeStyleSheet.disabled = !isDark;
+        dom.toggleClass(dom.body, isDark ? "add" : "remove", "dark");
+      };
+    localStorage[TOGGLE_ID] ??= matchMedia("(prefers-color-scheme: dark)").matches;
+    const toggle = dom.create("label", `<input type="checkbox" ${(localStorage[TOGGLE_ID] === "true") ? 'checked' : ''} /><span />`),
+      checkbox = dom.find(toggle, "input");
+    toggle.id = TOGGLE_ID;
+    dom.on(checkbox, "change", toggleDarkTheme);
+    hook.init(toggleDarkTheme);
+    hook.doneEach(() => dom.before(dom.find('section.cover.show') || dom.find('.sidebar > .app-name'), toggle));
+    dom.style(
+`#${TOGGLE_ID} > input {
+  display: none;
+}
+#${TOGGLE_ID} {
+  position: absolute;
+  display: inline-block;
+  width: 52px;
+  height: 28px;
+  margin-left: 2rem;
+  margin-top: 1.5rem;
+  left: 0;
+  top: 0;
+  z-index: 0;
+  cursor: pointer;
+}
+.sidebar > .app-name {
+  position: relative;
+}
+.app-name > #${TOGGLE_ID} {
+  margin-right: 1rem;
+  margin-top: 0;
+  right: 0;
+  left: unset;
+}
+#${TOGGLE_ID}::before, #${TOGGLE_ID}::after {
+  position: absolute;
+  top: 0.1em;
+  font-size: 16px;
+  transition: opacity 0.3s;
+}
+#${TOGGLE_ID}::before {
+  content: "🌙";
+  left: 0.1em;
+  opacity: 0;
+  z-index: 1;
+}
+#${TOGGLE_ID}::after {
+  content: "🌞";
+  right: 0.1em;
+  opacity: 1;
+}
+#${TOGGLE_ID} > span {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--theme-color, #42b983);
+  border-radius: 28px;
+  transition: background-color 0.3s;
+}
+#${TOGGLE_ID} > span::before {
+  content: "";
+  position: absolute;
+  height: 22px;
+  width: 22px;
+  left: 3px;
+  top: 3px;
+  z-index: 1;
+  background-color: white;
+  border-radius: 50%;
+  transition: transform 0.3s;
+}
+.dark #${TOGGLE_ID}::after {
+  opacity: 0;
+}
+.dark #${TOGGLE_ID}::before {
+  opacity: 1;
+}
+.dark #${TOGGLE_ID} > span {
+  background-color: var(--theme-color, #ea6f5a);
+}
+.dark #${TOGGLE_ID} > span::before {
+  transform: translateX(24px);
+}
+.dark .sidebar li {
+  margin-right: 0;
+}
+.dark section.cover.show {
+  background-color: rgb(79 58 120) !important;
+}`);
   };
 
   $docsify = $docsify || {};

--- a/site/plugins/dark-theme-toggle.js
+++ b/site/plugins/dark-theme-toggle.js
@@ -1,98 +1,21 @@
-(function () {
-  const darkThemeTogglePlugin = function (hook, vm) {
-    const TOGGLE_ID = `${vm.config.name}-docsify-dark-theme-toggle`,
+(() => {
+  const darkThemeTogglePlugin = (hook, vm) => {
+    const TOGGLE_ID = "docsify-dark-theme-toggle",
       dom = Docsify.dom,
       darkThemeStyleSheet = dom.find('link[href$="dark.css"]'),
       toggleEl = dom.create("div", "<span />"),
       applyTheme = (swap = false) => {
-        const isDark = (localStorage[TOGGLE_ID] = Boolean(
-          swap ^ (localStorage[TOGGLE_ID] == "true")
-        ));
+        const isDark = Boolean(swap ^ (localStorage[TOGGLE_ID] == "true"));
+        localStorage[TOGGLE_ID] = isDark;
         darkThemeStyleSheet.disabled = !isDark;
         dom.toggleClass(dom.body, isDark ? "add" : "remove", "dark");
-      },
-      toggleStyle = `#${TOGGLE_ID} {
-  position: absolute;
-  display: inline-block;
-  width: 52px;
-  height: 28px;
-  margin-left: 2rem;
-  margin-top: 1.5rem;
-  left: 0;
-  top: 0;
-  z-index: 0;
-  cursor: pointer;
-}
-.sidebar > .app-name {
-  position: relative;
-}
-.app-name > #${TOGGLE_ID} {
-  margin-right: 1rem;
-  margin-top: 0;
-  right: 0;
-  left: unset;
-}
-#${TOGGLE_ID}::before, #${TOGGLE_ID}::after {
-  position: absolute;
-  top: 0.1em;
-  font-size: 16px;
-  transition: opacity 0.3s;
-}
-#${TOGGLE_ID}::before {
-  content: "🌙";
-  left: 0.1em;
-  opacity: 0;
-  z-index: 1;
-}
-#${TOGGLE_ID}::after {
-  content: "🌞";
-  right: 0.1em;
-  opacity: 1;
-}
-#${TOGGLE_ID} > span {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: var(--theme-color, #42b983);
-  border-radius: 28px;
-  transition: background-color 0.3s;
-}
-#${TOGGLE_ID} > span::before {
-  content: "";
-  position: absolute;
-  height: 22px;
-  width: 22px;
-  left: 3px;
-  top: 3px;
-  z-index: 1;
-  background-color: white;
-  border-radius: 50%;
-  transition: transform 0.3s;
-}
-.dark #${TOGGLE_ID}::after {
-  opacity: 0;
-}
-.dark #${TOGGLE_ID}::before {
-  opacity: 1;
-}
-.dark #${TOGGLE_ID} > span {
-  background-color: var(--theme-color, #ea6f5a);
-}
-.dark #${TOGGLE_ID} > span::before {
-  transform: translateX(24px);
-}`;
+      };
     localStorage[TOGGLE_ID] ??= matchMedia("(prefers-color-scheme: dark)").matches;
     toggleEl.id = TOGGLE_ID;
-    dom.on(toggleEl, "click", applyTheme.bind(this, true));
+    dom.on(toggleEl, "click", () => applyTheme(true));
     hook.init(applyTheme);
-    hook.doneEach(() => {
-      const targetEl = dom.find(".cover.show") || dom.find(".sidebar > .app-name");
-      dom.before(targetEl, toggleEl);
-    });
-    dom.style(toggleStyle);
+    hook.doneEach(() => dom.before(dom.find(".cover.show, .sidebar > .app-name"), toggleEl));
   };
-  $docsify = $docsify || {};
-  $docsify.plugins = [].concat($docsify.plugins || [], darkThemeTogglePlugin);
+  $docsify ??= {};
+  $docsify.plugins = [...($docsify.plugins ?? []), darkThemeTogglePlugin];
 })();

--- a/site/plugins/dark-theme-toggle.js
+++ b/site/plugins/dark-theme-toggle.js
@@ -1,0 +1,102 @@
+(function () {
+  const darkThemeTogglePlugin = function (hook, vm) {
+    const CHECKBOX_ID = "dark-theme-input";
+    const STORAGE_KEY = "docsify-toggle-dark-theme";
+    localStorage[STORAGE_KEY] ??= matchMedia("(prefers-color-scheme: dark)").matches;
+    const initialValue = localStorage[STORAGE_KEY] === "true";
+    const dom = Docsify.dom;
+    const darkThemeStyleSheet = dom.find('link[href$="dark.css"]');
+    const toggleDarkMode = (isDark) => (darkThemeStyleSheet.disabled = !isDark);
+    const pluginStyleEl = document.createElement("style");
+    pluginStyleEl.textContent = `#${CHECKBOX_ID} {
+			display: none;
+		}
+		.dark-theme-label {
+			position: absolute;
+			display: inline-block;
+			width: 52px;
+			height: 28px;
+			margin-left: 2rem;
+			margin-top: 2rem;
+			z-index: 1;
+			cursor: pointer;
+		}
+		.dark-theme-label::before, .dark-theme-label::after {
+			position: absolute;
+			font-size: 16px;
+			z-index: 1;
+			transition: opacity 0.3s;
+		}
+		.dark-theme-label::after {
+			content: "🌞";
+			right: 0.1em;
+			top: 0.1em;
+			opacity: 1;
+		}
+		.dark-theme-label::before {
+			content: "🌙";
+			top: 0.1em;
+			left: 0.1em;
+			opacity: 0;
+		}
+		.slider {
+			position: absolute;
+			top: 0;
+			left: 0;
+			right: 0;
+			bottom: 0;
+			background-color: var(--theme-color, #42b983);
+			border-radius: 28px;
+			transition: background-color 0.3s;
+		}
+		.slider::before {
+			content: "";
+			position: absolute;
+			height: 22px;
+			width: 22px;
+			left: 3px;
+			top: 3px;
+			background-color: white;
+			border-radius: 50%;
+			transition: transform 0.3s;
+		}
+		#${CHECKBOX_ID}:checked + .dark-theme-label::after {
+			opacity: 0;
+		}
+		#${CHECKBOX_ID}:checked + .dark-theme-label::before {
+			opacity: 1;
+		}
+		#${CHECKBOX_ID}:checked + .dark-theme-label .slider {
+			background-color: var(--theme-color, #ea6f5a);
+		}
+		#${CHECKBOX_ID}:checked + .dark-theme-label .slider::before {
+			transform: translateX(24px);
+		}
+		#${CHECKBOX_ID}:checked ~ section.cover.show {
+			background-color: rgb(79 58 120) !important;
+		}`;
+    document.head.appendChild(pluginStyleEl);
+    hook.init(() => toggleDarkMode(initialValue));
+    hook.ready(() => {
+      const body = dom.body;
+      const checkbox = dom.create("input");
+      checkbox.id = CHECKBOX_ID;
+      checkbox.type = "checkbox";
+      checkbox.checked = initialValue;
+      checkbox.addEventListener("change", () => {
+        toggleDarkMode((localStorage[STORAGE_KEY] = checkbox.checked));
+      });
+      const label = dom.create("label");
+      label.setAttribute("for", CHECKBOX_ID);
+      label.className = "dark-theme-label";
+      const slider = dom.create("span");
+      slider.className = "slider";
+      label.appendChild(slider);
+      body.prepend(label);
+      body.prepend(checkbox);
+    });
+  };
+
+  $docsify = $docsify || {};
+  $docsify.plugins = [].concat($docsify.plugins || [], darkThemeTogglePlugin);
+})();

--- a/site/plugins/dark-theme-toggle.js
+++ b/site/plugins/dark-theme-toggle.js
@@ -7,7 +7,7 @@
     const dom = Docsify.dom;
     const darkThemeStyleSheet = dom.find('link[href$="dark.css"]');
     const toggleDarkMode = (isDark) => (darkThemeStyleSheet.disabled = !isDark);
-    const pluginStyleEl = document.createElement("style");
+    const pluginStyleEl = dom.create("style");
     pluginStyleEl.textContent = `#${CHECKBOX_ID} {
 			display: none;
 		}
@@ -78,7 +78,7 @@
 		section.cover.show {
 			z-index: -1;
 		}`;
-    document.head.appendChild(pluginStyleEl);
+    dom.head.appendChild(pluginStyleEl);
     hook.init(() => toggleDarkMode(initialValue));
     hook.ready(() => {
       const body = dom.body;

--- a/site/plugins/dark-theme-toggle.js
+++ b/site/plugins/dark-theme-toggle.js
@@ -6,7 +6,7 @@
       toggleEl = dom.create("div", "<span />"),
       isDarkThemeEnabled = () => localStorage[TOGGLE_ID] === "true",
       applyTheme = (swap = false) => {
-      const isDark = localStorage[TOGGLE_ID] = swap ? !isDarkThemeEnabled() : isDarkThemeEnabled();
+        const isDark = localStorage[TOGGLE_ID] = swap ? !isDarkThemeEnabled() : isDarkThemeEnabled();
         darkThemeStyleSheet.disabled = !isDark;
         dom.toggleClass(dom.body, isDark ? "add" : "remove", "dark");
       },

--- a/site/plugins/dark-theme-toggle.js
+++ b/site/plugins/dark-theme-toggle.js
@@ -3,23 +3,20 @@
     const TOGGLE_ID = `${vm.config.name}-docsify-dark-theme-toggle`,
       dom = Docsify.dom,
       darkThemeStyleSheet = dom.find('link[href$="dark.css"]'),
-      toggleDarkTheme = () => {
-        const isDark = localStorage[TOGGLE_ID] = checkbox.checked;
+      toggleEl = dom.create("div", "<span />"),
+      isDarkThemeEnabled = () => localStorage[TOGGLE_ID] === "true",
+      applyTheme = (swap = false) => {
+      const isDark = localStorage[TOGGLE_ID] = swap ? !isDarkThemeEnabled() : isDarkThemeEnabled();
         darkThemeStyleSheet.disabled = !isDark;
         dom.toggleClass(dom.body, isDark ? "add" : "remove", "dark");
-      };
+      },
+      findTargetEl = () => dom.find(".cover.show") || dom.find(".sidebar > .app-name");
     localStorage[TOGGLE_ID] ??= matchMedia("(prefers-color-scheme: dark)").matches;
-    const toggle = dom.create("label", `<input type="checkbox" ${(localStorage[TOGGLE_ID] === "true") ? 'checked' : ''} /><span />`),
-      checkbox = dom.find(toggle, "input");
-    toggle.id = TOGGLE_ID;
-    dom.on(checkbox, "change", toggleDarkTheme);
-    hook.init(toggleDarkTheme);
-    hook.doneEach(() => dom.before(dom.find('section.cover.show') || dom.find('.sidebar > .app-name'), toggle));
-    dom.style(
-`#${TOGGLE_ID} > input {
-  display: none;
-}
-#${TOGGLE_ID} {
+    toggleEl.id = TOGGLE_ID;
+    dom.on(toggleEl, "click", applyTheme.bind(this, true));
+    hook.init(applyTheme);
+    hook.doneEach(() => dom.before(findTargetEl(), toggleEl));
+    dom.style(`#${TOGGLE_ID} {
   position: absolute;
   display: inline-block;
   width: 52px;
@@ -94,11 +91,9 @@
 .dark .sidebar li {
   margin-right: 0;
 }
-.dark section.cover.show {
+.dark .cover.show {
   background-color: rgb(79 58 120) !important;
-}`);
-  };
-
+}`);};
   $docsify = $docsify || {};
   $docsify.plugins = [].concat($docsify.plugins || [], darkThemeTogglePlugin);
 })();

--- a/site/plugins/dark-theme-toggle.js
+++ b/site/plugins/dark-theme-toggle.js
@@ -18,26 +18,25 @@
 			height: 28px;
 			margin-left: 2rem;
 			margin-top: 2rem;
-			z-index: 1;
+			z-index: 0;
 			cursor: pointer;
 		}
 		.dark-theme-label::before, .dark-theme-label::after {
 			position: absolute;
+			top: 0.1em;
 			font-size: 16px;
-			z-index: 1;
 			transition: opacity 0.3s;
 		}
 		.dark-theme-label::after {
 			content: "🌞";
 			right: 0.1em;
-			top: 0.1em;
 			opacity: 1;
 		}
 		.dark-theme-label::before {
 			content: "🌙";
-			top: 0.1em;
 			left: 0.1em;
 			opacity: 0;
+			z-index: 1;
 		}
 		.slider {
 			position: absolute;
@@ -56,7 +55,7 @@
 			width: 22px;
 			left: 3px;
 			top: 3px;
-      z-index: 2;
+			z-index: 1;
 			background-color: white;
 			border-radius: 50%;
 			transition: transform 0.3s;
@@ -75,6 +74,9 @@
 		}
 		#${CHECKBOX_ID}:checked ~ section.cover.show {
 			background-color: rgb(79 58 120) !important;
+		}
+		section.cover.show {
+			z-index: -1;
 		}`;
     document.head.appendChild(pluginStyleEl);
     hook.init(() => toggleDarkMode(initialValue));


### PR DESCRIPTION
I've implemented a small, standalone docsify plugin that toggles the official docsify dark theme.

The plugin persists theme selection in localStorage, and uses matchMedia("(prefers-color-scheme: dark)") to respect system default dark mode preference. 