### PR TITLE
Reject out-of-range 12-hour values with a meridiem in fromFormat

### DIFF
--- a/src/impl/tokenParser.js
+++ b/src/impl/tokenParser.js
@@ -368,8 +368,15 @@ function dateTimeFromMatches(matches) {
     matches.M = (matches.q - 1) * 3 + 1;
   }
 
+  let hourInvalidReason;
+
   if (!isUndefined(matches.h)) {
-    if (matches.h < 12 && matches.a === 1) {
+    if (!isUndefined(matches.a) && (matches.h < 1 || matches.h > 12)) {
+      // "h" is the 12-hour token, so when a meridiem ("a") is also present the
+      // hour must be within [1, 12]. Anything else (e.g. "18:30 AM") is not a
+      // valid 12-hour time, so the result is invalid.
+      hourInvalidReason = `the 12-hour value "${matches.h}" is not in the [1, 12] range`;
+    } else if (matches.h < 12 && matches.a === 1) {
       matches.h += 12;
     } else if (matches.h === 12 && matches.a === 0) {
       matches.h = 0;
@@ -393,7 +400,7 @@ function dateTimeFromMatches(matches) {
     return r;
   }, {});
 
-  return [vals, zone, specificOffset];
+  return [vals, zone, specificOffset, hourInvalidReason];
 }
 
 let dummyDateTimeCache = null;
@@ -449,9 +456,9 @@ export class TokenParser {
       return { input, tokens: this.tokens, invalidReason: this.invalidReason };
     } else {
       const [rawMatches, matches] = match(input, this.regex, this.handlers),
-        [result, zone, specificOffset] = matches
+        [result, zone, specificOffset, parseInvalidReason] = matches
           ? dateTimeFromMatches(matches)
-          : [null, null, undefined];
+          : [null, null, undefined, undefined];
       if (hasOwnProperty(matches, "a") && hasOwnProperty(matches, "H")) {
         throw new ConflictingSpecificationError(
           "Can't include meridiem when specifying 24-hour format"
@@ -466,6 +473,7 @@ export class TokenParser {
         result,
         zone,
         specificOffset,
+        invalidReason: parseInvalidReason,
       };
     }
   }

--- a/test/datetime/tokenParse.test.js
+++ b/test/datetime/tokenParse.test.js
@@ -74,6 +74,20 @@ test("DateTime.fromFormat() throws if you specify meridiem with 24-hour time", (
   expect(() => DateTime.fromFormat("930PM", "Hmma")).toThrow(ConflictingSpecificationError);
 });
 
+// #1625
+test("DateTime.fromFormat() rejects 12-hour values outside [1, 12] with a meridiem", () => {
+  expect(DateTime.fromFormat("18:30 AM", "h:mm a").isValid).toBe(false);
+  expect(DateTime.fromFormat("16:00 PM", "h:mm a").isValid).toBe(false);
+  expect(DateTime.fromFormat("0:30 AM", "h:mm a").isValid).toBe(false);
+  expect(DateTime.fromFormat("13:00 PM", "h:mm a").isValid).toBe(false);
+
+  // Valid 12-hour values are still parsed correctly.
+  expect(DateTime.fromFormat("8:30 AM", "h:mm a").hour).toBe(8);
+  expect(DateTime.fromFormat("12:30 AM", "h:mm a").hour).toBe(0);
+  expect(DateTime.fromFormat("12:30 PM", "h:mm a").hour).toBe(12);
+  expect(DateTime.fromFormat("1:00 PM", "h:mm a").hour).toBe(13);
+});
+
 // #714
 test("DateTime.fromFormat() makes dots optional and handles non breakable spaces", () => {
   function parseMeridiem(input, isAM) {


### PR DESCRIPTION
Fixes #1625. `DateTime.fromFormat("18:30 AM", "h:mm a").isValid` returned `true` even though `18` is not a valid hour for the 12-hour `h` token. The parser now validates that, when a meridiem is present, the `h` value is within `[1, 12]`, surfacing an invalid result through luxon's existing invalid-reason channel. Valid inputs are unchanged. Added a regression test.

Closes #1625