### PR TITLE
Keep endOf() inside the unit when the next unit's boundary is ambiguous or a hole

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -54,6 +54,10 @@ import Invalid from "./impl/invalid.js";
 const INVALID = "Invalid DateTime";
 const MAX_DATE = 8.64e15;
 
+// units that plus()/minus() advance with calendar math, i.e. by changing the calendar fields and
+// keeping the local time of day, rather than by adding a fixed number of milliseconds
+const calendarUnits = ["years", "quarters", "months", "weeks", "days"];
+
 function unsupportedZone(zone) {
   return new Invalid("unsupported zone", `the zone "${zone.name}" is not supported`);
 }
@@ -1806,11 +1810,28 @@ export default class DateTime {
    * @return {DateTime}
    */
   endOf(unit, opts) {
-    return this.isValid
-      ? this.plus({ [unit]: 1 })
-          .startOf(unit, opts)
-          .minus(1)
-      : this;
+    if (!this.isValid) return this;
+
+    // The end of a unit is one millisecond before the start of the next one. For calendar units we
+    // step off the *start* of the current unit instead of off `this`, because plus() keeps the
+    // local time of day: stepping from an arbitrary time of day can land in a DST hole or on the
+    // later of two ambiguous local times, and startOf() then reports the start of the unit *after*
+    // the next one. Sub-day units advance by a fixed number of milliseconds and can't overshoot
+    // that way, and normalizing them first would conflate the two halves of an ambiguous hour.
+    //
+    // Non-string units are left alone so that the computed key below still string-coerces them and
+    // throws InvalidUnitError, rather than normalizeUnit() throwing a TypeError on them here.
+    const normalized = typeof unit === "string" ? Duration.normalizeUnit(unit) : null;
+    const start = calendarUnits.includes(normalized) ? this.startOf(unit, opts) : this;
+
+    // At the very bottom of the representable range startOf() can fall out of it and go invalid.
+    // Step off `this` there instead of propagating the invalid.
+    const base = start.isValid ? start : this;
+
+    return base
+      .plus({ [unit]: 1 })
+      .startOf(unit, opts)
+      .minus(1);
   }
 
   // OUTPUT

--- a/test/datetime/dst.test.js
+++ b/test/datetime/dst.test.js
@@ -152,6 +152,44 @@ for (const [name, local] of Object.entries(dateTimeConstructors)) {
   });
 }
 
+// #398 covered the case where the *current* unit starts on a DST hole. These cover the case
+// where the *next* unit does not start at a plain, unambiguous local midnight.
+describe("DateTime#endOf across an unusual unit boundary", () => {
+  test("endOf('day') stays in the day when the next day starts with an ambiguous midnight", () => {
+    // Cuba leaves DST at 01:00, so 2022-11-06T00:00 happens twice
+    const d = DateTime.fromISO("2022-11-05T12:00", { zone: "America/Havana" });
+    expect(d.endOf("day").toISO()).toBe("2022-11-05T23:59:59.999-04:00");
+  });
+
+  test("endOf('month') and endOf('quarter') stay in the unit when the next one starts with an ambiguous midnight", () => {
+    // Tunisia left DST at 01:00 on 1978-10-01, so that midnight happens twice
+    const d = DateTime.fromISO("1978-09-30T12:00", { zone: "Africa/Tunis" });
+    expect(d.endOf("month").toISO()).toBe("1978-09-30T23:59:59.999+02:00");
+    expect(d.endOf("quarter").toISO()).toBe("1978-09-30T23:59:59.999+02:00");
+  });
+
+  test("endOf('day') stays in the day when the next day's last hour is a hole", () => {
+    // Bangladesh entered DST at 23:00 on 2009-06-19, so 2009-06-19T23:30 doesn't exist
+    const d = DateTime.fromISO("2009-06-18T23:30", { zone: "Asia/Dhaka" });
+    expect(d.endOf("day").toISO()).toBe("2009-06-18T23:59:59.999+06:00");
+  });
+
+  test("hasSame('day') doesn't reach into the next day over an ambiguous midnight", () => {
+    const d = DateTime.fromISO("2022-11-05T12:00", { zone: "America/Havana" });
+    // the first of the two 2022-11-06T00:30s, i.e. the next day
+    const next = DateTime.fromMillis(Date.UTC(2022, 10, 6, 4, 30), { zone: "America/Havana" });
+    expect(next.day).toBe(6);
+    expect(d.hasSame(next, "day")).toBe(false);
+  });
+
+  test("endOf() on sub-day units keeps the half of an ambiguous hour it started in", () => {
+    // Venezuela moved from -04:00 to -04:30 at 03:00, so 02:30 through 03:00 happens twice
+    const d = DateTime.fromMillis(Date.UTC(2007, 11, 9, 7), { zone: "America/Caracas" });
+    expect(d.toISO()).toBe("2007-12-09T02:30:00.000-04:30");
+    expect(d.endOf("hour").toISO()).toBe("2007-12-09T02:59:59.999-04:30");
+  });
+});
+
 describe("DateTime.local() with offset caching", () => {
   const edtTs = 1495653314000; // May 24, 2017 15:15:14 -0400
   const estTs = 1484456400000; // Jan 15, 2017 00:00 -0500

--- a/test/datetime/math.test.js
+++ b/test/datetime/math.test.js
@@ -2,6 +2,7 @@
 
 import { DateTime, Duration } from "../../src/luxon";
 import { casualMatrix } from "../../src/duration";
+import { InvalidUnitError } from "../../src/errors";
 
 function createDateTime() {
   return DateTime.fromObject({
@@ -533,4 +534,25 @@ test("DateTime#endOf maintains invalidity", () => {
 
 test("DateTime#endOf throws on invalid units", () => {
   expect(() => DateTime.fromISO("2016-03-12T10:00").endOf("splork")).toThrow();
+});
+
+test("DateTime#endOf throws InvalidUnitError on non-string units", () => {
+  const dt = DateTime.fromISO("2016-03-12T10:00");
+  expect(() => dt.endOf(1)).toThrow(InvalidUnitError);
+  expect(() => dt.endOf({})).toThrow(InvalidUnitError);
+  expect(() => dt.endOf([])).toThrow(InvalidUnitError);
+});
+
+// endOf() normalizes to the start of the unit first, which at the very bottom of the
+// representable range falls out of it; that must not turn a valid result invalid
+test("DateTime#endOf stays valid at the bottom of the representable range", () => {
+  const min = DateTime.fromMillis(-8.64e15, { zone: "UTC" });
+  expect(min.endOf("year").isValid).toBe(true);
+  expect(min.endOf("year").toISO()).toBe("-271821-12-31T23:59:59.999Z");
+  expect(min.endOf("quarter").toISO()).toBe("-271821-06-30T23:59:59.999Z");
+  expect(min.endOf("month").toISO()).toBe("-271821-04-30T23:59:59.999Z");
+  expect(min.endOf("day").toISO()).toBe("-271821-04-20T23:59:59.999Z");
+
+  const minish = DateTime.fromMillis(-8.64e15 + 3600000, { zone: "Asia/Kathmandu" });
+  expect(minish.endOf("day").toISO()).toBe("-271821-04-20T23:59:59.999+05:41");
 });


### PR DESCRIPTION
## Problem

`DateTime#endOf()` can return an instant that is **not inside the unit it was asked about**. Against a fresh `npm i luxon@3.7.2` (also reproduces on `master` @ f427515a), Node v26.7.0, process `TZ=UTC`:

```js
const { DateTime } = require("luxon");

DateTime.fromISO("2022-11-05T12:00", { zone: "America/Havana" }).endOf("day").toISO();
// => "2022-11-06T00:59:59.999-04:00"     an hour into the NEXT day
// expected "2022-11-05T23:59:59.999-04:00"

DateTime.fromISO("2009-06-18T23:30", { zone: "Asia/Dhaka" }).endOf("day").toISO();
// => "2009-06-19T22:59:59.999+06:00"     a whole day late
// expected "2009-06-18T23:59:59.999+06:00"

DateTime.fromISO("1978-09-30T12:00", { zone: "Africa/Tunis" }).endOf("month").toISO();
// => "1978-10-01T00:59:59.999+02:00"     end of September is in October
// expected "1978-09-30T23:59:59.999+02:00"
```

`hasSame()` is `startOf(unit) <= inputMs && inputMs <= endOf(unit)`, so it inherits the overshoot and reports two different days — in the same zone — as the same day:

```js
const a = DateTime.fromISO("2022-11-05T12:00", { zone: "America/Havana" });          // 2022-11-05
const b = DateTime.fromMillis(Date.UTC(2022, 10, 6, 4, 30), { zone: "America/Havana" }); // 2022-11-06
a.hasSame(b, "day"); // => true
```

Reproducing needs the right precondition: the input must sit on the day *before* the transition, and the transition must be a fall-back **at 01:00** so that the following day's local midnight occurs twice. A normal 02:00 fall-back does not reproduce — `America/New_York 2022-11-05T12:00` correctly gives `2022-11-05T23:59:59.999-04:00`.

## Root cause

`src/datetime.js:1808`

```js
endOf(unit, opts) {
  return this.isValid
    ? this.plus({ [unit]: 1 })
        .startOf(unit, opts)
        .minus(1)
    : this;
}
```

`endOf()` finds the start of the next unit and steps back 1 ms. It gets there with `this.plus({unit: 1})`. For years/quarters/months/weeks/days that is calendar math: `adjustTime()` (`src/datetime.js:153`) rebuilds the calendar fields and **keeps the local time of day**, then resolves the offset through `fixOffset()` (`src/datetime.js:105`), whose `o` argument is documented as *"our guess, which determines which offset we'll pick in ambiguous cases"*. Two things follow:

1. **Ambiguous boundary.** Cuba leaves DST at 01:00, so `2022-11-06T00:00` exists twice. From `2022-11-05T12:00-04:00`, `plus({days: 1})` gives `2022-11-06T12:00-05:00`; `startOf("day")` then guesses `-05:00` and lands on the **second** midnight. `minus(1)` from there is still inside 11-06.
2. **Hole near the end of the next unit.** Bangladesh jumped 23:00 → 00:00 on 2009-06-19, so `2009-06-19T23:30` does not exist. From `2009-06-18T23:30`, `plus({days: 1})` falls in that hole and `fixOffset()`'s hole branch (`src/datetime.js:127`) bumps it forward past 06-19 entirely.

#399 fixed the complementary case — the *current* unit starting on a hole — by moving `startOf()` after `plus()`. Both failures above are properties of the value `plus()` produces, so that reordering doesn't reach them. The principle #399 stated ("the end of a unit is one millisecond before the start of the subsequent unit") is exactly what this PR makes hold.

This is also the shape @diesieben07 sketched for `hasSame` in #647:

> ```js
> const adjustedToZoneStart = adjustedToZone.startOf(unit);
> const adjustedToZoneEnd = adjustedToZoneStart.plus({[unit]: 1});
> ```

— normalize to the start of the unit first, then advance. Same idea, applied inside `endOf()`.

## Fix

For calendar units, step off `startOf(unit)` instead of off `this`, so `plus()` advances from a boundary where the local time of day is already normalized to midnight (or, if that midnight is a hole, to the first instant that does exist — still the start of the unit). The trailing `startOf()` stays, because `plus()` from a boundary can itself land on a hole — that's the `America/Sao_Paulo` case from #398, which still passes.

Two behaviours of the old formulation are preserved deliberately, each pinned by a test:

- **Non-string units still throw `InvalidUnitError`.** `master` never passed the raw argument to `Duration.normalizeUnit`; it reached it through the computed key in `plus({[unit]: 1})`, which string-coerces first. Calling `normalizeUnit` directly on `endOf(1)` / `endOf({})` / `endOf([])` would throw a raw `TypeError: unit.toLowerCase is not a function` instead, so the normalization is guarded by a `typeof unit === "string"` check.
- **The bottom of the representable range.** `this.startOf(unit)` can fall below the minimum date and go invalid, which would then propagate through the rest of the chain. `DateTime.fromMillis(-8.64e15, {zone:"UTC"}).endOf("year")` must stay `-271821-12-31T23:59:59.999Z`, not become `Invalid DateTime`. When the normalized start is invalid, `endOf()` falls back to stepping off `this`, reproducing master exactly.

**Sub-day units are excluded, and that's measured, not a hedge.** `plus({hours: 1})` is exact millisecond math and cannot overshoot this way. Applying the same reorder to them made things worse: `startOf("hour")` on the *second* half of an ambiguous hour jumps back to the first half, so `plus({hours: 1})` never leaves the wall-clock hour. Over the probe set below, the unrestricted variant produced **1,344 containment regressions** (1,342 `hour`, 2 `minute`) across 19 zones — e.g. `America/Caracas 2007-12-09T02:30-04:30`.`endOf("hour")` went from a correct `02:59:59.999-04:30` to `01:59:59.999-04:00`. Restricting to calendar units takes that to zero. A test pins the sub-day behaviour so the conditional can't be "simplified" away later.

## Evidence

Fail-then-pass on a true baseline (`git show HEAD~1:src/datetime.js > src/datetime.js`; `grep -c calendarUnits src/datetime.js` → `0`), new tests in place:

```
Tests:       4 failed, 93 skipped, 1 passed, 98 total
  ● endOf('day') ... next day starts with an ambiguous midnight
                          Expected: "2022-11-05T23:59:59.999-04:00"
                          Received: "2022-11-06T00:59:59.999-04:00"
  ● endOf('month') and endOf('quarter') ...
                          Expected: "1978-09-30T23:59:59.999+02:00"
                          Received: "1978-10-01T00:59:59.999+02:00"
  ● endOf('day') ... next day's last hour is a hole
                          Expected: "2009-06-18T23:59:59.999+06:00"
                          Received: "2009-06-19T22:59:59.999+06:00"
  ● hasSame('day') doesn't reach into the next day
                          Expected: false / Received: true
```

(The one passing test is the `America/Caracas` sub-day guard — deliberately a no-change assertion.)

The two regression guards in `math.test.js` pass on master by construction; against the *unguarded* version of this patch they fail, which is what makes them worth keeping:

```
  ● DateTime#endOf throws InvalidUnitError on non-string units
      Expected constructor: InvalidUnitError
      Received constructor: TypeError  ("unit.toLowerCase is not a function")
  ● DateTime#endOf stays valid at the bottom of the representable range
      Expected: true / Received: false
```

With the fix, all pass:

```
$ npx jest test/datetime/dst.test.js test/datetime/math.test.js
Tests:       98 passed, 98 total     # includes the #399 regression test, unchanged
```

### Cross-zone differential

Baseline build vs fixed build, same process. Probe construction, stated so the counts can be re-derived:

- **zones**: all 418 from `Intl.supportedValuesOf("timeZone")`
- **transitions**: every UTC-offset transition in `[1970-01-01, 2040-01-01)` (20,968 of them), found by a 10-day coarse scan then binary search to 1-minute resolution
- **deltas**: 23 offsets around each transition — `±{0, 1ms, 1s, 1min, 30min, 1h, 90min, 2h, 6h, 12h, 24h, 36h}`, deduped
- **random**: 60 uniformly random instants per zone in `[1970, 2040)`, seeded LCG
- **units**: year, quarter, month, week, day, hour, minute, second

= 507,344 probes, 4,058,752 checks. Each disagreement classified two ways: whether the result is inside the input's unit (calendar-field label match), and whether it is the **true last instant** of that unit (descending 1-minute scan to the last matching minute, then ms binary search inside it).

```
checks: 4058752   identical: 4056275   differing: 2477

result outside the unit  -> fixed by this PR:   1695  (40 zones)  {day: 1488, month: 96, quarter: 77, week: 34}
result outside the unit  -> introduced:            0  (0 zones)
changed, both inside the unit:                   782  (4 zones)  {day: 756, month: 26}
```

Under the stricter metric the partition is exactly the same, with no overlap: the patch is the true last instant in exactly those 1,695 cases and master is not; **master is the true last instant in exactly those 782 cases and the patch is not**. So the third row is a real regression under the strict reading, not a wash — see below.

Zones fixed: `Africa/Algiers, Africa/Tunis, America/Godthab, America/Guyana, America/Havana, America/Iqaluit, America/Juneau, America/Managua, America/Scoresbysund, America/Sitka, Antarctica/Casey, Antarctica/Davis, Antarctica/Vostok, Asia/Amman, Asia/Chita, Asia/Colombo, Asia/Dhaka, Asia/Gaza, Asia/Hebron, Asia/Jerusalem, Asia/Kuala_Lumpur, Asia/Magadan, Asia/Pyongyang, Asia/Singapore, Asia/Tehran, Atlantic/Azores, Atlantic/Madeira, Europe/Athens, Europe/Bucharest, Europe/Budapest, Europe/Lisbon, Europe/Madrid, Europe/Malta, Europe/Monaco, Europe/Paris, Europe/Rome, Europe/San_Marino, Europe/Sofia, Europe/Vatican, Pacific/Efate`.

An invariant audit over the same probes on published 3.7.2 — "does `endOf(u)` land inside unit `u`?" — finds **1,689 violations across 40 zones, of which 180 are at instants in 2026 or later** (`America/Havana`, `America/Godthab`, `America/Scoresbysund`, `Atlantic/Azores`). So this bites on live, recurring rules, not only history.

### The 782 changed-but-inside cases are a regression too

They are confined to `America/Goose_Bay`, `America/Moncton`, `America/St_Johns` and `Antarctica/Casey` — zones that fell back at **00:01** local, where the calendar-day label is non-contiguous in epoch time (the local date runs 24 → 25 → 24 → 25). Both versions return `1987-10-24T23:59:59.999`; they differ only in offset. **Master returns the later of the two, which is genuinely the last instant of that day; this PR returns the earlier one, which is not.** The user-visible consequence, `America/Goose_Bay`, 1987-10-24:

```js
const d    = DateTime.fromMillis(Date.UTC(1987, 9, 24, 12),    { zone: "America/Goose_Bay" });
const late = DateTime.fromMillis(Date.UTC(1987, 9, 25, 3, 30), { zone: "America/Goose_Bay" }); // .day === 24

                                    master                          this PR
d.endOf("day")                      ...T23:59:59.999-04:00          ...T23:59:59.999-03:00
d.hasSame(late, "day")              true   (correct)                false  (wrong)
Interval.fromDateTimes(d.startOf("day"), d.endOf("day")).length("hours")
                                    25.00  (correct)                24.00
```

So this PR trades a `hasSame` false **positive** in 40 zones for a `hasSame` false **negative** in 4. I think that's worth it, but you should have the number in front of you, not buried under "neutral".

What limits the damage: every affected transition in those four zones is historical and none of the rules recur. `America/Goose_Bay` and `America/St_Johns`: 24 transitions each, 1987-10-25 through 2010-11-07 (both moved to an 02:00 fall-back afterwards). `America/Moncton`: 14, 1993-10-31 through 2006-10-29. `Antarctica/Casey`: 4 one-off Antarctic schedule changes, latest 2023-03-08. A scan to 2040 finds no future occurrences. The 40 zones on the other side include rules that fire every year.

If you'd rather not accept that trade, the alternative is to make `startOf()` on an ambiguous boundary consistently pick the earliest instant and have `endOf()` derive from it — a larger default-behaviour change I didn't want to make unasked.

### Full CI sequence, locally

`npm run build`, `npm run format-check` ("All matched files use Prettier code style!"), `npm run test`, `npm run site` — all four succeed.

```
                       true baseline (f427515a)              with this PR
Test Suites: 2 failed, 56 passed, 58 total   |   2 failed, 56 passed, 58 total
Tests:       9 failed, 1213 passed, 1222     |   9 failed, 1220 passed, 1229
```

+7 tests, +7 passing, 0 new failures. The 9 failures are identical before and after and are pre-existing: locale time-format assertions failing on the U+202F narrow no-break space newer ICU emits before the meridiem (`Expected: "9:23 AM" / Received: "9:23 AM"` — visually identical, different codepoint). Artifact of local Node v26.7.0; the CI matrix tops out at 25.8.1. None touch zone math.

## Performance

The extra `startOf()` costs one more `objToTS`/`fixOffset` and one more `Intl` offset lookup on calendar units. Interleaved median of 5 × 200k iterations, same process, Node v26.7.0:

| call | zone | master | this PR | Δ |
|---|---|---|---|---|
| `endOf("day")` | UTC | 497 ms | 566 ms | +13.8% |
| `endOf("day")` | America/New_York | 4076 ms | 4647 ms | +14.0% |
| `endOf("month")` | America/New_York | 4134 ms | 4724 ms | +14.3% |
| `endOf("hour")` | America/New_York | 4496 ms | 4521 ms | +0.5% |
| `hasSame(…, "day")` | America/New_York | 5137 ms | 5696 ms | +10.9% |

Sub-day units are unaffected, as expected. **The `hasSame` row is the awkward one**: #647 is an open, still-unresolved complaint that `hasSame` is too slow, and this PR moves it 10.9% the wrong way. The two are worth fixing together — implementing #647 as `startOf(unit) <= inputMs && inputMs < startOf(unit).plus({[unit]: 1})` would drop one of the two `startOf` calls *and* remove the false positive at the source, since it stops depending on `endOf` entirely. I'm happy to do that in this PR or a follow-up, whichever you prefer.

I didn't add a fast-path-then-validate branch inside `endOf` to claw back the calendar-unit cost, because validating "is the result still in the right unit" needs unit-specific field comparison — the kind of extra branching that tends to grow its own bugs. Say the word if you'd rather have the cycles.

No regexes, loops or unbounded allocation are involved, so there's no complexity/ReDoS surface in either direction. I fuzzed the `unit` argument across both builds — `1`, `{}`, `[]`, `"splork"`, `""`, `null`, `undefined`, `NaN`, `0`, `Symbol`, and the prototype keys `__proto__`, `constructor`, `toString`, `hasOwnProperty`, `valueOf` — and behaviour is identical to master on every one of them.

## What I could not verify

- Only ran on Node v26.7.0 / macOS. Not on the CI matrix (20 / 22 / 24 / 25).
- Test cases use long-frozen historical tzdata (Cuba 2022, Tunisia 1978, Bangladesh 2009, Venezuela 2007) to avoid rot, but I didn't check them against the older ICU bundled with Node 20.
- The 782 cases above are a genuine regression under the strict "last instant of the unit" metric. I judged the trade worth it because those rules are historical and non-recurring while the 40 fixed zones include annual ones — but that's my judgement, not a ruling.
- The differential is 4,058,752 checks, not exhaustive, so "0 introduced" means 0 in 4,058,752.
- One incidental change in the other direction, near the **top** of the range: `DateTime.fromMillis(8.64e15 - 1000, {zone:"UTC"}).endOf("day")` returns `+275760-09-12T23:59:59.999Z` on this PR where master returns `Invalid DateTime`. That looks like an improvement, but it is a validity change and I'm flagging it rather than letting you find it.
- Known adjacent issues I deliberately left alone, since each is a default-behaviour change rather than a bug fix and CONTRIBUTING says to ask first:
  - `startOf()` on an ambiguous midnight is offset-dependent — `Havana 2022-11-06T00:30-04:00` and the same wall time at `-05:00` give `startOf("day")` results an hour apart, so it isn't always the earliest instant of the unit. This is the root of the 782 cases.
  - `startOf("hour")` can leave the hour in zones with non-hour-aligned transitions (`Pacific/Chatham 2026-09-27T03:45+13:45` → `04:00`). This is why the fix is scoped to calendar units; `endOf("hour")` in those zones is still wrong and this PR doesn't improve it.
  - `endOf("year")` is non-idempotent across `Pacific/Kiritimati`'s skipped 1994-12-31 — a different root cause in `adjustTime`/`fixOffset`, not in `endOf`'s ordering.

This work was done with LLM assistance. Every number above is reproducible from the probe construction described; happy to attach the scripts.
