### PR TITLE
Fix Duration#normalize compounding conversions through intermediate units

### DIFF
--- a/src/duration.js
+++ b/src/duration.js
@@ -145,6 +145,12 @@ function durationToMillis(matrix, vals) {
   return sum;
 }
 
+// the number of milliseconds in a single unit, used to convert between two
+// units in a way that stays consistent with the duration's total value
+function unitToMillis(matrix, unit) {
+  return unit === "milliseconds" ? 1 : matrix[unit]["milliseconds"];
+}
+
 // NB: mutates parameters
 function normalizeValues(matrix, vals) {
   // the logic below assumes the overall value of the duration is positive
@@ -172,7 +178,16 @@ function normalizeValues(matrix, vals) {
         // Math.floor takes care of both of these cases, rounding away from 0
         // if previousVal < 0 it makes the absolute value larger
         // if previousVal >= it makes the absolute value smaller
-        const rollUp = Math.floor(previousVal / conv);
+        //
+        // Decide how many whole `current` units to roll up using the units'
+        // millisecond values rather than matrix[current][previous]. The casual
+        // matrix's pairwise factors can be internally inconsistent (e.g. 1 month
+        // = 4 weeks but also = 30 days); dividing by that factor would otherwise
+        // let a chained roll-up such as days -> weeks -> months roll up units
+        // that aren't really there and change the duration's total value (#1514).
+        const rollUp = Math.floor(
+          (previousVal * unitToMillis(matrix, previous)) / unitToMillis(matrix, current)
+        );
         vals[current] += rollUp * factor;
         vals[previous] -= rollUp * conv * factor;
       }

--- a/test/duration/units.test.js
+++ b/test/duration/units.test.js
@@ -236,6 +236,15 @@ test("Duration#normalize handles the full grid partially negative durations", ()
   });
 });
 
+test("Duration#normalize does not compound conversions through intermediate units", () => {
+  // 28 days is exactly 4 weeks, which is less than a (30-day) month, so it must
+  // not roll up into a month just because both `weeks` and `months` keys exist.
+  // See https://github.com/moment/luxon/issues/1514
+  const dur = Duration.fromObject({ months: 0, weeks: 0, days: 28 }).normalize();
+  expect(dur.as("days")).toBe(28);
+  expect(dur.toObject()).toEqual({ months: 0, weeks: 4, days: 0 });
+});
+
 test("Duration#normalize maintains invalidity", () => {
   const dur = Duration.invalid("because").normalize();
   expect(dur.isValid).toBe(false);


### PR DESCRIPTION
Fixes #1514

## Problem

`Duration.normalize()` can silently change the total length of a duration when
both a `weeks` key and a higher calendar unit (`months`/`years`/`quarters`) are
present:

```js
Duration.fromObject({ days: 28, weeks: 0, months: 0 }).normalize().as("days");
// => 30  (expected 28)
```

28 days is exactly 4 weeks — less than a (casual) 30‑day month — yet `normalize()`
turns the duration into `{ months: 1 }` and `as("days")` then reports 30. The
normalized duration no longer represents the same amount of time as the original.

## Root cause

`normalizeValues()` in `src/duration.js` rolls lower‑order units up into
higher‑order ones with a `reduceRight` pass, using the pairwise conversion factor
`matrix[current][previous]` to decide how many whole higher units are present:

```js
const rollUp = Math.floor(previousVal / matrix[current][previous]);
```

The casual conversion matrix is **internally inconsistent**: it defines
`months.weeks = 4` (1 month = 4 weeks = 28 days) *and* `months.days = 30`
(1 month = 30 days). Because both `weeks` and `months` keys exist, 28 days is
first rolled into 4 weeks (correct, 28 days == 4 weeks), and those 4 weeks are
then rolled into 1 month via `matrix[months][weeks] === 4` (`floor(4 / 4) === 1`).
That second step asserts "4 weeks == 1 month", which is false in milliseconds
(28 days vs. 30 days), so the chained roll‑up `days -> weeks -> months` gains 2
days. This is exactly the mechanism the maintainer described in the issue thread,
and the same class of problem the code already acknowledges in a test comment
(`test/duration/units.test.js`: "Normalizing would convert to
{ quarters: 4, months: 1, days: 10 } which would be converted back to 404 days").

## Fix

`src/duration.js` — decide the roll‑up **count** from each unit's millisecond
value instead of the possibly‑inconsistent pairwise matrix factor:

```js
const rollUp = Math.floor(
  (previousVal * unitToMillis(matrix, previous)) / unitToMillis(matrix, current)
);
```

A unit only rolls up when the lower‑order value genuinely contains at least one
whole higher‑order unit *in milliseconds*. For 4 weeks vs. 1 month this is
`floor(28 / 30) === 0`, so the spurious roll‑up no longer happens and the 28‑day
duration stays 28 days.

The actual decrement still uses the exact matrix factor
(`vals[previous] -= rollUp * matrix[current][previous] * factor`), so integer
conversions stay exact — critically, this preserves the exactness of the
`longterm`/accurate matrix (where e.g. `years.months === 12` is an exact integer
that a millisecond ratio would round to `11.9999…`) and does not introduce
fractions into results that were previously whole numbers.

A small helper `unitToMillis(matrix, unit)` returns the millisecond value of a
single unit (`1` for `milliseconds`, which has no matrix row), mirroring the
existing `matrix[unit]["milliseconds"]` access pattern in `durationToMillis`.

## Tests

`test/duration/units.test.js` — added a regression test next to the existing
`Duration#normalize` cases:

```js
test("Duration#normalize does not compound conversions through intermediate units", () => {
  const dur = Duration.fromObject({ months: 0, weeks: 0, days: 28 }).normalize();
  expect(dur.as("days")).toBe(28);
  expect(dur.toObject()).toEqual({ months: 0, weeks: 4, days: 0 });
});
```

## Verification

Before the fix (pristine `src/duration.js`), the new test fails:

```
✕ Duration#normalize does not compound conversions through intermediate units
    Expected: 28
    Received: 30
```

After the fix:

```
$ npx jest test/duration/
Test Suites: 15 passed, 15 total
Tests:       180 passed, 180 total
```

Full-suite comparison (the 46 failures are pre-existing environment failures in
timezone/DST/locale suites, identical with and without this change):

```
baseline : Tests: 46 failed, 1162 passed, 1208 total
with fix  : Tests: 46 failed, 1163 passed, 1209 total   (+1 = the new test)
```

`npx prettier --check src/duration.js test/duration/units.test.js` passes.

The exact reproduction object from the issue now also preserves the total
duration: `normalize().toMillis() === toMillis()`.

## Compatibility

- Behavior only changes for durations that previously rolled a lower unit up into
  a higher unit *across an internally inconsistent casual pair* when the lower unit
  did not actually contain a full higher unit (e.g. `{ days: 28, weeks: 0,
  months: 0 }` → now `{ weeks: 4 }` instead of `{ months: 1 }`;
  `{ years: 0, months: 12 }` → stays `{ months: 12 }` instead of `{ years: 1 }`).
  In every such case the previous result silently changed the duration's total
  value; the new result preserves it.
- No change for the accurate/`longterm` matrix (already internally consistent) or
  for any time-only units, which is why all existing `normalize`, `shiftTo`,
  `shiftToAll`, and `rescale` tests continue to pass unchanged.
- This intentionally does **not** alter the separate, already-documented casual
  rounding that occurs for *genuine* multi-unit roll-ups (e.g. 400 days →
  `{ quarters: 4, months: 1, days: 10 }`), which the maintainers handle by not
  normalizing in `shiftTo`; that is out of scope for this issue.
