### PR TITLE
fix(Duration): consistent sign in shiftTo for smallest-unit fractions

### DIFF
--- a/src/duration.js
+++ b/src/duration.js
@@ -839,12 +839,15 @@ export default class Duration {
               const higherUnit = reverseUnits[j];
               if (higherUnit in built) {
                 const conv = this.matrix[higherUnit][unit];
-                // we want to an integer divide by "conv" and round away from zero.
+                // we want to integer divide by "conv" and round the magnitude away from zero,
+                // so that any leftover fraction flips to the overall sign.
                 // For example: 3 hours, -122 minutes
                 // => -122 / 60 => -3 hours to borrow so that we get 0 hours, 58 minutes
                 // Another example: -3 hours, 122 minutes
                 // => 122 / 60 => 3 hours to borrow so that we get 0 hours, -58 minutes
-                const toBorrow = Math.trunc((unitValue + (conv - 1) * unitSign) / conv);
+                // Rounding the magnitude up (rather than truncating) also handles a wrong-signed
+                // fraction smaller than "conv" in the smallest unit, e.g. 0.001 leftover seconds.
+                const toBorrow = unitSign * Math.ceil(Math.abs(unitValue) / conv);
                 built[higherUnit] += toBorrow;
                 // this may leave a fractional part behind - it will be fixed below
                 built[unit] -= toBorrow * conv;

--- a/test/duration/units.test.js
+++ b/test/duration/units.test.js
@@ -116,6 +116,16 @@ test("Duration#shiftTo does not produce unnecessary fractions in higher order un
   expect(shifted.minutes).toBeCloseTo(894.6, 5);
 });
 
+test("Duration#shiftTo keeps a consistent sign when the leftover fraction lands in the smallest unit", () => {
+  // -86399999 ms. The fraction (0.001 s) that lands in the smallest requested unit
+  // must take the overall (negative) sign, not stay positive.
+  const shifted = Duration.fromObject({ days: -1, milliseconds: 1 })
+    .shiftTo("minutes", "seconds")
+    .toObject();
+  expect(shifted.minutes).toBe(-1439);
+  expect(shifted.seconds).toBeCloseTo(-59.999, 5);
+});
+
 // #1620
 test("Duration#siftTo does not create intermediate units when lower order units can go directly into a higher one", () => {
   const duration = Duration.fromObject({


### PR DESCRIPTION
Diagnosed and fixed with AI assistance (Claude). shiftTo's documented consistent-sign invariant was violated when the leftover fraction landed in the smallest unit; see commit.