### PR TITLE
fix(interval): respect endpoint zones in hasSame for empty intervals

### DIFF
--- a/src/interval.js
+++ b/src/interval.js
@@ -285,7 +285,10 @@ export default class Interval {
    * @return {boolean}
    */
   hasSame(unit) {
-    return this.isValid ? this.isEmpty() || this.e.minus(1).hasSame(this.s, unit) : false;
+    if (!this.isValid) return false;
+    // For an empty interval, compare the endpoints directly so that endpoints
+    // in different zones (with differing local unit values) are respected.
+    return this.isEmpty() ? this.s.hasSame(this.e, unit) : this.e.minus(1).hasSame(this.s, unit);
   }
 
   /**

--- a/test/interval/info.test.js
+++ b/test/interval/info.test.js
@@ -260,3 +260,13 @@ test.each([
     i = Interval.fromDateTimes(n, n);
   expect(i.hasSame("day")).toBe(true);
 });
+
+test("Interval#hasSame respects the zones of an empty interval's endpoints", () => {
+  // Same instant, but the endpoints are in different zones so their local
+  // hours differ (12:15 in UTC+2 vs 11:15 in UTC+1).
+  const s = DateTime.fromISO("2023-01-01T10:15:00.000+00:00", { zone: "UTC+2" }),
+    e = DateTime.fromISO("2023-01-01T10:15:00.000+00:00", { zone: "UTC+1" }),
+    i = Interval.fromDateTimes(s, e);
+  expect(i.isEmpty()).toBe(true);
+  expect(i.hasSame("hour")).toBe(false);
+});


### PR DESCRIPTION
## Problem

`Interval#hasSame` short-circuited to `true` for any empty interval, ignoring the case where the two endpoints share an instant but sit in different zones with differing local unit values.

## Fix

Compare the endpoints directly for empty intervals so a zone mismatch is respected:

```js
hasSame(unit) {
  if (!this.isValid) return false;
  return this.isEmpty() ? this.s.hasSame(this.e, unit) : this.e.minus(1).hasSame(this.s, unit);
}
```

## Testing

Added a test in `test/interval/info.test.js` covering an empty interval whose endpoints share an instant but sit in different zones. Existing `hasSame` tests continue to pass.

Closes #1424
