### PR TITLE
Keep an explicit zero quarters visible in Duration#toHuman

### DIFF
--- a/src/duration.js
+++ b/src/duration.js
@@ -480,7 +480,7 @@ export default class Duration {
         let val = this.values[unit];
         if (convertUnit) {
           const val2 = this.values[convertUnit];
-          if (val2) {
+          if (val2 !== undefined) {
             val = (val ?? 0) + val2 * this.matrix[convertUnit][unit];
           }
         }

--- a/test/duration/format.test.js
+++ b/test/duration/format.test.js
@@ -471,6 +471,11 @@ test("Duration#toHuman works in differt languages", () => {
   );
 });
 
+test("Duration#toHuman keeps an explicit zero quarters visible", () => {
+  expect(Duration.fromObject({ quarters: 0 }).toHuman()).toEqual("0 months");
+  expect(Duration.fromObject({ quarters: 0, hours: 5 }).toHuman()).toEqual("0 months, 5 hours");
+});
+
 test("Duration#toHuman handles quarters", () => {
   expect(
     Duration.fromObject({


### PR DESCRIPTION
The fix for #1545 folds quarters into months in toHuman since Intl.NumberFormat has no concept of a quarter, but the check that decides whether to apply that fold only looked at truthiness of the quarters value. That means Duration.fromObject({ quarters: 0 }).toHuman() prints nothing at all, and quarters: 0 alongside other units disappears from the list entirely, regardless of the showZeros option.

Every other unit doesn't behave this way. Duration.fromObject({ months: 0 }).toHuman() correctly prints "0 months" by default, since showZeros defaults to true and the unit was explicitly part of the duration. quarters: 0 should get the same treatment once it's converted to months for display.

Changed the check from a truthy test to an explicit undefined check, so a duration with quarters set to exactly zero still shows "0 months" (or nothing, with showZeros: false, same as any other unit). Added a test covering the standalone case and quarters: 0 combined with another unit.

Ran the full local suite - the only failures are pre-existing and environment-specific (several datetime/zone tests assume the container's local timezone is America/New_York, which isn't the case here), none touch Duration or toHuman.