### PR TITLE
fix(docs): correct swapped standalone/format token columns in parsing table

### DIFF
--- a/docs/parsing.md
+++ b/docs/parsing.md
@@ -205,13 +205,13 @@ Because Luxon was able to parse the string without difficulty, the output is a l
 | a                |              | meridiem                                                          | `AM`                        |
 | d                |              | day of the month, no padding                                      | `6`                         |
 | dd               |              | day of the month, padded to 2                                     | `06`                        |
-| E                | c            | day of the week, as number from 1-7 (Monday is 1, Sunday is 7)    | `3`                         |
-| EEE              | ccc          | day of the week, as an abbreviate localized string                | `Wed`                       |
-| EEEE             | cccc         | day of the week, as an unabbreviated localized string             | `Wednesday`                 |
-| M                | L            | month as an unpadded number                                       | `8`                         |
-| MM               | LL           | month as an padded number                                         | `08`                        |
-| MMM              | LLL          | month as an abbreviated localized string                          | `Aug`                       |
-| MMMM             | LLLL         | month as an unabbreviated localized string                        | `August`                    |
+| c                | E            | day of the week, as number from 1-7 (Monday is 1, Sunday is 7)    | `3`                         |
+| ccc              | EEE          | day of the week, as an abbreviate localized string                | `Wed`                       |
+| cccc             | EEEE         | day of the week, as an unabbreviated localized string             | `Wednesday`                 |
+| L                | M            | month as an unpadded number                                       | `8`                         |
+| LL               | MM           | month as an padded number                                         | `08`                        |
+| LLL              | MMM          | month as an abbreviated localized string                          | `Aug`                       |
+| LLLL             | MMMM         | month as an unabbreviated localized string                        | `August`                    |
 | y                |              | year, 1-6 digits, very literally                                  | `2014`                      |
 | yy               |              | two-digit year, interpreted as > 1960 by default (also accepts 4) | `14`                        |
 | yyyy             |              | four-digit year                                                   | `2014`                      |


### PR DESCRIPTION
Closes #1777.

## Problem

The token table under [Parsing → Table of tokens](https://moment.github.io/luxon/#/parsing?id=table-of-tokens) had the **Standalone token** and **Format token** columns swapped for every weekday and month row. It listed the format tokens `E`/`M` under "Standalone token" and the standalone tokens `c`/`L` under "Format token".

That is the reverse of:

- the equivalent table in [`docs/formatting.md`](https://moment.github.io/luxon/#/formatting?id=table-of-tokens), where the weekday row is `c` (standalone) / `E` (format) and the month row is `L` (standalone) / `M` (format); and
- Luxon's API, where `c`/`L` are the standalone tokens and `E`/`M` are the format tokens.

## Fix

Swap the two columns for all affected rows in `docs/parsing.md` so the parsing table matches the formatting table and the API:

| Unit | Standalone | Format |
| --- | --- | --- |
| weekday | `c`, `ccc`, `cccc` | `E`, `EEE`, `EEEE` |
| month | `L`, `LL`, `LLL`, `LLLL` | `M`, `MM`, `MMM`, `MMMM` |

Docs-only change; no code affected.

This supersedes #1779, which fixed the same issue but was closed because its author was unable to sign the CLA.
