### PR TITLE
docs: clarify fromFormat token table link in JSDoc

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -980,7 +980,7 @@ export default class DateTime {
    * Create a DateTime from an input string and format string.
    * Defaults to en-US if no locale has been specified, regardless of the system's locale. For a table of tokens and their interpretations, see [here](https://moment.github.io/luxon/#/parsing?id=table-of-tokens).
    * @param {string} text - the string to parse
-   * @param {string} fmt - the format the string is expected to be in (see the link below for the formats)
+   * @param {string} fmt - the format the string is expected to be in (see the [table of tokens](https://moment.github.io/luxon/#/parsing?id=table-of-tokens))
    * @param {Object} opts - options to affect the creation
    * @param {string|Zone} [opts.zone='local'] - use this zone if no offset is specified in the input string itself. Will also convert the DateTime to this zone
    * @param {boolean} [opts.setZone=false] - override the zone with a zone specified in the string itself, if it specifies one


### PR DESCRIPTION
## Summary
- The `DateTime.fromFormat` JSDoc told readers to "see the link below" for format tokens, but the only link is in the description above that line.
- Point the `fmt` parameter note at the parsing token table URL so the generated API docs are clear.

Fixes #1298

## Test plan
- [ ] Confirm the `fmt` param text in `src/datetime.js` links to https://moment.github.io/luxon/#/parsing?id=table-of-tokens
- [ ] Optionally regenerate API docs (`npm run api-docs`) and check `DateTime.fromFormat` no longer says "link below"