### PR TITLE
Fix lost negative sign in Duration#toFormat when largest unit is zero (signMode negativeLargestOnly)

### DIFF
--- a/src/impl/formatter.js
+++ b/src/impl/formatter.js
@@ -412,7 +412,21 @@ export default class Formatter {
             // "auto" and "negative" are the same, but "auto" has better support
             signDisplay = "auto";
           }
-          return this.num(lildur.get(mapped) * inversionFactor, token.length, signDisplay);
+          let value = lildur.get(mapped) * inversionFactor;
+          // When the negative sign is only shown on the largest unit (signMode
+          // "negativeLargestOnly") and that unit rounds to zero, "auto" sign display
+          // would drop the sign entirely (positive zero formats without a sign),
+          // making a negative duration indistinguishable from a positive one. Use
+          // negative zero so the sign is preserved on the largest unit.
+          if (
+            this.opts.signMode === "negativeLargestOnly" &&
+            mapped === info.largestUnit &&
+            info.isNegativeDuration &&
+            value === 0
+          ) {
+            value = -0;
+          }
+          return this.num(value, token.length, signDisplay);
         } else {
           return token;
         }

--- a/test/duration/format.test.js
+++ b/test/duration/format.test.js
@@ -323,6 +323,33 @@ test("Duration#toFormat shows no negative sign on the largest unit when using si
   ).toBe("4503");
 });
 
+test("Duration#toFormat keeps the negative sign on the largest unit when it is zero with signMode negativeLargestOnly", () => {
+  // The largest formatted unit rounds to zero, but the duration is negative.
+  // The sign must still appear on the largest unit, otherwise the result is
+  // indistinguishable from a positive duration.
+  expect(
+    Duration.fromObject({ minutes: -30 }).toFormat("h:mm", {
+      signMode: "negativeLargestOnly",
+    })
+  ).toBe("-0:30");
+  expect(
+    Duration.fromObject({ seconds: -30 }).toFormat("h:mm:ss", {
+      signMode: "negativeLargestOnly",
+    })
+  ).toBe("-0:00:30");
+  expect(
+    Duration.fromObject({ minutes: -45 }).toFormat("d:h:m", {
+      signMode: "negativeLargestOnly",
+    })
+  ).toBe("-0:0:45");
+  // A positive duration whose largest unit is zero must remain unsigned.
+  expect(
+    Duration.fromObject({ minutes: 30 }).toFormat("h:mm", {
+      signMode: "negativeLargestOnly",
+    })
+  ).toBe("0:30");
+});
+
 // - signMode all
 
 test("Duration#toFormat with signMode all shows positive sign on positive durations", () => {


### PR DESCRIPTION
With `signMode: "negativeLargestOnly"`, the negative sign is shown only on the largest formatted unit. When that unit rounds to zero, `"auto"` sign display dropped the sign entirely, so a negative duration formatted identically to a positive one.

### Reproduction
```js
Duration.fromObject({ minutes: -30 }).toFormat("h:mm", { signMode: "negativeLargestOnly" })
// => "0:30"  (looks positive; expected "-0:30")
```
The largest unit (`hours`) rounds to `0`, and positive zero formats without a sign, so the whole duration reads as positive.

### Fix
In `src/impl/formatter.js`, when `signMode === "negativeLargestOnly"`, the token is the largest unit, the duration is negative, and the value is `0`, emit **negative zero** (`-0`) for that unit so the sign is preserved. Everything else is untouched: positive durations, other sign modes, and non-zero largest units behave exactly as before.

### Tests
Added a regression test in `test/duration/format.test.js`. It **fails without** the change (`"0:30"` instead of `"-0:30"`) and **passes with** it. Full `test/duration/format.test.js` suite passes (49/49).