### PR TITLE
IANAZone returns the canonical IANA zone name; Test included in IANA.test.js

### DIFF
--- a/src/zones/IANAZone.js
+++ b/src/zones/IANAZone.js
@@ -116,9 +116,19 @@ export default class IANAZone extends Zone {
   constructor(name) {
     super();
     /** @private **/
-    this.zoneName = name;
-    /** @private **/
     this.valid = IANAZone.isValidZone(name);
+    /** @private **/
+    if (this.valid) {
+      // Get canonical zone name from Intl.DateTimeFormat
+      try {
+        const dtf = new Intl.DateTimeFormat("en-US", { timeZone: name });
+        this.zoneName = dtf.resolvedOptions().timeZone;
+      } catch (e) {
+        this.zoneName = name;
+      }
+    } else {
+      this.zoneName = name;
+    }
   }
 
   /**

--- a/src/zones/IANAZone.js
+++ b/src/zones/IANAZone.js
@@ -102,33 +102,41 @@ export default class IANAZone extends Zone {
    * @return {boolean}
    */
   static isValidZone(zone) {
+    return IANAZone.normalizeZone(zone) != null;
+  }
+
+  /**
+   * Normalize the name of the provided IANA zone or return null
+   * if it is not a valid IANA zone.
+   * @param {string} zone - The string to normalize
+   * @example IANAZone.normalizeZone("America/New_York") //=> "America/New_York"
+   * @example IANAZone.normalizeZone("america/NEw_York") //=> "America/New_York"
+   * @example IANAZone.normalizeZone("EST5EDT") //=> "America/New_York"
+   * @example IANAZone.isValidZone("Fantasia/Castle") //=> null
+   * @example IANAZone.isValidZone("Sport~~blorp") //=> null
+   * @return {string|null}
+   */
+  static normalizeZone(zone) {
     if (!zone) {
-      return false;
+      return null;
     }
     try {
-      new Intl.DateTimeFormat("en-US", { timeZone: zone }).format();
-      return true;
+      return new Intl.DateTimeFormat("en-US", { timeZone: zone }).resolvedOptions().timeZone;
     } catch (e) {
-      return false;
+      return null;
     }
   }
 
   constructor(name) {
     super();
+    const normalizedName = IANAZone.normalizeZone(name);
     /** @private **/
-    this.valid = IANAZone.isValidZone(name);
+    this.valid = normalizedName != null;
+    // For backwards compatibility we only normalize in casing, otherwise would also normalize something like
+    // EST5EDT to America/New_York.
     /** @private **/
-    if (this.valid) {
-      // Get canonical zone name from Intl.DateTimeFormat
-      try {
-        const dtf = new Intl.DateTimeFormat("en-US", { timeZone: name });
-        this.zoneName = dtf.resolvedOptions().timeZone;
-      } catch (e) {
-        this.zoneName = name;
-      }
-    } else {
-      this.zoneName = name;
-    }
+    this.zoneName =
+      normalizedName && normalizedName.toLowerCase() === name.toLowerCase() ? normalizedName : name;
   }
 
   /**

--- a/test/zones/IANA.test.js
+++ b/test/zones/IANA.test.js
@@ -112,3 +112,12 @@ test("IANAZone.isValid returns false for invalid zone names", () => {
   expect(new IANAZone("America/Blorp").isValid).toBe(false);
   expect(new IANAZone(null).isValid).toBe(false);
 });
+
+test("IANAZone returns canonical zone name regardless of input casing", () => {
+  expect(new IANAZone("america/nEw_york").name).toBe("America/New_York");
+  expect(new IANAZone("AMERICA/NEW_YORK").name).toBe("America/New_York");
+  expect(new IANAZone("America/New_York").name).toBe("America/New_York");
+  expect(new IANAZone("europe/paris").name).toBe("Europe/Paris");
+  expect(new IANAZone("EUROPE/PARIS").name).toBe("Europe/Paris");
+  expect(new IANAZone("Asia/Tokyo").name).toBe("Asia/Tokyo");
+});

--- a/test/zones/IANA.test.js
+++ b/test/zones/IANA.test.js
@@ -113,6 +113,16 @@ test("IANAZone.isValid returns false for invalid zone names", () => {
   expect(new IANAZone(null).isValid).toBe(false);
 });
 
+test("IANAZone.normalize normalizes the zone name", () => {
+  expect(IANAZone.normalizeZone("america/nEw_york")).toBe("America/New_York");
+  expect(IANAZone.normalizeZone("AMERICA/NEW_YORK")).toBe("America/New_York");
+  expect(IANAZone.normalizeZone("America/New_York")).toBe("America/New_York");
+  expect(IANAZone.normalizeZone("EST5EDT")).toBe("America/New_York");
+  expect(IANAZone.normalizeZone("europe/paris")).toBe("Europe/Paris");
+  expect(IANAZone.normalizeZone("EUROPE/PARIS")).toBe("Europe/Paris");
+  expect(IANAZone.normalizeZone("Asia/Tokyo")).toBe("Asia/Tokyo");
+});
+
 test("IANAZone returns canonical zone name regardless of input casing", () => {
   expect(new IANAZone("america/nEw_york").name).toBe("America/New_York");
   expect(new IANAZone("AMERICA/NEW_YORK").name).toBe("America/New_York");


### PR DESCRIPTION
Addressing #1717 

Adds following implementation to get canonical IANA timezone name, instead of just using user provided casing.

```js
const dtf = new Intl.DateTimeFormat("en-US", { timeZone: name });
this.zoneName = dtf.resolvedOptions().timeZone;
```

Added a test "`IANAZone returns canonical zone name regardless of input casing`" which passes the implementation.