### PR TITLE
Fix FixedOffsetZone reporting isValid=true for unsupported inputs

### DIFF
--- a/src/zones/fixedOffsetZone.js
+++ b/src/zones/fixedOffsetZone.js
@@ -50,6 +50,8 @@ export default class FixedOffsetZone extends Zone {
     super();
     /** @private **/
     this.fixed = offset;
+    /** @private **/
+    this.valid = Number.isInteger(offset);
   }
 
   /**
@@ -140,11 +142,11 @@ export default class FixedOffsetZone extends Zone {
 
   /**
    * Return whether this Zone is valid:
-   * All fixed offset zones are valid.
+   * All fixed offset zones are valid, provided they were constructed with a numeric offset.
    * @override
    * @type {boolean}
    */
   get isValid() {
-    return true;
+    return this.valid;
   }
 }

--- a/test/zones/fixedOffset.test.js
+++ b/test/zones/fixedOffset.test.js
@@ -1,5 +1,5 @@
 /* global test expect */
-import { FixedOffsetZone, IANAZone } from "../../src/luxon";
+import { DateTime, FixedOffsetZone, IANAZone } from "../../src/luxon";
 
 test("FixedOffsetZone.utcInstance returns a singleton", () => {
   expect(FixedOffsetZone.utcInstance).toBe(FixedOffsetZone.utcInstance);
@@ -61,6 +61,30 @@ test("FixedOffsetZone.formatOffset prints the correct sign before the offset", (
   expect(FixedOffsetZone.instance(0).formatOffset(0, "short")).toBe("+00:00");
   expect(FixedOffsetZone.instance(30).formatOffset(0, "short")).toBe("+00:30");
   expect(FixedOffsetZone.instance(300).formatOffset(0, "short")).toBe("+05:00");
+});
+
+test("FixedOffsetZone is valid when constructed with a numeric offset", () => {
+  expect(new FixedOffsetZone(0).isValid).toBe(true);
+  expect(new FixedOffsetZone(120).isValid).toBe(true);
+  expect(new FixedOffsetZone(-300).isValid).toBe(true);
+  expect(FixedOffsetZone.instance(60).isValid).toBe(true);
+});
+
+test("FixedOffsetZone is invalid when constructed with a non-numeric offset", () => {
+  // see https://github.com/moment/luxon/issues/1068
+  expect(new FixedOffsetZone("CDT").isValid).toBe(false);
+  expect(new FixedOffsetZone("5").isValid).toBe(false);
+  expect(new FixedOffsetZone("abc").isValid).toBe(false);
+  expect(new FixedOffsetZone(NaN).isValid).toBe(false);
+  expect(new FixedOffsetZone(undefined).isValid).toBe(false);
+  expect(new FixedOffsetZone(null).isValid).toBe(false);
+  expect(new FixedOffsetZone({}).isValid).toBe(false);
+});
+
+test("A DateTime in an invalid FixedOffsetZone is itself invalid", () => {
+  const dt = DateTime.fromMillis(0, { zone: new FixedOffsetZone("CDT") });
+  expect(dt.isValid).toBe(false);
+  expect(dt.invalidReason).toBe("unsupported zone");
 });
 
 test("FixedOffsetZone.equals requires both zones to be fixed", () => {


### PR DESCRIPTION
Closes #1068

## The bug

`FixedOffsetZone` is a public, exported class, but its constructor performs no validation and `isValid` unconditionally returns `true`. As a result a zone built from an input it does not support still claims to be valid:

```js
const zone = new luxon.FixedOffsetZone("CDT");
zone.isValid;        // true  (should be false)
zone.offset(0);      // "CDT"
zone.name;           // "UTC-NaN"
zone.formatOffset(0, "short"); // "-NaN:NaN"
```

Because the zone lies about its validity, a `DateTime` that uses it slips past the existing `zone.isValid` guards in `datetime.js` and ends up invalid for the wrong reason (`"invalid input"` downstream) rather than being cleanly rejected.

This was confirmed as a bug by the maintainer in the issue:

> the bug here is not that the zone isn't working; it's that `isValid` should return false. "CDT" is not a valid input for building a zone.

`FixedOffsetZone` exposes factory methods (`parseSpecifier`, `instance`) that already return `null`/numbers for bad input, but the public constructor was never protected, so this only manifests when the class is instantiated directly.

## The fix

The constructor now records whether it was given a numeric offset, and `isValid` returns that flag:

```js
this.valid = Number.isInteger(offset);
```

- Valid numeric offsets (incl. `0` and `-0`) remain valid — no behavior change for any existing/internal caller (all internal call sites pass integers from `signedOffset(...)` or matched numeric captures).
- Non-numeric inputs (`"CDT"`, `"5"`, `NaN`, `undefined`, `null`, `{}`, …) now produce an invalid zone, mirroring how `IANAZone.create("Bogus/Zone")` already behaves.
- A `DateTime` built in such a zone is now itself invalid with the meaningful reason `"unsupported zone"`.

## Tests

Added to `test/zones/fixedOffset.test.js`:
- numeric offsets stay valid,
- non-numeric inputs are invalid,
- a `DateTime` in an invalid `FixedOffsetZone` is invalid with reason `"unsupported zone"`.

The two behavioral tests fail on `master` and pass with this change. The full zone test suite passes; the only failures in the repo (`format.test.js` / `toFormat.test.js`) are pre-existing locale/ICU-version differences unrelated to this change.