### PR TITLE
docs: fix toRelative example so it produces the documented output

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -2279,7 +2279,7 @@ export default class DateTime {
    * @param {string} options.locale - override the locale of this DateTime
    * @param {string} options.numberingSystem - override the numberingSystem of this DateTime. The Intl system may choose not to honor this
    * @example DateTime.now().plus({ days: 1 }).toRelative() //=> "in 1 day"
-   * @example DateTime.now().setLocale("es").toRelative({ days: 1 }) //=> "dentro de 1 día"
+   * @example DateTime.now().setLocale("es").plus({ days: 1 }).toRelative() //=> "dentro de 1 día"
    * @example DateTime.now().plus({ days: 1 }).toRelative({ locale: "fr" }) //=> "dans 23 heures"
    * @example DateTime.now().minus({ days: 2 }).toRelative() //=> "2 days ago"
    * @example DateTime.now().minus({ days: 2 }).toRelative({ unit: "hours" }) //=> "48 hours ago"


### PR DESCRIPTION
The Spanish `toRelative` example claims an output it can't produce:

```js
DateTime.now().setLocale("es").toRelative({ days: 1 }) //=> "dentro de 1 día"
```

`{ days: 1 }` isn't a valid `toRelative` option, so it's ignored and the call compares `now` to its default base (`now`). On 3.7.2 it returns `"hace 0 segundos"`, not `"dentro de 1 día"`.

The neighbouring examples get the offset from `.plus(...)` / `.minus(...)` before calling `toRelative()`, and the sibling `toRelativeCalendar` docstring uses the same shape:

```js
DateTime.now().setLocale("es").plus({ days: 1 }).toRelativeCalendar() //=> "mañana"
```

This adds the missing `.plus({ days: 1 })` so the example matches its stated output:

```js
DateTime.now().setLocale("es").plus({ days: 1 }).toRelative() //=> "dentro de 1 día"
```

Docstring-only change. #1771 recently fixed a broken example in the sibling `toRelativeCalendar`; this is the matching fix for `toRelative`.
