### PR TITLE
fix: give the RFC date parsers their own century rules

### DIFF
--- a/src/impl/regexParser.js
+++ b/src/impl/regexParser.js
@@ -1,11 +1,5 @@
-import {
-  untruncateYear,
-  signedOffset,
-  parseInteger,
-  parseMillis,
-  isUndefined,
-  parseFloating,
-} from "./util.js";
+import Settings from "../settings.js";
+import { signedOffset, parseInteger, parseMillis, isUndefined, parseFloating } from "./util.js";
 import * as English from "./english.js";
 import FixedOffsetZone from "../zones/fixedOffsetZone.js";
 import IANAZone from "../zones/IANAZone.js";
@@ -170,9 +164,47 @@ const obsOffsets = {
   PST: -8 * 60,
 };
 
-function fromStrings(weekdayStr, yearStr, monthStr, dayStr, hourStr, minuteStr, secondStr) {
+// `Settings.twoDigitCutoffYear` exists for `fromFormat`, where the user chooses
+// the century rule for their own `yy` token. The formats below are not the
+// user's to choose: each one carries its own rule, and the two rules disagree
+// with each other, so one cutoff cannot serve both.
+
+// RFC 9110 5.6.7: "Recipients of a timestamp value in rfc850-date format ...
+// MUST interpret a timestamp that appears to be more than 50 years in the
+// future as representing the most recent year in the past that had the same
+// last two digits." A sliding window, so it moves with the clock.
+function untruncateHTTPYear(yearStr) {
+  const year = parseInteger(yearStr);
+  if (yearStr.length !== 2) return year;
+
+  const nowYear = new Date(Settings.now()).getUTCFullYear();
+  let candidate = Math.floor(nowYear / 100) * 100 + year;
+  while (candidate - nowYear > 50) candidate -= 100;
+  return candidate;
+}
+
+// RFC 2822 4.3, kept by RFC 5322 4.3 as obs-year: two digits from 00 to 49 add
+// 2000, two digits from 50 to 99 add 1900, and "any three digit year" adds 1900.
+// A fixed rule, unlike the one above.
+function untruncateRFC2822Year(yearStr) {
+  const year = parseInteger(yearStr);
+  if (yearStr.length === 2) return year <= 49 ? 2000 + year : 1900 + year;
+  if (yearStr.length === 3) return 1900 + year;
+  return year;
+}
+
+function fromStrings(
+  weekdayStr,
+  yearStr,
+  monthStr,
+  dayStr,
+  hourStr,
+  minuteStr,
+  secondStr,
+  untruncate
+) {
   const result = {
-    year: yearStr.length === 2 ? untruncateYear(parseInteger(yearStr)) : parseInteger(yearStr),
+    year: untruncate(yearStr),
     month: English.monthsShort.indexOf(monthStr) + 1,
     day: parseInteger(dayStr),
     hour: parseInteger(hourStr),
@@ -209,7 +241,16 @@ function extractRFC2822(match) {
       offHourStr,
       offMinuteStr,
     ] = match,
-    result = fromStrings(weekdayStr, yearStr, monthStr, dayStr, hourStr, minuteStr, secondStr);
+    result = fromStrings(
+      weekdayStr,
+      yearStr,
+      monthStr,
+      dayStr,
+      hourStr,
+      minuteStr,
+      secondStr,
+      untruncateRFC2822Year
+    );
 
   let offset;
   if (obsOffset) {
@@ -242,13 +283,33 @@ const rfc1123 =
 
 function extractRFC1123Or850(match) {
   const [, weekdayStr, dayStr, monthStr, yearStr, hourStr, minuteStr, secondStr] = match,
-    result = fromStrings(weekdayStr, yearStr, monthStr, dayStr, hourStr, minuteStr, secondStr);
+    // Only rfc850-date carries two digits; IMF-fixdate always writes four, and
+    // untruncateHTTPYear leaves those alone.
+    result = fromStrings(
+      weekdayStr,
+      yearStr,
+      monthStr,
+      dayStr,
+      hourStr,
+      minuteStr,
+      secondStr,
+      untruncateHTTPYear
+    );
   return [result, FixedOffsetZone.utcInstance];
 }
 
 function extractASCII(match) {
   const [, weekdayStr, monthStr, dayStr, hourStr, minuteStr, secondStr, yearStr] = match,
-    result = fromStrings(weekdayStr, yearStr, monthStr, dayStr, hourStr, minuteStr, secondStr);
+    result = fromStrings(
+      weekdayStr,
+      yearStr,
+      monthStr,
+      dayStr,
+      hourStr,
+      minuteStr,
+      secondStr,
+      untruncateHTTPYear
+    );
   return [result, FixedOffsetZone.utcInstance];
 }
 

--- a/test/datetime/regexParse.test.js
+++ b/test/datetime/regexParse.test.js
@@ -1,6 +1,6 @@
 /* global test expect */
 
-import { DateTime } from "../../src/luxon";
+import { DateTime, Settings } from "../../src/luxon";
 import { withNow } from "../helpers";
 
 //------
@@ -775,6 +775,39 @@ test("DateTime.fromRFC2822() rejects incorrect days of the week", () => {
   expect(dt.isValid).toBe(false);
 });
 
+// RFC 2822 4.3, kept by RFC 5322 as obs-year: 00 to 49 add 2000, 50 to 99 add
+// 1900, and any three digit year adds 1900. A fixed rule, unlike the HTTP one,
+// so no clock is needed here.
+test("DateTime.fromRFC2822() applies the obs-year rule to a two-digit year", () => {
+  // 15 June 1950 was a Thursday; under a cutoff of 60 this would be 2050.
+  const past = DateTime.fromRFC2822("Thu, 15 Jun 50 08:49:37 +0000");
+  expect(past.isValid).toBe(true);
+  expect(past.toUTC().year).toBe(1950);
+
+  // 15 June 2049 was a Tuesday.
+  const future = DateTime.fromRFC2822("Tue, 15 Jun 49 08:49:37 +0000");
+  expect(future.isValid).toBe(true);
+  expect(future.toUTC().year).toBe(2049);
+});
+
+test("DateTime.fromRFC2822() adds 1900 to a three-digit year", () => {
+  const dt = DateTime.fromRFC2822("15 Jun 099 08:49:37 +0000");
+  expect(dt.isValid).toBe(true);
+  expect(dt.toUTC().year).toBe(1999);
+});
+
+test("DateTime.fromRFC2822() ignores Settings.twoDigitCutoffYear", () => {
+  const oldCutoff = Settings.twoDigitCutoffYear;
+  try {
+    Settings.twoDigitCutoffYear = 99;
+    const dt = DateTime.fromRFC2822("Thu, 15 Jun 50 08:49:37 +0000");
+    expect(dt.isValid).toBe(true);
+    expect(dt.toUTC().year).toBe(1950);
+  } finally {
+    Settings.twoDigitCutoffYear = oldCutoff;
+  }
+});
+
 test("DateTime.fromRFC2822() can elide the day of the week", () => {
   const dt = DateTime.fromRFC2822("01 Nov 2016 13:23:12 +0600");
   expect(dt.isValid).toBe(true);
@@ -876,6 +909,59 @@ test("DateTime.fromHTTP() can parse RFC 850", () => {
     millisecond: 0,
   });
 });
+
+// RFC 9110 5.6.7 asks for a sliding window rather than a fixed cutoff: a
+// two-digit year that would land more than 50 years ahead means the most recent
+// past year with the same two digits. The clock is frozen here so the
+// expectations do not drift as the window moves.
+withNow(
+  "DateTime.fromHTTP() reads a two-digit year 50 years ahead as the future",
+  DateTime.fromObject({ year: 2026, month: 8, day: 8 }, { zone: "utc" }),
+  () => {
+    // 2076 is exactly 50 years out, so it is not "more than 50 years", and
+    // Monday is right for 15 June 2076.
+    const dt = DateTime.fromHTTP("Monday, 15-Jun-76 08:49:37 GMT");
+    expect(dt.isValid).toBe(true);
+    expect(dt.toUTC().year).toBe(2076);
+  }
+);
+
+withNow(
+  "DateTime.fromHTTP() reads a two-digit year past the window as the past",
+  DateTime.fromObject({ year: 2026, month: 8, day: 8 }, { zone: "utc" }),
+  () => {
+    // 2077 would be 51 years out, so it wraps to 1977, a Wednesday.
+    const dt = DateTime.fromHTTP("Wednesday, 15-Jun-77 08:49:37 GMT");
+    expect(dt.isValid).toBe(true);
+    expect(dt.toUTC().year).toBe(1977);
+  }
+);
+
+withNow(
+  "DateTime.fromHTTP() moves the window with the clock",
+  DateTime.fromObject({ year: 2126, month: 8, day: 8 }, { zone: "utc" }),
+  () => {
+    const dt = DateTime.fromHTTP("Saturday, 15-Jun-76 08:49:37 GMT");
+    expect(dt.isValid).toBe(true);
+    expect(dt.toUTC().year).toBe(2176);
+  }
+);
+
+withNow(
+  "DateTime.fromHTTP() ignores Settings.twoDigitCutoffYear",
+  DateTime.fromObject({ year: 2026, month: 8, day: 8 }, { zone: "utc" }),
+  () => {
+    const oldCutoff = Settings.twoDigitCutoffYear;
+    try {
+      Settings.twoDigitCutoffYear = 99;
+      const dt = DateTime.fromHTTP("Wednesday, 15-Jun-77 08:49:37 GMT");
+      expect(dt.isValid).toBe(true);
+      expect(dt.toUTC().year).toBe(1977);
+    } finally {
+      Settings.twoDigitCutoffYear = oldCutoff;
+    }
+  }
+);
 
 test("DateTime.fromHTTP() can parse RFC 850 on Wednesday", () => {
   const dt = DateTime.fromHTTP("Wednesday, 29-Jun-22 08:49:37 GMT");


### PR DESCRIPTION
`fromStrings` resolves every two-digit year through `untruncateYear`, which reads `Settings.twoDigitCutoffYear`. That setting is a good fit for `fromFormat`, where the user chose the `yy` token and can say what it means. The three formats behind `fromHTTP` and `fromRFC2822` are a different situation: the user did not choose them, each one states its own century rule, and the two rules do not agree with each other, so one cutoff cannot serve both.

### RFC 9110 5.6.7, the HTTP side

> Recipients of a timestamp value in rfc850-date format, which uses a two-digit year, MUST interpret a timestamp that appears to be more than 50 years in the future as representing the most recent year in the past that had the same last two digits.

That is a sliding window, and the fixed cutoff of 60 does not track it. Comparing all hundred two-digit years against the rule today, sixteen land in the wrong century, `61` through `76`. Because luxon checks the weekday against the year it settled on, the visible result is a rejection rather than a date read one century off:

```
DateTime.fromHTTP("Monday, 15-Jun-76 08:49:37 GMT")
  before  Invalid DateTime: mismatched weekday   (resolved 1976, a Tuesday)
  after   2076-06-15T08:49:37Z
```

The count is not stable either. It is sixteen today and grows by one every year, since the window moves and the cutoff does not.

### RFC 2822 4.3, the email side

> If a two digit year is encountered whose value is between 00 and 49, the year is interpreted by adding 2000 [...] If a two digit year is encountered with a value between 50 and 99, or any three digit year is encountered, the year is interpreted by adding 1900.

A fixed rule, and a different one. The cutoff of 60 moves eleven of the hundred, `50` through `60`, and three-digit years were not handled at all, because the branch only fired on `yearStr.length === 2`:

```
DateTime.fromRFC2822("Thu, 15 Jun 50 08:49:37 +0000")
  before  Invalid DateTime: mismatched weekday   (resolved 2050, a Wednesday)
  after   1950-06-15T08:49:37Z

DateTime.fromRFC2822("15 Jun 099 08:49:37 +0000")
  before  year 99
  after   year 1999
```

### What changed

`fromStrings` now takes the century rule from its caller, and the three extractors pass the one their format defines. `untruncateHTTPYear` uses `Settings.now()`, so the window is testable and moves with a mocked clock. Nothing else reads `Settings.twoDigitCutoffYear` differently, and `fromFormat` is untouched.

I grouped the two rules into one change rather than splitting them, because they are the same defect in the same function and fixing one alone would leave `fromStrings` half converted. Happy to split if you would rather review them apart.

### Tests

Seven added to `test/datetime/regexParse.test.js`, six of which fail on `main`:

```
✕ DateTime.fromRFC2822() applies the obs-year rule to a two-digit year
✕ DateTime.fromRFC2822() adds 1900 to a three-digit year
✕ DateTime.fromRFC2822() ignores Settings.twoDigitCutoffYear
✕ DateTime.fromHTTP() reads a two-digit year 50 years ahead as the future
✕ DateTime.fromHTTP() moves the window with the clock
✕ DateTime.fromHTTP() ignores Settings.twoDigitCutoffYear
```

The seventh, `reads a two-digit year past the window as the past`, passes on both sides on purpose. It pins the far edge of the window so the fix cannot simply push every year into the future.

The HTTP ones freeze the clock with the existing `withNow` helper, one of them at 2126, so the expectations do not drift as the window moves.

Full suite goes from 1217 to 1224, all passing, run in the provided Docker container with `TZ=America/New_York`. `prettier --check` is clean.
