### PR TITLE
Match any whitespace for a whitespace literal in fromFormat

### DIFF
--- a/src/impl/tokenParser.js
+++ b/src/impl/tokenParser.js
@@ -46,7 +46,12 @@ function simple(regex) {
 }
 
 function escapeToken(value) {
-  return value.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, "\\$&");
+  // Match any whitespace where a literal contains whitespace, so that strings
+  // produced by `toLocaleString` (which can use NBSP ` ` or narrow NBSP
+  // ` ` around the meridiem) round-trip back through `fromFormat`.
+  return value.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, (match) =>
+    /\s/.test(match) ? "\\s" : `\\${match}`
+  );
 }
 
 /**

--- a/test/datetime/tokenParse.test.js
+++ b/test/datetime/tokenParse.test.js
@@ -109,6 +109,22 @@ test("DateTime.fromFormat() makes dots optional and handles non breakable spaces
   });
 });
 
+// `toLocaleString` can emit a non-breaking (U+00A0) or narrow non-breaking
+// (U+202F) space before the meridiem, so a whitespace literal in the format
+// should match any whitespace to allow round-tripping.
+// See https://github.com/moment/luxon/issues/1619
+test("DateTime.fromFormat() matches any whitespace for a whitespace literal", () => {
+  const nbsp = String.fromCharCode(0x00a0);
+  const narrow = String.fromCharCode(0x202f);
+
+  for (const space of [" ", nbsp, narrow]) {
+    const d = DateTime.fromFormat(`10:30${space}AM`, "h:mm a");
+    expect(d.isValid).toBe(true);
+    expect(d.hour).toBe(10);
+    expect(d.minute).toBe(30);
+  }
+});
+
 test("DateTime.fromFormat() parses variable-digit years", () => {
   expect(DateTime.fromFormat("", "y").isValid).toBe(false);
   expect(DateTime.fromFormat("2", "y").year).toBe(2);


### PR DESCRIPTION
Fixes #1619.

### Problem

Modern ICU has `toLocaleString` place a non-breaking (U+00A0) or narrow non-breaking (U+202F) space before the meridiem. As a result, a string Luxon itself produced cannot be parsed back:

```js
const s = DateTime.fromISO("2024-04-17T10:30:00.000Z", { setZone: true })
  .toLocaleString(DateTime.TIME_SIMPLE); // "10:30 AM"

DateTime.fromFormat(s, "h:mm a").isValid; // false
```

### Cause

A whitespace literal in the format string is escaped by `escapeToken`, which turned a space into `\<space>` — a regex matching only a regular space (U+0020). The macro-token path (`case " "` → `simple(/[^\S\n\r]/)`) and the token-list path (`fixListRegex` → `\s`) already accept any whitespace; only the plain literal path did not.

### Fix

Escape whitespace in literals to `\s` so it matches any whitespace, mirroring the existing `fixListRegex` behaviour. Non-whitespace literals are unaffected (still escaped exactly).

### Tests

Added a test asserting `fromFormat("10:30<space>AM", "h:mm a")` is valid for a regular space, U+00A0, and U+202F. It fails without this change and passes with it. The existing meridiem/NBSP test (which covers NBSP *inside* the meridiem token) still passes.