### PR TITLE
fix: avoid exponential notation in Duration#toISO

### DIFF
--- a/src/duration.js
+++ b/src/duration.js
@@ -209,6 +209,15 @@ function removeZeroes(vals) {
   return newVals;
 }
 
+// Render a number for toISO(). JS prints very small magnitudes in exponential
+// notation (e.g. `1e-7`), which is not valid ISO 8601 and which fromISO() cannot
+// parse, so expand those to a plain decimal. (toFixed keeps exponential notation
+// for magnitudes >= 1e21, so very large durations are left untouched here.)
+function toISONumber(value) {
+  const str = `${value}`;
+  return str.includes("e") ? value.toFixed(20).replace(/\.?0+$/, "") : str;
+}
+
 /**
  * A Duration object represents a period of time, like "2 months" or "1 day, 1 hour". Conceptually, it's just a map of units to their quantities, accompanied by some additional configuration and methods for creating, parsing, interrogating, transforming, and formatting them. They can be used on their own or in conjunction with other Luxon types; for example, you can use {@link DateTime#plus} to add a Duration object to a DateTime, producing another DateTime.
  *
@@ -566,18 +575,19 @@ export default class Duration {
     if (!this.isValid) return null;
 
     let s = "P";
-    if (this.years !== 0) s += this.years + "Y";
-    if (this.months !== 0 || this.quarters !== 0) s += this.months + this.quarters * 3 + "M";
-    if (this.weeks !== 0) s += this.weeks + "W";
-    if (this.days !== 0) s += this.days + "D";
+    if (this.years !== 0) s += toISONumber(this.years) + "Y";
+    if (this.months !== 0 || this.quarters !== 0)
+      s += toISONumber(this.months + this.quarters * 3) + "M";
+    if (this.weeks !== 0) s += toISONumber(this.weeks) + "W";
+    if (this.days !== 0) s += toISONumber(this.days) + "D";
     if (this.hours !== 0 || this.minutes !== 0 || this.seconds !== 0 || this.milliseconds !== 0)
       s += "T";
-    if (this.hours !== 0) s += this.hours + "H";
-    if (this.minutes !== 0) s += this.minutes + "M";
+    if (this.hours !== 0) s += toISONumber(this.hours) + "H";
+    if (this.minutes !== 0) s += toISONumber(this.minutes) + "M";
     if (this.seconds !== 0 || this.milliseconds !== 0)
       // this will handle "floating point madness" by removing extra decimal places
       // https://stackoverflow.com/questions/588004/is-floating-point-math-broken
-      s += roundTo(this.seconds + this.milliseconds / 1000, 3) + "S";
+      s += toISONumber(roundTo(this.seconds + this.milliseconds / 1000, 3)) + "S";
     if (s === "P") s += "T0S";
     return s;
   }

--- a/test/duration/format.test.js
+++ b/test/duration/format.test.js
@@ -77,6 +77,25 @@ test("Duration#toISO handles mixed negative/positive numbers in seconds/millisec
   expect(Duration.fromObject({ seconds: -17, milliseconds: 548 }).toISO()).toBe("PT-16.452S");
 });
 
+test("Duration#toISO does not use exponential notation for very small values", () => {
+  // JS renders very small magnitudes in exponential notation (e.g. "1e-7"),
+  // which is not valid ISO 8601 and which Duration.fromISO cannot parse.
+  expect(Duration.fromObject({ years: 1e-7 }).toISO()).toBe("P0.0000001Y");
+  expect(Duration.fromObject({ days: 1e-7 }).toISO()).toBe("P0.0000001D");
+  expect(Duration.fromObject({ hours: 1e-7 }).toISO()).toBe("PT0.0000001H");
+  expect(Duration.fromObject({ minutes: 1e-7 }).toISO()).toBe("PT0.0000001M");
+});
+
+test("Duration#toISO output round-trips small fractional values through fromISO", () => {
+  // Converting a small duration to a coarse unit yields a tiny fractional value.
+  const dur = Duration.fromObject({ milliseconds: 1 }).shiftTo("hours");
+  expect(dur.toISO()).not.toMatch(/e/i);
+  expect(Duration.fromISO(dur.toISO()).isValid).toBe(true);
+
+  const exact = Duration.fromObject({ hours: 1e-7 });
+  expect(Duration.fromISO(exact.toISO()).hours).toBe(1e-7);
+});
+
 //------
 // #toISOTime()
 //------


### PR DESCRIPTION
### Problem

`Duration#toISO()` builds the string by concatenating each field value directly (`this.hours + "H"`, etc.). When a field holds a very small magnitude, JavaScript renders it in exponential notation, which is **not valid ISO 8601** and which `Duration.fromISO` cannot parse — so `toISO()` produces output its own parser rejects:

```js
const d = Duration.fromObject({ milliseconds: 1 }).shiftTo("hours");
d.toISO();                       // "PT2.7777777777777776e-7H"
Duration.fromISO(d.toISO()).isValid;   // false

Duration.fromObject({ hours: 1e-7 }).toISO();   // "PT1e-7H"  (unparsable)
Duration.fromObject({ days: 1e-7 }).toISO();    // "P1e-7D"   (unparsable)
```

Converting a small duration to a coarser unit — a normal operation — is enough to reach it.

### Fix

Route each field value through a small helper that expands exponential notation to a plain decimal, so `toISO()` always emits valid ISO 8601 that round-trips through `fromISO()`:

```js
Duration.fromObject({ hours: 1e-7 }).toISO();   // "PT0.0000001H"
Duration.fromISO("PT0.0000001H").hours;         // 1e-7
```

Values that already render without exponential notation are returned unchanged, so existing output is byte-identical (the helper is a no-op for them). Magnitudes `>= 1e21` keep exponential notation from `toFixed`, so they're untouched here — those additionally run into the parser's separate `\d{1,20}` digit cap (see #1311) and are out of scope for this change.

### Tests / verification

Added `toISO` assertions for the no-exponential output and a `fromISO(toISO())` round-trip. `test/duration/format.test.js` is green (50/50). Across the full suite the change adds 2 passing tests and introduces no new failures (verified by stash-comparing failure counts: 46 failed both with and without the change — those are the pre-existing timezone/locale environment failures that need luxon's CI `TZ=America/New_York` + full-ICU setup, unrelated to this change). `prettier --check` passes.