### PR TITLE
feat: add weekSettings support to DateTime.reconfigure()

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1581,13 +1581,21 @@ export default class DateTime {
   }
 
   /**
-   * "Set" the locale, numberingSystem, or outputCalendar. Returns a newly-constructed DateTime.
+   * "Set" the locale, numberingSystem, outputCalendar, or weekSettings. Returns a newly-constructed DateTime.
    * @param {Object} properties - the properties to set
+   * @param {string} [properties.locale] - the locale to set
+   * @param {string} [properties.numberingSystem] - the numbering system to set
+   * @param {string} [properties.outputCalendar] - the output calendar to set
+   * @param {Object} [properties.weekSettings] - the week settings to set
+   * @param {number} [properties.weekSettings.firstDay] - the first day of the week (1-7, Monday-Sunday)
+   * @param {number} [properties.weekSettings.minimalDays] - the minimum number of days in the first week
+   * @param {number[]} [properties.weekSettings.weekend] - the weekend days
    * @example DateTime.local(2017, 5, 25).reconfigure({ locale: 'en-GB' })
+   * @example DateTime.local(2017, 5, 25).reconfigure({ weekSettings: { firstDay: 1 } })
    * @return {DateTime}
    */
-  reconfigure({ locale, numberingSystem, outputCalendar } = {}) {
-    const loc = this.loc.clone({ locale, numberingSystem, outputCalendar });
+  reconfigure({ locale, numberingSystem, outputCalendar, weekSettings } = {}) {
+    const loc = this.loc.clone({ locale, numberingSystem, outputCalendar, weekSettings });
     return clone(this, { loc });
   }
 

--- a/test/datetime/reconfigure.test.js
+++ b/test/datetime/reconfigure.test.js
@@ -41,3 +41,21 @@ test("DateTime#reconfigure() with no arguments no opts", () => {
   expect(recon.numberingSystem).toBe("beng");
   expect(recon.outputCalendar).toBe("coptic");
 });
+
+test("DateTime#reconfigure() sets the weekSettings", () => {
+  const original = DateTime.local(2022, 1, 4, { locale: "en-US" });
+  const recon = original.reconfigure({
+    weekSettings: { firstDay: 6, minimalDays: 1, weekend: [1, 2] },
+  });
+  expect(recon.startOf("week", { useLocaleWeeks: true }).weekday).toBe(6);
+});
+
+test("DateTime#reconfigure() preserves weekSettings when setting other options", () => {
+  const original = DateTime.local(2022, 1, 4, {
+    locale: "en-US",
+    weekSettings: { firstDay: 3, minimalDays: 1, weekend: [] },
+  });
+  const recon = original.reconfigure({ locale: "de-DE" });
+  expect(recon.locale).toBe("de-DE");
+  expect(recon.startOf("week", { useLocaleWeeks: true }).weekday).toBe(3);
+});


### PR DESCRIPTION
## Summary

Adds `weekSettings` support to `DateTime.reconfigure()`, allowing users to change week settings on an existing DateTime instance.

## Problem

As reported in #1746, `DateTime.reconfigure()` did not accept `weekSettings` even though:
1. The underlying `Locale.clone()` method already supports it
2. The TypeScript types suggest it should be supported
3. Other DateTime factory methods accept `weekSettings`

This made it impossible to change week settings on an existing DateTime without recreating it entirely.

## Solution

Added `weekSettings` to the destructured parameters of `reconfigure()` and pass it through to `Locale.clone()`.

## Example

```javascript
// Set custom week settings on an existing DateTime
const dt = DateTime.local(2022, 1, 4, { locale: "en-US" });
const reconfigured = dt.reconfigure({ 
  weekSettings: { firstDay: 6, minimalDays: 1, weekend: [1, 2] } 
});
reconfigured.startOf("week", { useLocaleWeeks: true }).weekday; // => 6
```

## Tests

Added tests to verify:
1. `reconfigure()` correctly sets weekSettings
2. `reconfigure()` preserves existing weekSettings when setting other options

Fixes #1746