### PR TITLE
fix(rfc2822): strip nested comments before parsing

### DIFF
--- a/src/impl/regexParser.js
+++ b/src/impl/regexParser.js
@@ -223,10 +223,40 @@ function extractRFC2822(match) {
   return [result, new FixedOffsetZone(offset)];
 }
 
+// RFC 5322 3.2.2 defines `ccontent` as `ctext / quoted-pair / comment`, so a
+// comment can hold another comment, and a backslash inside one escapes the next
+// character. `\([^()]*\)` cannot express either: it stops at the first `)` and
+// leaves the tail of the outer comment in the string, which then fails to match
+// the date grammar. Walking the string handles both.
+function stripComments(s) {
+  let out = "",
+    depth = 0;
+
+  for (let i = 0; i < s.length; i++) {
+    const char = s[i];
+
+    if (depth > 0 && char === "\\") {
+      // quoted-pair: whatever follows is comment text, including a parenthesis
+      i++;
+    } else if (char === "(") {
+      depth++;
+    } else if (char === ")" && depth > 0) {
+      depth--;
+      if (depth === 0) out += " ";
+    } else if (depth === 0) {
+      out += char;
+    }
+  }
+
+  // An unclosed comment is not a comment. Hand back the original and let the
+  // date grammar reject it, rather than swallowing the rest of the string.
+  return depth === 0 ? out : s;
+}
+
 function preprocessRFC2822(s) {
   // Remove comments and folding whitespace and replace multiple-spaces with a single space
-  return s
-    .replace(/\([^()]*\)|[\n\t]/g, " ")
+  return stripComments(s)
+    .replace(/[\n\t]/g, " ")
     .replace(/(\s\s+)/g, " ")
     .trim();
 }

--- a/test/datetime/regexParse.test.js
+++ b/test/datetime/regexParse.test.js
@@ -775,6 +775,32 @@ test("DateTime.fromRFC2822() rejects incorrect days of the week", () => {
   expect(dt.isValid).toBe(false);
 });
 
+// RFC 5322 3.2.2: ccontent includes comment, so comments nest, and a backslash
+// inside one escapes the next character.
+test("DateTime.fromRFC2822() accepts a nested comment", () => {
+  const dt = DateTime.fromRFC2822("Tue, 01 Nov 2016 13:23:12 +0630 (a (b) c)");
+  expect(dt.isValid).toBe(true);
+  expect(dt.toUTC().toISO({ suppressMilliseconds: true })).toBe("2016-11-01T06:53:12Z");
+});
+
+test("DateTime.fromRFC2822() accepts a nested comment in the middle", () => {
+  const dt = DateTime.fromRFC2822("Tue, 01 (day (of) month) Nov 2016 13:23:12 +0630");
+  expect(dt.isValid).toBe(true);
+  expect(dt.toUTC().toISO({ suppressMilliseconds: true })).toBe("2016-11-01T06:53:12Z");
+});
+
+test("DateTime.fromRFC2822() accepts an escaped parenthesis inside a comment", () => {
+  // The runtime string holds a backslash before the parenthesis, which RFC 5322
+  // calls a quoted-pair: the `)` is comment text, not the end of the comment.
+  const dt = DateTime.fromRFC2822("Tue, 01 Nov 2016 13:23:12 +0630 (smile \\) here)");
+  expect(dt.isValid).toBe(true);
+  expect(dt.toUTC().toISO({ suppressMilliseconds: true })).toBe("2016-11-01T06:53:12Z");
+});
+
+test("DateTime.fromRFC2822() still rejects an unclosed comment", () => {
+  expect(DateTime.fromRFC2822("Tue, 01 Nov 2016 13:23:12 +0630 (oops").isValid).toBe(false);
+});
+
 test("DateTime.fromRFC2822() can elide the day of the week", () => {
   const dt = DateTime.fromRFC2822("01 Nov 2016 13:23:12 +0600");
   expect(dt.isValid).toBe(true);


### PR DESCRIPTION
`preprocessRFC2822` clears comments with `\([^()]*\)`, which can only match a comment that holds no parenthesis of its own. RFC 5322 3.2.2 allows two things that expression cannot express:

```
comment  = "(" *([FWS] ccontent) [FWS] ")"
ccontent = ctext / quoted-pair / comment
```

Comments nest, and a backslash inside one escapes whatever follows. In both cases the regex stops at the first `)`, leaves the tail of the outer comment in the string, and the date grammar then rejects the whole date:

```
DateTime.fromRFC2822("Tue, 01 Nov 2016 13:23:12 +0630 (a (b) c)")
  before  Invalid DateTime: unparsable
  after   2016-11-01T06:53:12Z

DateTime.fromRFC2822("Tue, 01 (day (of) month) Nov 2016 13:23:12 +0630")
  before  Invalid DateTime: unparsable
  after   2016-11-01T06:53:12Z
```

Same date without the nesting parses fine today, which is what makes it look like a gap rather than a decision.

### What changed

A short scan replaces the regex. It counts depth, treats a backslash inside a comment as a quoted-pair, and only emits the separating space when the outermost comment closes.

One deliberate limit: if the string ends while still inside a comment, the original is handed back untouched. An unclosed `(` is not a comment, and swallowing the rest of the line would turn an invalid input into a parseable one. There is a test pinning that.

The `[\n\t]` replacement and the whitespace collapse are unchanged, just moved after the scan.

### Tests

Four added, three of which fail on `master`:

```
✕ DateTime.fromRFC2822() accepts a nested comment
✕ DateTime.fromRFC2822() accepts a nested comment in the middle
✕ DateTime.fromRFC2822() accepts an escaped parenthesis inside a comment
```

The fourth, `still rejects an unclosed comment`, passes on both sides on purpose: it is there so the scan cannot start accepting input the old regex refused.

Full suite goes from 1217 to 1221, all passing, run in the provided Docker container with `TZ=America/New_York`. `prettier --check` is clean.

This is independent of #1794, which touches the century rules in the same file. They will conflict textually if both land, and I am happy to rebase whichever one goes second.
