### PR TITLE
fix: fall back to the default locale when formatting with an unknown locale

### DIFF
--- a/src/impl/locale.js
+++ b/src/impl/locale.js
@@ -263,7 +263,15 @@ class PolyDateFormatter {
 
     const intlOpts = { ...this.opts };
     intlOpts.timeZone = intlOpts.timeZone || z;
-    this.dtf = getCachedDTF(intl, intlOpts);
+
+    // Intl silently falls back to the system locale for unknown locales, so the
+    // default locale is listed as a backup for Intl to prefer over the system one.
+    // The formatter cache is keyed by the locales list, so changing
+    // Settings.defaultLocale picks up new formatters.
+    this.dtf =
+      Settings.defaultLocale && Settings.defaultLocale !== intl
+        ? getCachedDTF([intl, Settings.defaultLocale], intlOpts)
+        : getCachedDTF(intl, intlOpts);
   }
 
   format() {

--- a/test/datetime/toFormat.test.js
+++ b/test/datetime/toFormat.test.js
@@ -2,6 +2,9 @@
 
 import { DateTime } from "../../src/luxon";
 
+const Helpers = require("../helpers");
+const { withDefaultLocale } = Helpers;
+
 const dt = DateTime.fromObject(
   {
     year: 1982,
@@ -26,6 +29,23 @@ test("DateTime#toFormat accepts the locale from the DateTime or the options", ()
   expect(dt.setLocale("fr").toFormat("LLLL")).toBe("mai");
   expect(dt.toFormat("LLLL", { locale: "fr" })).toBe("mai");
   expect(dt.setLocale("pt").toFormat("LLLL", { locale: "fr" })).toBe("mai");
+});
+
+test("DateTime#toFormat falls back to the default locale for unsupported locales", () => {
+  withDefaultLocale("fr", () => {
+    expect(dt.toFormat("LLLL", { locale: "zz" })).toBe("mai");
+    expect(dt.toFormat("ffff", { locale: "zz" })).toBe(dt.toFormat("ffff", { locale: "fr" }));
+  });
+});
+
+test("DateTime#toFormat picks up changes of the default locale for unsupported locales", () => {
+  withDefaultLocale("fr", () => {
+    expect(dt.toFormat("LLLL", { locale: "zz" })).toBe("mai");
+  });
+
+  withDefaultLocale("en-US", () => {
+    expect(dt.toFormat("LLLL", { locale: "zz" })).toBe("May");
+  });
 });
 
 test("DateTime#toFormat('u') returns fractional seconds", () => {


### PR DESCRIPTION
## Summary

Formatting a DateTime with an unsupported locale option fell back to the system locale instead of Settings.defaultLocale, because Intl silently resolves unknown locales to the system one. Following the discussion in #1366, the default locale is now passed to Intl as a backup locale when it differs from the requested one, so Intl prefers it over the system locale. The formatter cache key includes the locales list, so changes to Settings.defaultLocale take effect immediately.

## Testing

Reproduced on master: with Settings.defaultLocale = "fr", dt.toFormat("LLLL", { locale: "zz" }) returned the system-locale month name instead of "mai". Added regression tests in toFormat.test.js covering the fallback and the behavior after changing Settings.defaultLocale. The full jest suite matches the clean-master baseline on Windows, with both new tests passing.

## Checklist

- [x] Bug reproduced before fix
- [x] Root cause identified
- [x] Bug fixed
- [x] Tests passed

Fixes #1366
