### PR TITLE
fix: support X and x tokens for unix epoch parsing

### DIFF
--- a/docs/parsing.md
+++ b/docs/parsing.md
@@ -239,4 +239,6 @@ Because Luxon was able to parse the string without difficulty, the output is a l
 | ff               |              | less short localized date and time                                | `Aug 6, 2014, 1:07 PM`      |
 | F                |              | short localized date and time with seconds                        | `8/6/2014, 1:07:04 PM`      |
 | FF               |              | less short localized date and time with seconds                   | `Aug 6, 2014, 1:07:04 PM`   |
+| X                |              | unix timestamp in seconds                                         | `1407344824`                |
+| x                |              | unix timestamp in milliseconds                                    | `1407344824054`             |
 | '                |              | literal start/end, characters between are not tokenized           | `'T'`                       |

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1001,9 +1001,15 @@ export default class DateTime {
         numberingSystem,
         defaultToEN: true,
       }),
-      [vals, parsedZone, specificOffset, invalid] = parseFromTokens(localeToUse, text, fmt);
+      [vals, parsedZone, specificOffset, invalid, knownEpochMs] = parseFromTokens(
+        localeToUse,
+        text,
+        fmt
+      );
     if (invalid) {
       return DateTime.invalid(invalid);
+    } else if (knownEpochMs !== undefined) {
+      return DateTime.fromMillis(knownEpochMs, opts);
     } else {
       return parseDataToDateTime(vals, parsedZone, opts, `format ${fmt}`, text, specificOffset);
     }
@@ -2429,10 +2435,13 @@ export default class DateTime {
       );
     }
 
-    const { result, zone, specificOffset, invalidReason } = formatParser.explainFromTokens(text);
+    const { result, zone, specificOffset, invalidReason, knownEpochMs } =
+      formatParser.explainFromTokens(text);
 
     if (invalidReason) {
       return DateTime.invalid(invalidReason);
+    } else if (knownEpochMs !== undefined) {
+      return DateTime.fromMillis(knownEpochMs, opts);
     } else {
       return parseDataToDateTime(
         result,

--- a/src/impl/tokenParser.js
+++ b/src/impl/tokenParser.js
@@ -5,6 +5,7 @@ import IANAZone from "../zones/IANAZone.js";
 import DateTime from "../datetime.js";
 import { digitRegex, parseDigits } from "./digits.js";
 import { ConflictingSpecificationError } from "../errors.js";
+import Invalid from "./invalid.js";
 
 const MISSING_FTP = "missing Intl.DateTimeFormat.formatToParts support";
 
@@ -470,6 +471,20 @@ export class TokenParser {
           "Can't include meridiem when specifying 24-hour format"
         );
       }
+      if (hasOwnProperty(matches, "X") && hasOwnProperty(matches, "x")) {
+        if (matches.X * 1000 !== matches.x) {
+          return {
+            input,
+            tokens: this.tokens,
+            invalidReason: new Invalid(
+              "mismatched unix timestamp",
+              `X=${matches.X} (${matches.X * 1000}ms) and x=${
+                matches.x
+              } specify different points in time`
+            ),
+          };
+        }
+      }
       if (knownEpochMs !== undefined && result && Object.keys(result).length > 0) {
         // X is unix seconds with no sub-second precision; S/SSS/u add the missing ms part
         if (hasOwnProperty(matches, "X") && result.millisecond !== undefined) {
@@ -481,9 +496,14 @@ export class TokenParser {
           const epochDateTime = DateTime.fromMillis(knownEpochMs, { zone: zone ?? "UTC" });
           for (const [key, value] of Object.entries(result)) {
             if (epochDateTime[key] !== value) {
-              throw new ConflictingSpecificationError(
-                `Can't specify ${key} as ${value} when the unix timestamp implies ${epochDateTime[key]}`
-              );
+              return {
+                input,
+                tokens: this.tokens,
+                invalidReason: new Invalid(
+                  `mismatched ${key}`,
+                  `you can't specify ${key}=${value} when the unix timestamp implies ${key}=${epochDateTime[key]}`
+                ),
+              };
             }
           }
         }

--- a/src/impl/tokenParser.js
+++ b/src/impl/tokenParser.js
@@ -470,15 +470,9 @@ export class TokenParser {
         );
       }
       if (knownEpochMs !== undefined && result && Object.keys(result).length > 0) {
-        const definedZone = zone ?? "UTC";
-        const epochDateTime = DateTime.fromMillis(knownEpochMs, { zone: definedZone });
-        for (const [key, value] of Object.entries(result)) {
-          if (epochDateTime[key] !== value) {
-            throw new ConflictingSpecificationError(
-              `Can't specify ${key} as ${value} when the unix timestamp implies ${epochDateTime[key]}`
-            );
-          }
-        }
+        throw new ConflictingSpecificationError(
+          "Can't use other format tokens alongside a unix timestamp"
+        );
       }
       return {
         input,

--- a/src/impl/tokenParser.js
+++ b/src/impl/tokenParser.js
@@ -469,6 +469,17 @@ export class TokenParser {
           "Can't include meridiem when specifying 24-hour format"
         );
       }
+      if (knownEpochMs !== undefined && result && Object.keys(result).length > 0) {
+        const definedZone = zone ?? "UTC";
+        const epochDateTime = DateTime.fromMillis(knownEpochMs, { zone: definedZone });
+        for (const [key, value] of Object.entries(result)) {
+          if (epochDateTime[key] !== value) {
+            throw new ConflictingSpecificationError(
+              `Can't specify ${key} as ${value} when the unix timestamp implies ${epochDateTime[key]}`
+            );
+          }
+        }
+      }
       return {
         input,
         tokens: this.tokens,

--- a/src/impl/tokenParser.js
+++ b/src/impl/tokenParser.js
@@ -461,18 +461,32 @@ export class TokenParser {
       return { input, tokens: this.tokens, invalidReason: this.invalidReason };
     } else {
       const [rawMatches, matches] = match(input, this.regex, this.handlers),
-        [result, zone, specificOffset, knownEpochMs] = matches
+        [result, zone, specificOffset, knownEpochMsRaw] = matches
           ? dateTimeFromMatches(matches)
           : [null, null, undefined, undefined];
+      let knownEpochMs = knownEpochMsRaw;
       if (hasOwnProperty(matches, "a") && hasOwnProperty(matches, "H")) {
         throw new ConflictingSpecificationError(
           "Can't include meridiem when specifying 24-hour format"
         );
       }
       if (knownEpochMs !== undefined && result && Object.keys(result).length > 0) {
-        throw new ConflictingSpecificationError(
-          "Can't use other format tokens alongside a unix timestamp"
-        );
+        // X is unix seconds with no sub-second precision; S/SSS/u add the missing ms part
+        if (hasOwnProperty(matches, "X") && result.millisecond !== undefined) {
+          knownEpochMs = knownEpochMs + result.millisecond;
+          delete result.millisecond;
+        }
+        // All remaining tokens are redundant — validate they are consistent with the epoch
+        if (Object.keys(result).length > 0) {
+          const epochDateTime = DateTime.fromMillis(knownEpochMs, { zone: zone ?? "UTC" });
+          for (const [key, value] of Object.entries(result)) {
+            if (epochDateTime[key] !== value) {
+              throw new ConflictingSpecificationError(
+                `Can't specify ${key} as ${value} when the unix timestamp implies ${epochDateTime[key]}`
+              );
+            }
+          }
+        }
       }
       return {
         input,

--- a/src/impl/tokenParser.js
+++ b/src/impl/tokenParser.js
@@ -181,6 +181,11 @@ function unitForToken(token, loc) {
         // because we don't have any way to figure out what they are
         case "z":
           return simple(/[a-z_+-/]{1,256}?/i);
+        // unix timestamps
+        case "X":
+          return intUnit(/[+-]?\d+/);
+        case "x":
+          return intUnit(/[+-]?\d+/);
         // this special-case "token" represents a place where a macro-token expanded into a white-space literal
         // in this case we accept any non-newline white-space
         case " ":
@@ -393,7 +398,14 @@ function dateTimeFromMatches(matches) {
     return r;
   }, {});
 
-  return [vals, zone, specificOffset];
+  let knownEpochMs;
+  if (!isUndefined(matches.X)) {
+    knownEpochMs = matches.X * 1000;
+  } else if (!isUndefined(matches.x)) {
+    knownEpochMs = matches.x;
+  }
+
+  return [vals, zone, specificOffset, knownEpochMs];
 }
 
 let dummyDateTimeCache = null;
@@ -449,9 +461,9 @@ export class TokenParser {
       return { input, tokens: this.tokens, invalidReason: this.invalidReason };
     } else {
       const [rawMatches, matches] = match(input, this.regex, this.handlers),
-        [result, zone, specificOffset] = matches
+        [result, zone, specificOffset, knownEpochMs] = matches
           ? dateTimeFromMatches(matches)
-          : [null, null, undefined];
+          : [null, null, undefined, undefined];
       if (hasOwnProperty(matches, "a") && hasOwnProperty(matches, "H")) {
         throw new ConflictingSpecificationError(
           "Can't include meridiem when specifying 24-hour format"
@@ -466,6 +478,7 @@ export class TokenParser {
         result,
         zone,
         specificOffset,
+        knownEpochMs,
       };
     }
   }
@@ -485,8 +498,12 @@ export function explainFromTokens(locale, input, format) {
 }
 
 export function parseFromTokens(locale, input, format) {
-  const { result, zone, specificOffset, invalidReason } = explainFromTokens(locale, input, format);
-  return [result, zone, specificOffset, invalidReason];
+  const { result, zone, specificOffset, invalidReason, knownEpochMs } = explainFromTokens(
+    locale,
+    input,
+    format
+  );
+  return [result, zone, specificOffset, invalidReason, knownEpochMs];
 }
 
 export function formatOptsToTokens(formatOpts, locale) {

--- a/test/datetime/tokenParse.test.js
+++ b/test/datetime/tokenParse.test.js
@@ -1338,43 +1338,26 @@ test("fromFormat with x rejects empty string", () => {
   expect(dt.isValid).toBe(false);
 });
 
-// ConflictingSpecificationError when X/x clashes with other tokens
+// ConflictingSpecificationError when X/x is mixed with other tokens
 
-test("fromFormat throws ConflictingSpecificationError when X year is inconsistent", () => {
-  // epoch 1769758221 = 2026-01-30T07:30:21Z, year=2025 is wrong
-  expect(() => DateTime.fromFormat("2025 1769758221", "yyyy X")).toThrow(
+test("fromFormat throws ConflictingSpecificationError when X is mixed with year", () => {
+  expect(() => DateTime.fromFormat("2026 1769758221", "yyyy X")).toThrow(
     ConflictingSpecificationError
   );
 });
 
-test("fromFormat throws ConflictingSpecificationError when X month is inconsistent", () => {
-  // epoch 1769758221 = 2026-01-30T07:30:21Z, month=2 is wrong
-  expect(() => DateTime.fromFormat("02 1769758221", "MM X")).toThrow(ConflictingSpecificationError);
+test("fromFormat throws ConflictingSpecificationError when X is mixed with month", () => {
+  expect(() => DateTime.fromFormat("01 1769758221", "MM X")).toThrow(ConflictingSpecificationError);
 });
 
-test("fromFormat throws ConflictingSpecificationError when X hour is inconsistent", () => {
-  // epoch 1769758221 = 2026-01-30T07:30:21Z, hour=08 is wrong
-  expect(() => DateTime.fromFormat("08 1769758221", "HH X")).toThrow(ConflictingSpecificationError);
-});
-
-test("fromFormat throws ConflictingSpecificationError when x year is inconsistent", () => {
-  expect(() => DateTime.fromFormat("2025 1769758221000", "yyyy x")).toThrow(
-    ConflictingSpecificationError
-  );
-});
-
-test("fromFormat does not throw when X and other tokens are consistent (UTC)", () => {
-  // epoch 1769758221 = 2026-01-30T07:30:21Z
+test("fromFormat throws ConflictingSpecificationError when X is mixed with full datetime", () => {
   expect(() =>
     DateTime.fromFormat("2026-01-30T07:30:21 1769758221", "yyyy-MM-dd'T'HH:mm:ss X")
-  ).not.toThrow();
-  const dt = DateTime.fromFormat("2026-01-30T07:30:21 1769758221", "yyyy-MM-dd'T'HH:mm:ss X");
-  expect(dt.isValid).toBe(true);
-  expect(dt.toUTC().toISO()).toBe("2026-01-30T07:30:21.000Z");
+  ).toThrow(ConflictingSpecificationError);
 });
 
-test("fromFormat does not throw when x and other tokens are consistent (UTC)", () => {
-  expect(() => DateTime.fromFormat("2026 1769758221000", "yyyy x")).not.toThrow();
-  const dt = DateTime.fromFormat("2026 1769758221000", "yyyy x");
-  expect(dt.isValid).toBe(true);
+test("fromFormat throws ConflictingSpecificationError when x is mixed with year", () => {
+  expect(() => DateTime.fromFormat("2026 1769758221000", "yyyy x")).toThrow(
+    ConflictingSpecificationError
+  );
 });

--- a/test/datetime/tokenParse.test.js
+++ b/test/datetime/tokenParse.test.js
@@ -1338,26 +1338,90 @@ test("fromFormat with x rejects empty string", () => {
   expect(dt.isValid).toBe(false);
 });
 
-// ConflictingSpecificationError when X/x is mixed with other tokens
+// Consistent redundant tokens alongside X/x should succeed
 
-test("fromFormat throws ConflictingSpecificationError when X is mixed with year", () => {
-  expect(() => DateTime.fromFormat("2026 1769758221", "yyyy X")).toThrow(
+test("fromFormat accepts consistent year alongside X", () => {
+  // epoch 1769758221 = 2026-01-30T07:30:21Z
+  const dt = DateTime.fromFormat("2026 1769758221", "yyyy X");
+  expect(dt.isValid).toBe(true);
+  expect(dt.toUTC().toISO()).toBe("2026-01-30T07:30:21.000Z");
+});
+
+test("fromFormat accepts consistent month alongside X", () => {
+  // epoch 1769758221 = 2026-01-30, month = 01 (January)
+  const dt = DateTime.fromFormat("01 1769758221", "MM X");
+  expect(dt.isValid).toBe(true);
+  expect(dt.toUTC().month).toBe(1);
+});
+
+test("fromFormat accepts consistent full datetime alongside X", () => {
+  // epoch 1769758221 = 2026-01-30T07:30:21Z
+  const dt = DateTime.fromFormat("2026-01-30T07:30:21 1769758221", "yyyy-MM-dd'T'HH:mm:ss X");
+  expect(dt.isValid).toBe(true);
+  expect(dt.toUTC().toISO()).toBe("2026-01-30T07:30:21.000Z");
+});
+
+test("fromFormat accepts consistent year alongside x", () => {
+  // epoch 1769758221000 = 2026-01-30T07:30:21Z
+  const dt = DateTime.fromFormat("2026 1769758221000", "yyyy x");
+  expect(dt.isValid).toBe(true);
+  expect(dt.toUTC().year).toBe(2026);
+});
+
+// ConflictingSpecificationError when X/x tokens are inconsistent with other tokens
+
+test("fromFormat throws ConflictingSpecificationError when X year is inconsistent", () => {
+  // epoch 1769758221 = 2026-01-30T07:30:21Z, year=2025 is wrong
+  expect(() => DateTime.fromFormat("2025 1769758221", "yyyy X")).toThrow(
     ConflictingSpecificationError
   );
 });
 
-test("fromFormat throws ConflictingSpecificationError when X is mixed with month", () => {
-  expect(() => DateTime.fromFormat("01 1769758221", "MM X")).toThrow(ConflictingSpecificationError);
+test("fromFormat throws ConflictingSpecificationError when X month is inconsistent", () => {
+  // epoch 1769758221 = 2026-01-30T07:30:21Z, month=02 (February) is wrong
+  expect(() => DateTime.fromFormat("02 1769758221", "MM X")).toThrow(ConflictingSpecificationError);
 });
 
-test("fromFormat throws ConflictingSpecificationError when X is mixed with full datetime", () => {
-  expect(() =>
-    DateTime.fromFormat("2026-01-30T07:30:21 1769758221", "yyyy-MM-dd'T'HH:mm:ss X")
-  ).toThrow(ConflictingSpecificationError);
+test("fromFormat throws ConflictingSpecificationError when X hour is inconsistent", () => {
+  // epoch 1769758221 = 2026-01-30T07:30:21Z, hour=08 is wrong
+  expect(() => DateTime.fromFormat("08 1769758221", "HH X")).toThrow(ConflictingSpecificationError);
 });
 
-test("fromFormat throws ConflictingSpecificationError when x is mixed with year", () => {
-  expect(() => DateTime.fromFormat("2026 1769758221000", "yyyy x")).toThrow(
+test("fromFormat throws ConflictingSpecificationError when x year is inconsistent", () => {
+  // epoch 1769758221000 = 2026-01-30T07:30:21Z, year=2025 is wrong
+  expect(() => DateTime.fromFormat("2025 1769758221000", "yyyy x")).toThrow(
+    ConflictingSpecificationError
+  );
+});
+
+// X (unix seconds) + S/SSS/u: milliseconds are additive precision, not redundant
+
+test("fromFormat with X and SSS adds millisecond precision", () => {
+  // X gives second-precision, SSS adds the sub-second part
+  const dt = DateTime.fromFormat("1769758221 500", "X SSS");
+  expect(dt.isValid).toBe(true);
+  expect(dt.toUTC().valueOf()).toBe(1769758221500);
+  expect(dt.toUTC().millisecond).toBe(500);
+});
+
+test("fromFormat with X and S adds millisecond precision", () => {
+  const dt = DateTime.fromFormat("1769758221 5", "X S");
+  expect(dt.isValid).toBe(true);
+  expect(dt.toUTC().valueOf()).toBe(1769758221005);
+});
+
+// x (unix milliseconds) + S: redundant, validate consistency
+
+test("fromFormat accepts consistent SSS alongside x", () => {
+  // epoch 1769758221500 has millisecond = 500
+  const dt = DateTime.fromFormat("1769758221500 500", "x SSS");
+  expect(dt.isValid).toBe(true);
+  expect(dt.toUTC().millisecond).toBe(500);
+});
+
+test("fromFormat throws ConflictingSpecificationError when x millisecond is inconsistent with SSS", () => {
+  // epoch 1769758221500 has millisecond = 500, SSS=501 is wrong
+  expect(() => DateTime.fromFormat("1769758221500 501", "x SSS")).toThrow(
     ConflictingSpecificationError
   );
 });

--- a/test/datetime/tokenParse.test.js
+++ b/test/datetime/tokenParse.test.js
@@ -1297,3 +1297,84 @@ test("fromFormat with x for negative unix milliseconds (before 1970)", () => {
   expect(dt.valueOf()).toBe(-1000);
   expect(dt.year).toBe(1969);
 });
+
+test("fromFormat with X rejects decimal numbers", () => {
+  const dt = DateTime.fromFormat("1769758221.5", "X");
+  expect(dt.isValid).toBe(false);
+});
+
+test("fromFormat with x rejects decimal numbers", () => {
+  const dt = DateTime.fromFormat("1769758221000.5", "x");
+  expect(dt.isValid).toBe(false);
+});
+
+test("fromFormat with X rejects non-numeric input", () => {
+  const dt = DateTime.fromFormat("abc", "X");
+  expect(dt.isValid).toBe(false);
+});
+
+test("fromFormat with x rejects non-numeric input", () => {
+  const dt = DateTime.fromFormat("abc", "x");
+  expect(dt.isValid).toBe(false);
+});
+
+test("fromFormat with X rejects bare sign without digits", () => {
+  const dt = DateTime.fromFormat("+", "X");
+  expect(dt.isValid).toBe(false);
+});
+
+test("fromFormat with x rejects bare sign without digits", () => {
+  const dt = DateTime.fromFormat("-", "x");
+  expect(dt.isValid).toBe(false);
+});
+
+test("fromFormat with X rejects empty string", () => {
+  const dt = DateTime.fromFormat("", "X");
+  expect(dt.isValid).toBe(false);
+});
+
+test("fromFormat with x rejects empty string", () => {
+  const dt = DateTime.fromFormat("", "x");
+  expect(dt.isValid).toBe(false);
+});
+
+// ConflictingSpecificationError when X/x clashes with other tokens
+
+test("fromFormat throws ConflictingSpecificationError when X year is inconsistent", () => {
+  // epoch 1769758221 = 2026-01-30T07:30:21Z, year=2025 is wrong
+  expect(() => DateTime.fromFormat("2025 1769758221", "yyyy X")).toThrow(
+    ConflictingSpecificationError
+  );
+});
+
+test("fromFormat throws ConflictingSpecificationError when X month is inconsistent", () => {
+  // epoch 1769758221 = 2026-01-30T07:30:21Z, month=2 is wrong
+  expect(() => DateTime.fromFormat("02 1769758221", "MM X")).toThrow(ConflictingSpecificationError);
+});
+
+test("fromFormat throws ConflictingSpecificationError when X hour is inconsistent", () => {
+  // epoch 1769758221 = 2026-01-30T07:30:21Z, hour=08 is wrong
+  expect(() => DateTime.fromFormat("08 1769758221", "HH X")).toThrow(ConflictingSpecificationError);
+});
+
+test("fromFormat throws ConflictingSpecificationError when x year is inconsistent", () => {
+  expect(() => DateTime.fromFormat("2025 1769758221000", "yyyy x")).toThrow(
+    ConflictingSpecificationError
+  );
+});
+
+test("fromFormat does not throw when X and other tokens are consistent (UTC)", () => {
+  // epoch 1769758221 = 2026-01-30T07:30:21Z
+  expect(() =>
+    DateTime.fromFormat("2026-01-30T07:30:21 1769758221", "yyyy-MM-dd'T'HH:mm:ss X")
+  ).not.toThrow();
+  const dt = DateTime.fromFormat("2026-01-30T07:30:21 1769758221", "yyyy-MM-dd'T'HH:mm:ss X");
+  expect(dt.isValid).toBe(true);
+  expect(dt.toUTC().toISO()).toBe("2026-01-30T07:30:21.000Z");
+});
+
+test("fromFormat does not throw when x and other tokens are consistent (UTC)", () => {
+  expect(() => DateTime.fromFormat("2026 1769758221000", "yyyy x")).not.toThrow();
+  const dt = DateTime.fromFormat("2026 1769758221000", "yyyy x");
+  expect(dt.isValid).toBe(true);
+});

--- a/test/datetime/tokenParse.test.js
+++ b/test/datetime/tokenParse.test.js
@@ -1248,3 +1248,52 @@ test("DateTime.fromFormatParser throws error when used with a different locale t
     "fromFormatParser called with a locale of Locale(es-MX, null, null), but the format parser was created for Locale(es-ES, null, null)"
   );
 });
+
+test("fromFormat with unix seconds token X", () => {
+  const dt = DateTime.fromFormat("1769758221", "X");
+  expect(dt.isValid).toBe(true);
+  expect(dt.toUTC().toISO()).toBe("2026-01-30T07:30:21.000Z");
+});
+
+test("fromFormat with unix milliseconds token x", () => {
+  const dt = DateTime.fromFormat("1769758221000", "x");
+  expect(dt.isValid).toBe(true);
+  expect(dt.toUTC().toISO()).toBe("2026-01-30T07:30:21.000Z");
+});
+
+test("fromFormat with X at epoch zero", () => {
+  const dt = DateTime.fromFormat("0", "X", { zone: "UTC" });
+  expect(dt.isValid).toBe(true);
+  expect(dt.valueOf()).toBe(0);
+  expect(dt.year).toBe(1970);
+  expect(dt.month).toBe(1);
+  expect(dt.day).toBe(1);
+  expect(dt.hour).toBe(0);
+  expect(dt.minute).toBe(0);
+  expect(dt.second).toBe(0);
+});
+
+test("fromFormat with x at epoch zero", () => {
+  const dt = DateTime.fromFormat("0", "x", { zone: "UTC" });
+  expect(dt.isValid).toBe(true);
+  expect(dt.valueOf()).toBe(0);
+});
+
+test("fromFormat with X for negative unix timestamp (before 1970)", () => {
+  const dt = DateTime.fromFormat("-1", "X", { zone: "UTC" });
+  expect(dt.isValid).toBe(true);
+  expect(dt.valueOf()).toBe(-1000);
+  expect(dt.year).toBe(1969);
+  expect(dt.month).toBe(12);
+  expect(dt.day).toBe(31);
+  expect(dt.hour).toBe(23);
+  expect(dt.minute).toBe(59);
+  expect(dt.second).toBe(59);
+});
+
+test("fromFormat with x for negative unix milliseconds (before 1970)", () => {
+  const dt = DateTime.fromFormat("-1000", "x", { zone: "UTC" });
+  expect(dt.isValid).toBe(true);
+  expect(dt.valueOf()).toBe(-1000);
+  expect(dt.year).toBe(1969);
+});

--- a/test/datetime/tokenParse.test.js
+++ b/test/datetime/tokenParse.test.js
@@ -1368,30 +1368,34 @@ test("fromFormat accepts consistent year alongside x", () => {
   expect(dt.toUTC().year).toBe(2026);
 });
 
-// ConflictingSpecificationError when X/x tokens are inconsistent with other tokens
+// inconsistent tokens alongside X/x produce an invalid DateTime (not a throw)
 
-test("fromFormat throws ConflictingSpecificationError when X year is inconsistent", () => {
+test("fromFormat returns invalid DateTime when X year is inconsistent", () => {
   // epoch 1769758221 = 2026-01-30T07:30:21Z, year=2025 is wrong
-  expect(() => DateTime.fromFormat("2025 1769758221", "yyyy X")).toThrow(
-    ConflictingSpecificationError
-  );
+  const dt = DateTime.fromFormat("2025 1769758221", "yyyy X");
+  expect(dt.isValid).toBe(false);
+  expect(dt.invalidReason).toBe("mismatched year");
 });
 
-test("fromFormat throws ConflictingSpecificationError when X month is inconsistent", () => {
+test("fromFormat returns invalid DateTime when X month is inconsistent", () => {
   // epoch 1769758221 = 2026-01-30T07:30:21Z, month=02 (February) is wrong
-  expect(() => DateTime.fromFormat("02 1769758221", "MM X")).toThrow(ConflictingSpecificationError);
+  const dt = DateTime.fromFormat("02 1769758221", "MM X");
+  expect(dt.isValid).toBe(false);
+  expect(dt.invalidReason).toBe("mismatched month");
 });
 
-test("fromFormat throws ConflictingSpecificationError when X hour is inconsistent", () => {
+test("fromFormat returns invalid DateTime when X hour is inconsistent", () => {
   // epoch 1769758221 = 2026-01-30T07:30:21Z, hour=08 is wrong
-  expect(() => DateTime.fromFormat("08 1769758221", "HH X")).toThrow(ConflictingSpecificationError);
+  const dt = DateTime.fromFormat("08 1769758221", "HH X");
+  expect(dt.isValid).toBe(false);
+  expect(dt.invalidReason).toBe("mismatched hour");
 });
 
-test("fromFormat throws ConflictingSpecificationError when x year is inconsistent", () => {
+test("fromFormat returns invalid DateTime when x year is inconsistent", () => {
   // epoch 1769758221000 = 2026-01-30T07:30:21Z, year=2025 is wrong
-  expect(() => DateTime.fromFormat("2025 1769758221000", "yyyy x")).toThrow(
-    ConflictingSpecificationError
-  );
+  const dt = DateTime.fromFormat("2025 1769758221000", "yyyy x");
+  expect(dt.isValid).toBe(false);
+  expect(dt.invalidReason).toBe("mismatched year");
 });
 
 // X (unix seconds) + S/SSS/u: milliseconds are additive precision, not redundant
@@ -1419,9 +1423,25 @@ test("fromFormat accepts consistent SSS alongside x", () => {
   expect(dt.toUTC().millisecond).toBe(500);
 });
 
-test("fromFormat throws ConflictingSpecificationError when x millisecond is inconsistent with SSS", () => {
+test("fromFormat returns invalid DateTime when x millisecond is inconsistent with SSS", () => {
   // epoch 1769758221500 has millisecond = 500, SSS=501 is wrong
-  expect(() => DateTime.fromFormat("1769758221500 501", "x SSS")).toThrow(
-    ConflictingSpecificationError
-  );
+  const dt = DateTime.fromFormat("1769758221500 501", "x SSS");
+  expect(dt.isValid).toBe(false);
+  expect(dt.invalidReason).toBe("mismatched millisecond");
+});
+
+// X and x together
+
+test("fromFormat accepts X and x when they are consistent", () => {
+  // X=1769758221 seconds = 1769758221000 ms, x=1769758221000 ms — same point in time
+  const dt = DateTime.fromFormat("1769758221 1769758221000", "X x");
+  expect(dt.isValid).toBe(true);
+  expect(dt.toUTC().toISO()).toBe("2026-01-30T07:30:21.000Z");
+});
+
+test("fromFormat returns invalid DateTime when X and x are inconsistent", () => {
+  // X=1769758221 → 1769758221000ms, x=1769758222000 → different point in time
+  const dt = DateTime.fromFormat("1769758221 1769758222000", "X x");
+  expect(dt.isValid).toBe(false);
+  expect(dt.invalidReason).toBe("mismatched unix timestamp");
 });


### PR DESCRIPTION
**Fix issue** [#1757 ](https://github.com/moment/luxon/issues/1757)
The DateTime.fromFormat not supporting X and x unix timestamp tokens
Adds X (unix seconds) and x (unix milliseconds) token support to _fromFormat_ by extending _unitForToken_ .
Also, handles edge-case for epoch zero and negative timestamps (pre-1970).
Before:
  DateTime.fromFormat("1769758221", "X")  // Invalid DateTime 
  DateTime.fromFormat("1769758221000", "x")  // Invalid DateTime
After:
  DateTime.fromFormat("1769758221", "X").toUTC().toISO()   // "2026-01-30T07:30:21.000Z"
  DateTime.fromFormat("1769758221000", "x").toUTC().toISO() // "2026-01-30T07:30:21.000Z"

