### PR TITLE
Render dark mode toggle in sidebar on all pages

### DIFF
--- a/site/plugins/dark-theme-toggle.js
+++ b/site/plugins/dark-theme-toggle.js
@@ -15,8 +15,6 @@
     dom.on(toggleEl, "click", () => applyTheme(true));
     hook.init(applyTheme);
 
-    //hook.doneEach(() => dom.before(dom.find(".sidebar > .app-name"), toggleEl));
-
     hook.doneEach(() => {
       const cover = dom.find(".cover.show");
       const sidebarTarget = dom.find(".sidebar > .app-name");


### PR DESCRIPTION
Closes #1760 

This PR ensures the dark mode toggle is consistently rendered in the sidebar across all pages, including the landing page.

Previously, the toggle was attached to the cover section on the landing page, causing it to disappear when scrolling.

This change standardizes its placement to the sidebar for improved usability and continuity.