### PR TITLE
Accept the obsolete UT zone in fromRFC2822

### DIFF
--- a/src/impl/regexParser.js
+++ b/src/impl/regexParser.js
@@ -159,6 +159,7 @@ function extractISODuration(match) {
 // I'm just going to ignore that
 const obsOffsets = {
   GMT: 0,
+  UT: 0,
   EDT: -4 * 60,
   EST: -5 * 60,
   CDT: -5 * 60,

--- a/test/datetime/regexParse.test.js
+++ b/test/datetime/regexParse.test.js
@@ -831,6 +831,20 @@ test("DateTime.fromRFC2822() can use a weird subset of offset abbreviations", ()
   });
 });
 
+test("DateTime.fromRFC2822() can use the obsolete UT zone", () => {
+  const dt = DateTime.fromRFC2822("01 Nov 2016 13:23:12 UT");
+  expect(dt.isValid).toBe(true);
+  expect(dt.toUTC().toObject()).toEqual({
+    year: 2016,
+    month: 11,
+    day: 1,
+    hour: 13,
+    minute: 23,
+    second: 12,
+    millisecond: 0,
+  });
+});
+
 //------
 // .fromHTTP
 //-------


### PR DESCRIPTION
The `rfc2822` regex already matches `UT` in its zone alternation `(UT|GMT|[ECMP][SD]T)`, but `UT` is missing from the `obsOffsets` table in `extractRFC2822`. So `obsOffsets["UT"]` is `undefined`, which produces a `FixedOffsetZone(undefined)` and the parse fails as an invalid DateTime ("unsupported zone").

RFC 2822 / 5322 section 4.3 lists `UT` alongside `GMT` as an obsolete zone meaning +0000, so it should parse the same way `GMT` already does.

Repro on master:

```js
DateTime.fromRFC2822("01 Nov 2016 13:23:12 UT").isValid // false
```

Fix is one line, adding `UT: 0` to `obsOffsets`. With it, the above parses to `2016-11-01T13:23:12Z`. Added a test in `test/datetime/regexParse.test.js`; it fails on master and passes with the fix, and the rest of the regexParse suite stays green.

Note: I will need to sign the CLA.