### PR TITLE
fix(duration): shiftTo converts lower-order units directly into targets

### DIFF
--- a/src/duration.js
+++ b/src/duration.js
@@ -835,6 +835,22 @@ export default class Duration {
         built[k] = i;
         accumulated[k] = (own * 1000 - i * 1000) / 1000;
 
+        // roll the whole part of any lower-order source units straight into this unit.
+        // Doing the conversion directly (e.g. days -> years) avoids compounding it through
+        // intermediate units whose ratios are not mutually consistent (twelve 30-day months
+        // are not one 365-day year), which used to strand a spurious remainder in the lower
+        // units (#1620, #1604). Any fractional leftover stays on the source unit and is
+        // boiled down to a smaller unit further along.
+        const kIndex = orderedUnits.indexOf(k);
+        for (const down in vals) {
+          if (orderedUnits.indexOf(down) > kIndex && isNumber(vals[down])) {
+            const conv = this.matrix[k][down];
+            const added = Math.trunc(vals[down] / conv);
+            built[k] += added;
+            vals[down] = (vals[down] * 1000 - added * conv * 1000) / 1000;
+          }
+        }
+
         // otherwise, keep it in the wings to boil it later
       } else if (isNumber(vals[k])) {
         accumulated[k] = vals[k];

--- a/test/duration/units.test.js
+++ b/test/duration/units.test.js
@@ -116,6 +116,15 @@ test("Duration#shiftTo does not produce unnecessary fractions in higher order un
   expect(shifted.minutes).toBeCloseTo(894.6, 5);
 });
 
+test("Duration#shiftTo does not leave a remainder when higher-order units absorb the whole duration (#1620)", () => {
+  // 12 months == 1 year and 730 days == 2 years, so the result should be exactly 3 years.
+  // Regressed in 3.4.2: conversions were compounded through the intermediate "months"
+  // unit (730 days -> 24 months + 10 days -> 3 years leaving 10 stray days).
+  expect(
+    Duration.fromObject({ months: 12, days: 730 }).shiftTo("years", "months", "days").toObject()
+  ).toEqual({ years: 3, months: 0, days: 0 });
+});
+
 //------
 // #shiftToAll()
 //-------
@@ -147,6 +156,20 @@ test("Duration#shiftToAll does not produce unnecessary fractions in higher order
   expect(toAll.minutes).toBe(29);
   expect(toAll.seconds).toBe(6);
   expect(toAll.milliseconds).toBeCloseTo(0, 5);
+});
+
+test("Duration#shiftToAll does not inflate lower-order units when rolling up (#1604)", () => {
+  // 730 days is exactly 2 years; rolling up must not manufacture extra months/days.
+  expect(Duration.fromObject({ days: 730 }).shiftToAll().toObject()).toEqual({
+    years: 2,
+    months: 0,
+    weeks: 0,
+    days: 0,
+    hours: 0,
+    minutes: 0,
+    seconds: 0,
+    milliseconds: 0,
+  });
 });
 
 test("Duration#shiftToAll maintains invalidity", () => {


### PR DESCRIPTION
## Summary
Restores `Duration#shiftTo` / `shiftToAll` to convert each lower-order source unit **directly** into the target unit, fixing a regression introduced in 3.4.2 (#1494).

Fixes #1620
Refs #1604

## Problem
```js
Duration.fromObject({ months: 12, days: 730 }).shiftTo("years", "months", "days").toObject()
// 3.4.1 => { years: 3, months: 0, days: 0 }
// 3.4.2+ => { years: 3, months: 0, days: 10 }   // 10 stray days
```
12 months is exactly 1 year and 730 days is exactly 2 years (by luxon's 365-day matrix), so the result should be `{ years: 3 }`. This worked in 3.4.1 and broke in 3.4.2.

#1494 removed `shiftTo`'s direct unit conversion and delegated roll-up to `normalizeValues`, which chains through **adjacent** units. That compounds conversions through intermediate calendar units whose ratios are not mutually consistent (twelve 30-day months ≠ one 365-day year): `days→months` gives `24 months + 10 stray days`, then `months→years` leaves those 10 days stranded.

## Solution
After building each target unit, roll the whole part of every lower-order **present** source unit straight into it via a single exact matrix conversion, leaving any fractional leftover on the source unit to boil down further along. `normalize()` / `normalizeValues()` are untouched.

## Test Plan
- Added two tests in `test/duration/units.test.js` (`shiftTo` #1620 and `shiftToAll` for the `{ days: 730 }` case). Both fail before this change and pass after; expected values were confirmed against v3.4.1.
- Full duration suite passes (181/181). The full test run shows only 2 failures in `interval/format` and `datetime/format`, which are **pre-existing** on `master` (ICU/locale calendar-era strings, e.g. coptic `AM` vs `ERA1`) and unrelated to this change.
- The tests added by #1494/#1498 for negative and fractional durations all still pass, and `prettier --check` is clean.

## Compatibility
No change to `normalize()` — all existing normalize/shiftTo/shiftToAll tests (including the #1493/#1498 negative-and-fractional cases) still pass. Direct conversion is identical to the previous chained result for mutually-consistent units (ms/s/min/h); it only differs for calendar units, restoring the expected 3.4.1 output.

## Note on #1604
Flagging honestly: the exact repro in #1604 (`31535940000` ms) returns the same result in 3.4.1 and on current `master`, so it is **not** itself a regression and I don't claim to "fix" it — hence `Refs` rather than `Fixes`. The regressed case is the `{ days: 730 }.shiftToAll()` scenario raised in that thread, which this change corrects. If you'd prefer the roll-up consolidated inside `normalizeValues` instead of restored in `shiftTo`, happy to rework.