### PR TITLE
Reject out-of-range zone offsets in fromISO

### DIFF
--- a/src/impl/regexParser.js
+++ b/src/impl/regexParser.js
@@ -67,7 +67,7 @@ function simpleParse(...keys) {
 }
 
 // ISO and SQL parsing
-const offsetRegex = /(?:([Zz])|([+-]\d\d)(?::?(\d\d))?)/;
+const offsetRegex = /(?:([Zz])|([+-](?:2[0-3]|[01]\d))(?::?([0-5]\d))?)/;
 const isoExtendedZone = `(?:${offsetRegex.source}?(?:\\[(${ianaRegex.source})\\])?)?`;
 const isoTimeBaseRegex = /(\d\d)(?::?(\d\d)(?::?(\d\d)(?:[.,](\d{1,30}))?)?)?/;
 const isoTimeRegex = RegExp(`${isoTimeBaseRegex.source}${isoExtendedZone}`);

--- a/test/datetime/regexParse.test.js
+++ b/test/datetime/regexParse.test.js
@@ -557,6 +557,14 @@ test("DateTime.fromISO() doesn't accept 24:23", () => {
   expect(DateTime.fromISO("2018-05-25T24:23").isValid).toBe(false);
 });
 
+test("DateTime.fromISO() doesn't accept out-of-range zone offsets", () => {
+  expect(DateTime.fromISO("2016-05-25T09:08:34+00:60").isValid).toBe(false);
+  expect(DateTime.fromISO("2016-05-25T09:08:34+24:00").isValid).toBe(false);
+  expect(DateTime.fromISO("2016-05-25T09:08:34+99:99").isValid).toBe(false);
+  expect(DateTime.fromISO("2016-05-25T09:08:34+18:00").isValid).toBe(true);
+  expect(DateTime.fromISO("2016-05-25T09:08:34-05:30").isValid).toBe(true);
+});
+
 test("DateTime.fromISO() accepts extended zones", () => {
   let dt = DateTime.fromISO("2016-05-14T10:23:54[Europe/Paris]", {
     setZone: true,


### PR DESCRIPTION
`DateTime.fromISO` accepts UTC offsets whose hour or minute is out of range, and silently normalizes them:

```js
DateTime.fromISO("2023-06-15T12:00:00+00:60").isValid  // true, offset becomes +01:00
DateTime.fromISO("2023-06-15T12:00:00+24:00").isValid  // true
DateTime.fromISO("2023-06-15T12:00:00+99:99").isValid  // true, offset becomes +100:39
```

The clock fields are already range-checked (`12:60:00Z` is rejected), but the offset fields aren't. This limits the ISO offset regex to valid values (hour `00`–`23`, minute `00`–`59`), so those inputs are rejected while real offsets like `+14:00`, `+18:00` and `-05:30` still parse. Added a test.
